### PR TITLE
move bootstrap output up to top-level of cache dir

### DIFF
--- a/conjureup/juju.py
+++ b/conjureup/juju.py
@@ -136,8 +136,12 @@ def bootstrap(controller, cloud, series="xenial", credential=None):
         cmd += "--credential {}".format(credential)
     app.log.debug("bootstrap cmd: {}".format(cmd))
     try:
-        pathbase = os.path.join(app.config['spell-dir'],
-                                'bootstrap')
+        cache_dir = os.environ.get('XDG_CACHE_HOME', os.path.join(
+            os.path.expanduser('~'),
+            '.cache/conjure-up'))
+
+        pathbase = os.path.join(cache_dir,
+                                '{}-bootstrap').format(app.current_controller)
         with open(pathbase + ".out", 'w') as outf:
             with open(pathbase + ".err", 'w') as errf:
                 p = Popen(cmd, shell=True, stdout=outf,

--- a/conjureup/ui/views/bootstrapwait.py
+++ b/conjureup/ui/views/bootstrapwait.py
@@ -34,8 +34,13 @@ class BootstrapWaitView(WidgetWrap):
             i.set_text(
                 self.load_attributes[random.randrange(
                     len(self.load_attributes))])
-        bootstrap_stderrpath = os.path.join(app.config['spell-dir'],
-                                            'bootstrap.err')
+        cache_dir = os.environ.get('XDG_CACHE_HOME', os.path.join(
+            os.path.expanduser('~'),
+            '.cache/conjure-up'))
+
+        bootstrap_stderrpath = os.path.join(
+            cache_dir,
+            '{}-bootstrap.err').format(app.current_controller)
         try:
             out = check_output("tail -n 10 {}".format(bootstrap_stderrpath),
                                shell=True, stderr=DEVNULL)


### PR DESCRIPTION
Since controllers can be reused by multiple spells, don't save the bootstrap output in a spell dir.

Tested with localhost controller.

Signed-off-by: Michael McCracken <mike.mccracken@canonical.com>