### PR TITLE
Step feedback

### DIFF
--- a/conjureup/controllers/deploystatus/common.py
+++ b/conjureup/controllers/deploystatus/common.py
@@ -27,7 +27,8 @@ def wait_for_applications(script, msg_cb):
                     raise Exception("Error running {}".format(script))
 
                 try:
-                    result = json.loads(sh.stdout.decode('utf8'))
+                    lines = sh.stdout.decode('utf8').splitlines()
+                    result = json.loads(lines[-1])
                 except json.decoder.JSONDecodeError as e:
                     app.log.exception(sh.stdout.decode())
                     raise Exception(sh)

--- a/conjureup/controllers/steps/tui.py
+++ b/conjureup/controllers/steps/tui.py
@@ -31,11 +31,12 @@ class StepsController:
             step_metadata = {}
             with open(step_path) as fp:
                 step_metadata = yaml.load(fp.read())
-            model = StepModel(step_metadata)
+            model = StepModel(step_metadata, step_path)
             model.path = fname
             app.log.debug("Running step: {}".format(model))
             try:
                 step_model, _ = common.do_step(model,
+                                               None,
                                                utils.info)
                 self.results[step_model.title] = step_model.result
             except Exception as e:

--- a/conjureup/models/step.py
+++ b/conjureup/models/step.py
@@ -4,12 +4,11 @@ from conjureup.app_config import app
 
 
 class StepModel:
-    def __init__(self, step):
+    def __init__(self, step, path):
         self.title = step.get('title', '')
         self.description = step.get('description', '')
         self.result = ''
         self.viewable = step.get('viewable', False)
-        self.path = step.get('path', None)
 
         self.additional_input = step.get('additional-input', [])
 

--- a/conjureup/ui/widgets/step.py
+++ b/conjureup/ui/widgets/step.py
@@ -1,3 +1,6 @@
+import json
+import os
+
 from ubuntui.utils import Padding, Color
 from ubuntui.widgets.hr import HR
 from ubuntui.widgets.buttons import submit_btn
@@ -28,6 +31,7 @@ class StepWidget(WidgetWrap):
         self.title = Text(('info_minor', step_model.title))
         self.description = Text(('info_minor', step_model.description))
         self.result = Text(step_model.result)
+        self.output = Text(('info_minor', ''))
         self.icon = Text(("info_minor", "\N{BALLOT BOX}"))
 
         self.additional_input = []
@@ -52,10 +56,27 @@ class StepWidget(WidgetWrap):
 
         self.cb = cb
         self.step_pile = self.build_widget()
+        self.show_output = True
         super().__init__(self.step_pile)
 
     def __repr__(self):
         return "<StepWidget: {}>".format(self.model.title)
+
+    def update(self):
+        if not self.show_output:
+            return
+        if not os.path.exists(self.model.path + ".out"):
+            return
+        with open(self.model.path + ".out") as outf:
+            lines = outf.readlines()
+            if len(lines) < 1:
+                return
+            result = json.loads(lines[-1])
+            self.output.set_text(('body', "\n    " +
+                                  result['message']))
+
+    def clear_output(self):
+        self.output.set_text("")
 
     def set_description(self, description, color='info_minor'):
         self.description.set_text(
@@ -110,8 +131,9 @@ class StepWidget(WidgetWrap):
                 [
                     ('fixed', 3, self.icon),
                     self.description,
-                ], dividechars=1
-            )]
+                ], dividechars=1),
+            self.output
+        ]
         )
 
     def generate_additional_input(self):

--- a/conjureup/utils.py
+++ b/conjureup/utils.py
@@ -17,8 +17,8 @@ from bundleplacer.config import Config
 from bundleplacer.charmstore_api import MetadataController
 
 
-def run_script(path):
-    return run(path, shell=True, stderr=PIPE, stdout=PIPE, env=app.env)
+def run_script(path, stderr=PIPE, stdout=PIPE):
+    return run(path, shell=True, stderr=stderr, stdout=stdout, env=app.env)
 
 
 def run_attach(cmd, output_cb=None):

--- a/share/hooklib/common.sh
+++ b/share/hooklib/common.sh
@@ -171,6 +171,12 @@ waitForService()
     done
 }
 
+
+printInfo()
+{
+    printf '{"message": "%s"}' "$1"
+}
+
 # Parses result into json output
 #
 # Arguments:

--- a/share/hooklib/writer.py
+++ b/share/hooklib/writer.py
@@ -60,3 +60,9 @@ def error(msg):
         'isComplete': False
     }))
     sys.exit(0)
+
+
+def info(msg):
+    print(json.dumps({
+        'message': msg}))
+    sys.stdout.flush()


### PR DESCRIPTION
Adds an info() call to the python hooklib and a printInfo call to the sh hooklib.

Steps that use those calls will have the message shown in the GUI as the step executes.

The TUI doesn't support this right now because we're not using an event loop there.