### PR TITLE
add additional check for user namespace

### DIFF
--- a/conjureup/download.py
+++ b/conjureup/download.py
@@ -116,7 +116,7 @@ def get_remote_url(path):
                "/{}/bundle/{}/archive".format(namespace, bundle))
         return url
 
-    if path.startswith("cs:"):
+    if path.startswith("cs:") or path.startswith("cs:~"):
         url = ("https://api.jujucharms.com/charmstore/v5"
                "/{}/archive".format(path[3:]))
         return url


### PR DESCRIPTION
We just checked cs: and not cs:~ when parsing a bundle on the command line

Signed-off-by: Adam Stokes <adam.stokes@ubuntu.com>