### PR TITLE
Add lots of test scaffolding

### DIFF
--- a/conjureup/controllers/steps/gui.py
+++ b/conjureup/controllers/steps/gui.py
@@ -6,7 +6,7 @@ from conjureup.app_config import app
 from conjureup import utils
 from conjureup import controllers
 from conjureup.models.step import StepModel
-from .common import do_step, get_step_metadata_filenames
+from conjureup.controllers.steps import common
 import os.path as path
 import os
 import yaml
@@ -22,7 +22,8 @@ class StepsController:
         self.bundle_scripts = path.join(
             app.config['spell-dir'], 'conjure/steps'
         )
-        self.step_metas = get_step_metadata_filenames(self.bundle_scripts)
+        self.step_metas = common.get_step_metadata_filenames(
+            self.bundle_scripts)
 
         self.results = OrderedDict()
 
@@ -75,7 +76,7 @@ class StepsController:
             app.log.debug("Next focused button: {}".format(index))
             self.view.step_pile.focus_position = index
 
-        future = async.submit(partial(do_step,
+        future = async.submit(partial(common.do_step,
                                       step_model,
                                       step_widget,
                                       app.ui.set_footer,

--- a/conjureup/controllers/steps/tui.py
+++ b/conjureup/controllers/steps/tui.py
@@ -1,4 +1,4 @@
-from .common import do_step, get_step_metadata_filenames
+from conjureup.controllers.steps import common
 from collections import OrderedDict
 from conjureup import controllers
 from conjureup.app_config import app
@@ -15,7 +15,8 @@ class StepsController:
         self.bundle_scripts = path.join(
             app.config['spell-dir'], 'conjure/steps'
         )
-        self.step_metas = get_step_metadata_filenames(self.bundle_scripts)
+        self.step_metas = common.get_step_metadata_filenames(
+            self.bundle_scripts)
         self.results = OrderedDict()
 
     def finish(self):
@@ -36,9 +37,9 @@ class StepsController:
             model.path = step_ex_path
             app.log.debug("Running step: {}".format(model))
             try:
-                step_model, _ = do_step(model,
-                                        None,
-                                        utils.info)
+                step_model, _ = common.do_step(model,
+                                               None,
+                                               utils.info)
                 self.results[step_model.title] = step_model.result
             except Exception as e:
                 utils.error("Failed to run {}: {}".format(model.path, e))

--- a/conjureup/controllers/summary/common.py
+++ b/conjureup/controllers/summary/common.py
@@ -1,11 +1,6 @@
-from conjureup.app_config import app
-import os
 
 
-save_path = os.path.join(app.config['spell-dir'], 'results.txt')
-
-
-def write_results(results):
+def write_results(results, save_path):
     output = []
     for k, v in results.items():
         output.append("{}: {}".format(k, v))

--- a/conjureup/controllers/summary/gui.py
+++ b/conjureup/controllers/summary/gui.py
@@ -1,12 +1,16 @@
 from conjureup.ui.views.summary import SummaryView
 from conjureup.app_config import app
 from ubuntui.ev import EventLoop
-from . import common
+from conjureup.controllers.summary import common
+
+import os
 
 
 class SummaryController:
     def __init__(self):
         self.view = None
+        self.save_path = os.path.join(app.config['spell-dir'],
+                                      'results.txt')
 
     def finish(self):
         EventLoop.remove_alarms()
@@ -15,7 +19,7 @@ class SummaryController:
     def render(self, results):
         app.log.debug("Rendering summary results: {}".format(results))
 
-        common.write_results(results)
+        common.write_results(results, self.save_path)
         self.view = SummaryView(app, results, self.finish)
         app.ui.set_header(title="Deploy Summary",
                           excerpt="Deployment summary for {}".format(

--- a/conjureup/controllers/summary/tui.py
+++ b/conjureup/controllers/summary/tui.py
@@ -1,10 +1,17 @@
-from . import common
+from conjureup.app_config import app
+from conjureup.controllers.summary import common
 from conjureup import utils
+
+import os
 
 
 class SummaryController:
+    def __init__(self):
+        self.save_path = os.path.join(app.config['spell-dir'],
+                                      'results.txt')
+
     def render(self, results):
-        common.write_results(results)
+        common.write_results(results, self.save_path)
         utils.info("Installation of your big software is now complete.")
 
 _controller_class = SummaryController

--- a/test/test_controllers_bootstrapwait_gui.py
+++ b/test/test_controllers_bootstrapwait_gui.py
@@ -1,0 +1,84 @@
+#!/usr/bin/env python
+#
+# tests controllers/bootstrapwait/gui.py
+#
+# Copyright 2016 Canonical, Ltd.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+
+import unittest
+#  from unittest.mock import ANY, call, MagicMock, patch, sentinel
+from unittest.mock import patch, MagicMock
+
+from conjureup.controllers.bootstrapwait.gui import BootstrapWaitController
+
+
+class BootstrapwaitGUIRenderTestCase(unittest.TestCase):
+    def setUp(self):
+        self.controller = BootstrapWaitController()
+
+        self.finish_patcher = patch(
+            'conjureup.controllers.bootstrapwait.gui.'
+            'BootstrapWaitController.finish')
+        self.mock_finish = self.finish_patcher.start()
+
+        self.view_patcher = patch(
+            'conjureup.controllers.bootstrapwait.gui.BootstrapWaitView')
+        self.view_patcher.start()
+        self.app_patcher = patch(
+            'conjureup.controllers.bootstrapwait.gui.app')
+        mock_app = self.app_patcher.start()
+        mock_app.ui = MagicMock(name="app.ui")
+
+        self.eventloop_patcher = patch(
+            'conjureup.controllers.bootstrapwait.gui.EventLoop')
+        self.mock_eventloop = self.eventloop_patcher.start()
+
+    def tearDown(self):
+        self.finish_patcher.stop()
+        self.view_patcher.stop()
+        self.app_patcher.stop()
+        self.eventloop_patcher.stop()
+
+    def test_render(self):
+        "call render"
+        self.controller.render()
+
+
+class BootstrapwaitGUIFinishTestCase(unittest.TestCase):
+    def setUp(self):
+        self.controller = BootstrapWaitController()
+
+        self.controllers_patcher = patch(
+            'conjureup.controllers.bootstrapwait.gui.controllers')
+        self.mock_controllers = self.controllers_patcher.start()
+
+        self.render_patcher = patch(
+            'conjureup.controllers.bootstrapwait.gui.'
+            'BootstrapWaitController.render')
+        self.mock_render = self.render_patcher.start()
+        self.app_patcher = patch(
+            'conjureup.controllers.bootstrapwait.gui.app')
+        self.mock_app = self.app_patcher.start()
+        self.mock_app.ui = MagicMock(name="app.ui")
+
+    def tearDown(self):
+        self.controllers_patcher.stop()
+        self.render_patcher.stop()
+        self.app_patcher.stop()
+
+    def test_finish(self):
+        "call finish"
+        self.controller.finish()

--- a/test/test_controllers_bootstrapwait_tui.py
+++ b/test/test_controllers_bootstrapwait_tui.py
@@ -1,0 +1,74 @@
+#!/usr/bin/env python
+#
+# tests controllers/bootstrapwait/tui.py
+#
+# Copyright 2016 Canonical, Ltd.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+
+import unittest
+
+from unittest.mock import patch
+
+from conjureup.controllers.bootstrapwait.tui import BootstrapWaitController
+
+
+class BootstrapwaitTUIRenderTestCase(unittest.TestCase):
+    def setUp(self):
+        self.controller = BootstrapWaitController()
+
+        self.utils_patcher = patch(
+            'conjureup.controllers.bootstrapwait.tui.utils')
+        self.mock_utils = self.utils_patcher.start()
+
+        self.finish_patcher = patch(
+            'conjureup.controllers.bootstrapwait.tui.'
+            'BootstrapWaitController.finish')
+        self.mock_finish = self.finish_patcher.start()
+
+    def tearDown(self):
+        self.utils_patcher.stop()
+        self.finish_patcher.stop()
+
+    def test_render(self):
+        "call render"
+        self.controller.render()
+
+
+class BootstrapwaitTUIFinishTestCase(unittest.TestCase):
+    def setUp(self):
+        self.controller = BootstrapWaitController()
+
+        self.controllers_patcher = patch(
+            'conjureup.controllers.bootstrapwait.tui.controllers')
+        self.mock_controllers = self.controllers_patcher.start()
+
+        self.utils_patcher = patch(
+            'conjureup.controllers.bootstrapwait.tui.utils')
+        self.mock_utils = self.utils_patcher.start()
+
+        self.render_patcher = patch(
+            'conjureup.controllers.bootstrapwait.tui.'
+            'BootstrapWaitController.render')
+        self.mock_render = self.render_patcher.start()
+
+    def tearDown(self):
+        self.controllers_patcher.stop()
+        self.utils_patcher.stop()
+        self.render_patcher.stop()
+
+    def test_finish(self):
+        "call finish"
+        self.controller.finish()

--- a/test/test_controllers_bundlereadme_gui.py
+++ b/test/test_controllers_bundlereadme_gui.py
@@ -1,0 +1,97 @@
+#!/usr/bin/env python
+#
+# tests controllers/bundlereadme/gui.py
+#
+# Copyright 2016 Canonical, Ltd.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+
+import unittest
+
+from unittest.mock import ANY, patch, MagicMock
+
+from conjureup.controllers.bundlereadme.gui import BundleReadmeController
+
+
+class BundleReadmeGUIRenderTestCase(unittest.TestCase):
+    def setUp(self):
+        self.controller = BundleReadmeController()
+
+        self.utils_patcher = patch(
+            'conjureup.controllers.bundlereadme.gui.utils')
+        self.mock_utils = self.utils_patcher.start()
+
+        self.finish_patcher = patch(
+            'conjureup.controllers.bundlereadme.gui.'
+            'BundleReadmeController.finish')
+        self.mock_finish = self.finish_patcher.start()
+
+        self.view_patcher = patch(
+            'conjureup.controllers.bundlereadme.gui.BundleReadmeView')
+        self.mock_view = self.view_patcher.start()
+        self.app_patcher = patch(
+            'conjureup.controllers.bundlereadme.gui.app')
+        mock_app = self.app_patcher.start()
+        mock_app.ui = MagicMock(name="app.ui")
+
+        self.eventloop_patcher = patch(
+            'conjureup.controllers.bundlereadme.gui.EventLoop')
+        self.mock_eventloop = self.eventloop_patcher.start()
+        self.mock_eventloop.screen_size.return_value = (0, 100)
+
+    def tearDown(self):
+        self.utils_patcher.stop()
+        self.finish_patcher.stop()
+        self.view_patcher.stop()
+        self.app_patcher.stop()
+        self.eventloop_patcher.stop()
+
+    def test_render(self):
+        "call render"
+        self.controller.render()
+        self.mock_view.assert_called_once_with(ANY, ANY, 75)
+
+
+class BundleReadmeGUIFinishTestCase(unittest.TestCase):
+    def setUp(self):
+        self.controller = BundleReadmeController()
+
+        self.controllers_patcher = patch(
+            'conjureup.controllers.bundlereadme.gui.controllers')
+        self.mock_controllers = self.controllers_patcher.start()
+
+        self.utils_patcher = patch(
+            'conjureup.controllers.bundlereadme.gui.utils')
+        self.mock_utils = self.utils_patcher.start()
+
+        self.render_patcher = patch(
+            'conjureup.controllers.bundlereadme.gui.'
+            'BundleReadmeController.render')
+        self.mock_render = self.render_patcher.start()
+        self.app_patcher = patch(
+            'conjureup.controllers.bundlereadme.gui.app')
+        self.mock_app = self.app_patcher.start()
+        self.mock_app.ui = MagicMock(name="app.ui")
+
+    def tearDown(self):
+        self.controllers_patcher.stop()
+        self.utils_patcher.stop()
+        self.render_patcher.stop()
+        self.app_patcher.stop()
+
+    def test_finish(self):
+        "call finish"
+        self.controller.finish()
+        self.mock_controllers.use.assert_called_once_with('deploy')

--- a/test/test_controllers_clouds_gui.py
+++ b/test/test_controllers_clouds_gui.py
@@ -1,0 +1,94 @@
+#!/usr/bin/env python
+#
+# tests controllers/clouds/gui.py
+#
+# Copyright 2016 Canonical, Ltd.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+
+import unittest
+#  from unittest.mock import ANY, call, MagicMock, patch, sentinel
+from unittest.mock import patch, MagicMock
+
+from conjureup.controllers.clouds.gui import CloudsController
+
+
+class CloudsGUIRenderTestCase(unittest.TestCase):
+    def setUp(self):
+        self.controller = CloudsController()
+
+        self.utils_patcher = patch(
+            'conjureup.controllers.clouds.gui.utils')
+        self.mock_utils = self.utils_patcher.start()
+
+        self.finish_patcher = patch(
+            'conjureup.controllers.clouds.gui.CloudsController.finish')
+        self.mock_finish = self.finish_patcher.start()
+
+        self.view_patcher = patch(
+            'conjureup.controllers.clouds.gui.CloudView')
+        self.view_patcher.start()
+        self.app_patcher = patch(
+            'conjureup.controllers.clouds.gui.app')
+        mock_app = self.app_patcher.start()
+        mock_app.ui = MagicMock(name="app.ui")
+        self.common_patcher = patch(
+            'conjureup.controllers.clouds.gui.common')
+        self.mock_common = self.common_patcher.start()
+        self.mock_common.list_clouds.return_value = ['test1', 'test2']
+
+    def tearDown(self):
+        self.utils_patcher.stop()
+        self.finish_patcher.stop()
+        self.view_patcher.stop()
+        self.app_patcher.stop()
+        self.common_patcher.start()
+
+    def test_render(self):
+        "call render"
+        self.controller.render()
+
+
+class CloudsGUIFinishTestCase(unittest.TestCase):
+    def setUp(self):
+        self.controller = CloudsController()
+
+        self.controllers_patcher = patch(
+            'conjureup.controllers.clouds.gui.controllers')
+        self.mock_controllers = self.controllers_patcher.start()
+
+        self.utils_patcher = patch(
+            'conjureup.controllers.clouds.gui.utils')
+        self.mock_utils = self.utils_patcher.start()
+
+        self.render_patcher = patch(
+            'conjureup.controllers.clouds.gui.CloudsController.render')
+        self.mock_render = self.render_patcher.start()
+        self.app_patcher = patch(
+            'conjureup.controllers.clouds.gui.app')
+        self.mock_app = self.app_patcher.start()
+        self.mock_app.ui = MagicMock(name="app.ui")
+
+        self.cloudname = 'testcloudname'
+
+    def tearDown(self):
+        self.controllers_patcher.stop()
+        self.utils_patcher.stop()
+        self.render_patcher.stop()
+        self.app_patcher.stop()
+
+    def test_finish(self):
+        "call finish"
+        self.controller.finish(self.cloudname)

--- a/test/test_controllers_clouds_tui.py
+++ b/test/test_controllers_clouds_tui.py
@@ -1,0 +1,97 @@
+#!/usr/bin/env python
+#
+# tests controllers/clouds/tui.py
+#
+# Copyright 2016 Canonical, Ltd.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+
+import unittest
+#  from unittest.mock import ANY, call, MagicMock, patch, sentinel
+from unittest.mock import patch, MagicMock
+
+from conjureup.controllers.clouds.tui import CloudsController
+
+
+class CloudsTUIRenderTestCase(unittest.TestCase):
+    def setUp(self):
+        self.controller = CloudsController()
+
+        self.utils_patcher = patch(
+            'conjureup.controllers.clouds.tui.utils')
+        self.mock_utils = self.utils_patcher.start()
+
+        self.finish_patcher = patch(
+            'conjureup.controllers.clouds.tui.CloudsController.finish')
+        self.mock_finish = self.finish_patcher.start()
+
+        self.app_patcher = patch(
+            'conjureup.controllers.clouds.tui.app')
+        self.mock_app = self.app_patcher.start()
+        self.mock_app.ui = MagicMock(name="app.ui")
+
+        self.juju_patcher = patch(
+            'conjureup.controllers.clouds.tui.juju')
+        self.mock_juju = self.juju_patcher.start()
+
+    def tearDown(self):
+        self.utils_patcher.stop()
+        self.finish_patcher.stop()
+        self.app_patcher.stop()
+        self.juju_patcher.stop()
+
+    def test_render(self):
+        "Rendering with a known cloud should call finish"
+        self.mock_app.argv.cloud = "testcloud"
+        t = ['testcloud']
+        self.mock_juju.get_clouds.return_value.keys.return_value = t
+        self.controller.render()
+        self.mock_finish.assert_called_once_with()
+
+    def test_render_unknown(self):
+        "Rendering with an unknown cloud should raise"
+        with self.assertRaises(SystemExit):
+            self.controller.render()
+
+
+class CloudsTUIFinishTestCase(unittest.TestCase):
+    def setUp(self):
+        self.controller = CloudsController()
+
+        self.controllers_patcher = patch(
+            'conjureup.controllers.clouds.tui.controllers')
+        self.mock_controllers = self.controllers_patcher.start()
+
+        self.utils_patcher = patch(
+            'conjureup.controllers.clouds.tui.utils')
+        self.mock_utils = self.utils_patcher.start()
+
+        self.render_patcher = patch(
+            'conjureup.controllers.clouds.tui.CloudsController.render')
+        self.mock_render = self.render_patcher.start()
+        self.app_patcher = patch(
+            'conjureup.controllers.clouds.tui.app')
+        self.mock_app = self.app_patcher.start()
+        self.mock_app.ui = MagicMock(name="app.ui")
+
+    def tearDown(self):
+        self.controllers_patcher.stop()
+        self.utils_patcher.stop()
+        self.render_patcher.stop()
+        self.app_patcher.stop()
+
+    def test_finish(self):
+        "call finish"
+        self.controller.finish()

--- a/test/test_controllers_deploy_tui.py
+++ b/test/test_controllers_deploy_tui.py
@@ -1,0 +1,104 @@
+#!/usr/bin/env python
+#
+# tests controllers/deploy/tui.py
+#
+# Copyright 2016 Canonical, Ltd.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+
+import unittest
+#  from unittest.mock import , call, MagicMock, patch, sentinel
+from unittest.mock import ANY, patch, MagicMock, sentinel
+
+from conjureup.controllers.deploy.tui import DeployController
+
+
+class DeployTUIRenderTestCase(unittest.TestCase):
+    def setUp(self):
+
+        self.utils_patcher = patch(
+            'conjureup.controllers.deploy.tui.utils')
+        self.mock_utils = self.utils_patcher.start()
+
+        self.finish_patcher = patch(
+            'conjureup.controllers.deploy.tui.DeployController.finish')
+        self.mock_finish = self.finish_patcher.start()
+
+        self.app_patcher = patch(
+            'conjureup.controllers.deploy.tui.app')
+        mock_app = self.app_patcher.start()
+        mock_app.ui = MagicMock(name="app.ui")
+
+        self.bundleinfo_patcher = patch(
+            'conjureup.controllers.deploy.tui.get_bundleinfo')
+        self.mock_get_bundleinfo = self.bundleinfo_patcher.start()
+        self.mock_bundle = MagicMock(name="bundle")
+        self.mock_bundle.machines = {"1": sentinel.machine_1}
+        self.mock_service_1 = MagicMock(name="s1")
+        self.mock_get_bundleinfo.return_value = ("filename",
+                                                 self.mock_bundle,
+                                                 [self.mock_service_1])
+
+        self.controller = DeployController()
+
+        self.juju_patcher = patch(
+            'conjureup.controllers.deploy.tui.juju')
+        self.mock_juju = self.juju_patcher.start()
+        self.mock_juju.JUJU_ASYNC_QUEUE = sentinel.JUJU_ASYNC_QUEUE
+
+    def tearDown(self):
+        self.utils_patcher.stop()
+        self.finish_patcher.stop()
+        self.app_patcher.stop()
+        self.bundleinfo_patcher.stop()
+        self.juju_patcher.stop()
+
+    def test_render(self):
+        "call render"
+        with patch.object(self.controller, 'do_pre_deploy') as mock_predeploy:
+            self.controller.render()
+            mock_predeploy.assert_called_once_with()
+        self.mock_juju.add_machines.assert_called_once_with(ANY, exc_cb=ANY)
+
+
+class DeployTUIFinishTestCase(unittest.TestCase):
+    def setUp(self):
+        self.controller = DeployController()
+
+        self.controllers_patcher = patch(
+            'conjureup.controllers.deploy.tui.controllers')
+        self.mock_controllers = self.controllers_patcher.start()
+
+        self.utils_patcher = patch(
+            'conjureup.controllers.deploy.tui.utils')
+        self.mock_utils = self.utils_patcher.start()
+
+        self.render_patcher = patch(
+            'conjureup.controllers.deploy.tui.DeployController.render')
+        self.mock_render = self.render_patcher.start()
+        self.app_patcher = patch(
+            'conjureup.controllers.deploy.tui.app')
+        self.mock_app = self.app_patcher.start()
+        self.mock_app.ui = MagicMock(name="app.ui")
+
+    def tearDown(self):
+        self.controllers_patcher.stop()
+        self.utils_patcher.stop()
+        self.render_patcher.stop()
+        self.app_patcher.stop()
+
+    def test_finish(self):
+        "call finish"
+        self.controller.finish()

--- a/test/test_controllers_deploystatus_gui.py
+++ b/test/test_controllers_deploystatus_gui.py
@@ -1,0 +1,105 @@
+#!/usr/bin/env python
+#
+# tests controllers/deploystatus/gui.py
+#
+# Copyright 2016 Canonical, Ltd.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+
+import unittest
+#  from unittest.mock import ANY, call, MagicMock, patch, sentinel
+from unittest.mock import patch, MagicMock
+
+from conjureup.controllers.deploystatus.gui import DeployStatusController
+
+
+class DeployStatusGUIRenderTestCase(unittest.TestCase):
+    def setUp(self):
+
+        self.utils_patcher = patch(
+            'conjureup.controllers.deploystatus.gui.utils')
+        self.mock_utils = self.utils_patcher.start()
+
+        self.finish_patcher = patch(
+            'conjureup.controllers.deploystatus.gui.'
+            'DeployStatusController.finish')
+        self.mock_finish = self.finish_patcher.start()
+
+        self.view_patcher = patch(
+            'conjureup.controllers.deploystatus.gui.DeployStatusView')
+        self.view_patcher.start()
+        self.app_patcher = patch(
+            'conjureup.controllers.deploystatus.gui.app')
+        mock_app = self.app_patcher.start()
+        mock_app.ui = MagicMock(name="app.ui")
+        self.eventloop_patcher = patch(
+            'conjureup.controllers.deploystatus.gui.EventLoop')
+        self.mock_eventloop = self.eventloop_patcher.start()
+
+        self.controller = DeployStatusController()
+
+    def tearDown(self):
+        self.utils_patcher.stop()
+        self.finish_patcher.stop()
+        self.view_patcher.stop()
+        self.app_patcher.stop()
+        self.eventloop_patcher.stop()
+
+    def test_render(self):
+        "call render"
+        self.controller.render()
+
+
+class DeployStatusGUIFinishTestCase(unittest.TestCase):
+    def setUp(self):
+
+        self.controllers_patcher = patch(
+            'conjureup.controllers.deploystatus.gui.controllers')
+        self.mock_controllers = self.controllers_patcher.start()
+
+        self.utils_patcher = patch(
+            'conjureup.controllers.deploystatus.gui.utils')
+        self.mock_utils = self.utils_patcher.start()
+
+        self.render_patcher = patch(
+            'conjureup.controllers.deploystatus.gui.'
+            'DeployStatusController.render')
+        self.mock_render = self.render_patcher.start()
+        self.app_patcher = patch(
+            'conjureup.controllers.deploystatus.gui.app')
+        self.mock_app = self.app_patcher.start()
+        self.mock_app.ui = MagicMock(name="app.ui")
+
+        self.controller = DeployStatusController()
+
+    def tearDown(self):
+        self.controllers_patcher.stop()
+        self.utils_patcher.stop()
+        self.render_patcher.stop()
+        self.app_patcher.stop()
+
+    def test_finish_ok(self):
+        "finish with no exception calls steps"
+        mock_future = MagicMock(name='future')
+        mock_future.exception.return_value = False
+        self.controller.finish(mock_future)
+        self.mock_controllers.use.assert_called_once_with('steps')
+
+    def test_finish_exception(self):
+        "finish with exception just bails"
+        mock_future = MagicMock(name='future')
+        mock_future.exception.return_value = True
+        self.controller.finish(mock_future)
+        self.assertEqual(False, self.mock_controllers.use.called)

--- a/test/test_controllers_deploystatus_tui.py
+++ b/test/test_controllers_deploystatus_tui.py
@@ -1,0 +1,97 @@
+#!/usr/bin/env python
+#
+# tests controllers/deploystatus/tui.py
+#
+# Copyright 2016 Canonical, Ltd.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+
+import unittest
+#  from unittest.mock import ANY, call, MagicMock, patch, sentinel
+from unittest.mock import patch, MagicMock
+
+from conjureup.controllers.deploystatus.tui import DeployStatusController
+
+
+class DeployStatusTUIRenderTestCase(unittest.TestCase):
+    def setUp(self):
+
+        self.utils_patcher = patch(
+            'conjureup.controllers.deploystatus.tui.utils')
+        self.mock_utils = self.utils_patcher.start()
+
+        self.finish_patcher = patch(
+            'conjureup.controllers.deploystatus.tui.'
+            'DeployStatusController.finish')
+        self.mock_finish = self.finish_patcher.start()
+
+        self.app_patcher = patch(
+            'conjureup.controllers.deploystatus.tui.app')
+        mock_app = self.app_patcher.start()
+        mock_app.ui = MagicMock(name="app.ui")
+
+        self.controller = DeployStatusController()
+
+    def tearDown(self):
+        self.utils_patcher.stop()
+        self.finish_patcher.stop()
+        self.app_patcher.stop()
+
+    def test_render(self):
+        "call render"
+        self.controller.render()
+
+
+class DeployStatusTUIFinishTestCase(unittest.TestCase):
+    def setUp(self):
+
+        self.controllers_patcher = patch(
+            'conjureup.controllers.deploystatus.tui.controllers')
+        self.mock_controllers = self.controllers_patcher.start()
+
+        self.utils_patcher = patch(
+            'conjureup.controllers.deploystatus.tui.utils')
+        self.mock_utils = self.utils_patcher.start()
+
+        self.render_patcher = patch(
+            'conjureup.controllers.deploystatus.tui.'
+            'DeployStatusController.render')
+        self.mock_render = self.render_patcher.start()
+        self.app_patcher = patch(
+            'conjureup.controllers.deploystatus.tui.app')
+        self.mock_app = self.app_patcher.start()
+        self.mock_app.ui = MagicMock(name="app.ui")
+
+        self.controller = DeployStatusController()
+
+    def tearDown(self):
+        self.controllers_patcher.stop()
+        self.utils_patcher.stop()
+        self.render_patcher.stop()
+        self.app_patcher.stop()
+
+    def test_finish_ok(self):
+        "finish with no exception calls steps"
+        mock_future = MagicMock(name='future')
+        mock_future.exception.return_value = False
+        self.controller.finish(mock_future)
+        self.mock_controllers.use.assert_called_once_with('steps')
+
+    def test_finish_exception(self):
+        "finish with exception just bails"
+        mock_future = MagicMock(name='future')
+        mock_future.exception.return_value = True
+        self.controller.finish(mock_future)
+        self.assertEqual(False, self.mock_controllers.use.called)

--- a/test/test_controllers_lxdsetup_gui.py
+++ b/test/test_controllers_lxdsetup_gui.py
@@ -1,0 +1,87 @@
+#!/usr/bin/env python
+#
+# tests controllers/lxdsetup/gui.py
+#
+# Copyright 2016 Canonical, Ltd.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+
+import unittest
+#  from unittest.mock import ANY, call, MagicMock, patch, sentinel
+from unittest.mock import patch, MagicMock
+
+from conjureup.controllers.lxdsetup.gui import LXDSetupController
+
+
+class LXDSetupGUIRenderTestCase(unittest.TestCase):
+    def setUp(self):
+        self.controller = LXDSetupController()
+
+        self.utils_patcher = patch(
+            'conjureup.controllers.lxdsetup.gui.utils')
+        self.mock_utils = self.utils_patcher.start()
+
+        self.finish_patcher = patch(
+            'conjureup.controllers.lxdsetup.gui.LXDSetupController.finish')
+        self.mock_finish = self.finish_patcher.start()
+
+        self.view_patcher = patch(
+            'conjureup.controllers.lxdsetup.gui.LXDSetupView')
+        self.view_patcher.start()
+        self.app_patcher = patch(
+            'conjureup.controllers.lxdsetup.gui.app')
+        mock_app = self.app_patcher.start()
+        mock_app.ui = MagicMock(name="app.ui")
+
+    def tearDown(self):
+        self.utils_patcher.stop()
+        self.finish_patcher.stop()
+        self.view_patcher.stop()
+        self.app_patcher.stop()
+
+    def test_render(self):
+        "call render"
+        self.controller.render()
+
+
+class LXDSetupGUIFinishTestCase(unittest.TestCase):
+    def setUp(self):
+        self.controller = LXDSetupController()
+
+        self.controllers_patcher = patch(
+            'conjureup.controllers.lxdsetup.gui.controllers')
+        self.mock_controllers = self.controllers_patcher.start()
+
+        self.utils_patcher = patch(
+            'conjureup.controllers.lxdsetup.gui.utils')
+        self.mock_utils = self.utils_patcher.start()
+
+        self.render_patcher = patch(
+            'conjureup.controllers.lxdsetup.gui.LXDSetupController.render')
+        self.mock_render = self.render_patcher.start()
+        self.app_patcher = patch(
+            'conjureup.controllers.lxdsetup.gui.app')
+        self.mock_app = self.app_patcher.start()
+        self.mock_app.ui = MagicMock(name="app.ui")
+
+    def tearDown(self):
+        self.controllers_patcher.stop()
+        self.utils_patcher.stop()
+        self.render_patcher.stop()
+        self.app_patcher.stop()
+
+    def test_finish(self):
+        "call finish"
+        self.controller.finish()

--- a/test/test_controllers_newcloud_gui.py
+++ b/test/test_controllers_newcloud_gui.py
@@ -1,0 +1,87 @@
+#!/usr/bin/env python
+#
+# tests controllers/newcloud/gui.py
+#
+# Copyright 2016 Canonical, Ltd.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+
+import unittest
+#  from unittest.mock import ANY, call, MagicMock, patch, sentinel
+from unittest.mock import patch, MagicMock
+
+from conjureup.controllers.newcloud.gui import NewCloudController
+
+
+class NewCloudGUIRenderTestCase(unittest.TestCase):
+    def setUp(self):
+        self.controller = NewCloudController()
+
+        self.utils_patcher = patch(
+            'conjureup.controllers.newcloud.gui.utils')
+        self.mock_utils = self.utils_patcher.start()
+
+        self.finish_patcher = patch(
+            'conjureup.controllers.newcloud.gui.NewCloudController.finish')
+        self.mock_finish = self.finish_patcher.start()
+
+        self.view_patcher = patch(
+            'conjureup.controllers.newcloud.gui.NewCloudView')
+        self.view_patcher.start()
+        self.app_patcher = patch(
+            'conjureup.controllers.newcloud.gui.app')
+        mock_app = self.app_patcher.start()
+        mock_app.ui = MagicMock(name="app.ui")
+
+    def tearDown(self):
+        self.utils_patcher.stop()
+        self.finish_patcher.stop()
+        self.view_patcher.stop()
+        self.app_patcher.stop()
+
+    def test_render(self):
+        "call render"
+        self.controller.render('cloudname')
+
+
+class NewCloudGUIFinishTestCase(unittest.TestCase):
+    def setUp(self):
+        self.controller = NewCloudController()
+
+        self.controllers_patcher = patch(
+            'conjureup.controllers.newcloud.gui.controllers')
+        self.mock_controllers = self.controllers_patcher.start()
+
+        self.utils_patcher = patch(
+            'conjureup.controllers.newcloud.gui.utils')
+        self.mock_utils = self.utils_patcher.start()
+
+        self.render_patcher = patch(
+            'conjureup.controllers.newcloud.gui.NewCloudController.render')
+        self.mock_render = self.render_patcher.start()
+        self.app_patcher = patch(
+            'conjureup.controllers.newcloud.gui.app')
+        self.mock_app = self.app_patcher.start()
+        self.mock_app.ui = MagicMock(name="app.ui")
+
+    def tearDown(self):
+        self.controllers_patcher.stop()
+        self.utils_patcher.stop()
+        self.render_patcher.stop()
+        self.app_patcher.stop()
+
+    def test_finish(self):
+        "call finish"
+        self.controller.finish()

--- a/test/test_controllers_newcloud_tui.py
+++ b/test/test_controllers_newcloud_tui.py
@@ -1,0 +1,113 @@
+#!/usr/bin/env python
+#
+# tests controllers/newcloud/tui.py
+#
+# Copyright 2016 Canonical, Ltd.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+
+import unittest
+#  from unittest.mock import ANY, call, MagicMock, patch
+from unittest.mock import patch, MagicMock, sentinel
+
+from conjureup.controllers.newcloud.tui import NewCloudController
+
+
+class NewCloudTUIRenderTestCase(unittest.TestCase):
+    def setUp(self):
+        self.controller = NewCloudController()
+        self.controller.do_post_bootstrap = MagicMock()
+
+        self.utils_patcher = patch(
+            'conjureup.controllers.newcloud.tui.utils')
+        self.mock_utils = self.utils_patcher.start()
+
+        self.finish_patcher = patch(
+            'conjureup.controllers.newcloud.tui.NewCloudController.finish')
+        self.mock_finish = self.finish_patcher.start()
+
+        self.app_patcher = patch(
+            'conjureup.controllers.newcloud.tui.app')
+        self.mock_app = self.app_patcher.start()
+        self.mock_app.ui = MagicMock(name="app.ui")
+        self.juju_patcher = patch(
+            'conjureup.controllers.newcloud.tui.juju')
+        self.mock_juju = self.juju_patcher.start()
+
+        self.common_patcher = patch(
+            'conjureup.controllers.newcloud.tui.common')
+        self.mock_common = self.common_patcher.start()
+
+    def tearDown(self):
+        self.utils_patcher.stop()
+        self.finish_patcher.stop()
+        self.app_patcher.stop()
+        self.mock_juju.stop()
+        self.common_patcher.stop()
+
+    def test_render_non_localhost_no_creds(self):
+        "non-localhost cloud raises if no creds"
+        self.mock_common.try_get_creds.return_value = False
+        with self.assertRaises(SystemExit):
+            self.controller.render('testcloud')
+
+    def test_render_non_localhost_with_creds(self):
+        "non-localhost cloud ok if has creds"
+        self.mock_common.try_get_creds.return_value = True
+        self.controller.render('testcloud')
+        print(self.mock_common.mock_calls)
+
+    def test_render(self):
+        self.mock_common.try_get_creds.return_value = True
+        self.mock_app.current_controller = sentinel.controllername
+        self.controller.render('localhost')
+        self.mock_juju.bootstrap.assert_called_once_with(
+            controller=sentinel.controllername,
+            cloud='localhost',
+            credential=True)
+
+        self.controller.do_post_bootstrap.assert_called_once_with()
+        self.mock_finish.assert_called_once_with()
+
+
+class NewCloudTUIFinishTestCase(unittest.TestCase):
+    def setUp(self):
+        self.controller = NewCloudController()
+
+        self.controllers_patcher = patch(
+            'conjureup.controllers.newcloud.tui.controllers')
+        self.mock_controllers = self.controllers_patcher.start()
+
+        self.utils_patcher = patch(
+            'conjureup.controllers.newcloud.tui.utils')
+        self.mock_utils = self.utils_patcher.start()
+
+        self.render_patcher = patch(
+            'conjureup.controllers.newcloud.tui.NewCloudController.render')
+        self.mock_render = self.render_patcher.start()
+        self.app_patcher = patch(
+            'conjureup.controllers.newcloud.tui.app')
+        self.mock_app = self.app_patcher.start()
+        self.mock_app.ui = MagicMock(name="app.ui")
+
+    def tearDown(self):
+        self.controllers_patcher.stop()
+        self.utils_patcher.stop()
+        self.render_patcher.stop()
+        self.app_patcher.stop()
+
+    def test_finish(self):
+        "call finish"
+        self.controller.finish()

--- a/test/test_controllers_steps_gui.py
+++ b/test/test_controllers_steps_gui.py
@@ -1,0 +1,114 @@
+#!/usr/bin/env python
+#
+# tests controllers/steps/gui.py
+#
+# Copyright 2016 Canonical, Ltd.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+
+import unittest
+#  from unittest.mock import ANY, call, MagicMock, patch, sentinel
+from unittest.mock import patch, MagicMock, sentinel
+
+from conjureup.controllers.steps.gui import StepsController
+
+
+class StepsGUIRenderTestCase(unittest.TestCase):
+    def setUp(self):
+
+        self.utils_patcher = patch(
+            'conjureup.controllers.steps.gui.utils')
+        self.mock_utils = self.utils_patcher.start()
+
+        self.finish_patcher = patch(
+            'conjureup.controllers.steps.gui.StepsController.finish')
+        self.mock_finish = self.finish_patcher.start()
+
+        self.view_patcher = patch(
+            'conjureup.controllers.steps.gui.StepsView')
+        self.view_patcher.start()
+        self.app_patcher = patch(
+            'conjureup.controllers.steps.gui.app')
+        mock_app = self.app_patcher.start()
+        mock_app.ui = MagicMock(name="app.ui")
+
+        self.common_patcher = patch(
+            'conjureup.controllers.steps.gui.common')
+        self.mock_common = self.common_patcher.start()
+
+        self.controller = StepsController()
+
+    def tearDown(self):
+        self.utils_patcher.stop()
+        self.finish_patcher.stop()
+        self.view_patcher.stop()
+        self.app_patcher.stop()
+        self.common_patcher.stop()
+
+    def test_render(self):
+        "call render"
+        self.mock_common.get_step_metadata_filenames.return_value = []
+        self.controller.render()
+
+
+class StepsGUIFinishTestCase(unittest.TestCase):
+    def setUp(self):
+
+        self.controllers_patcher = patch(
+            'conjureup.controllers.steps.gui.controllers')
+        self.mock_controllers = self.controllers_patcher.start()
+
+        self.utils_patcher = patch(
+            'conjureup.controllers.steps.gui.utils')
+        self.mock_utils = self.utils_patcher.start()
+
+        self.render_patcher = patch(
+            'conjureup.controllers.steps.gui.StepsController.render')
+        self.mock_render = self.render_patcher.start()
+        self.app_patcher = patch(
+            'conjureup.controllers.steps.gui.app')
+        self.mock_app = self.app_patcher.start()
+        self.mock_app.ui = MagicMock(name="app.ui")
+
+        self.common_patcher = patch(
+            'conjureup.controllers.steps.gui.common')
+        self.mock_common = self.common_patcher.start()
+        m_f = self.mock_common.get_step_metadata_filenames
+        m_f.return_value = sentinel.step_metas
+
+        self.submit_patcher = patch(
+            'conjureup.controllers.steps.gui.async.submit')
+        self.mock_submit = self.submit_patcher.start()
+
+        self.controller = StepsController()
+        self.mock_stepsview = MagicMock()
+        self.controller.view = self.mock_stepsview
+
+    def tearDown(self):
+        self.controllers_patcher.stop()
+        self.utils_patcher.stop()
+        self.render_patcher.stop()
+        self.app_patcher.stop()
+        self.common_patcher.stop()
+        self.submit_patcher.stop()
+
+    def test_finish_done(self):
+        "call finish with done=True"
+        self.controller.results = sentinel.results
+        mock_model = MagicMock(name="model")
+        mock_widget = MagicMock(name="widget")
+        self.controller.finish(mock_model, mock_widget, done=True)
+        m_r = self.mock_controllers.use('summary').render
+        m_r.assert_called_once_with(sentinel.results)

--- a/test/test_controllers_steps_tui.py
+++ b/test/test_controllers_steps_tui.py
@@ -1,0 +1,95 @@
+#!/usr/bin/env python
+#
+# tests controllers/steps/tui.py
+#
+# Copyright 2016 Canonical, Ltd.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+
+import unittest
+
+from unittest.mock import patch, MagicMock, sentinel
+
+from conjureup.controllers.steps.tui import StepsController
+
+
+class StepsTUIRenderTestCase(unittest.TestCase):
+    def setUp(self):
+
+        self.utils_patcher = patch(
+            'conjureup.controllers.steps.tui.utils')
+        self.mock_utils = self.utils_patcher.start()
+
+        self.finish_patcher = patch(
+            'conjureup.controllers.steps.tui.StepsController.finish')
+        self.mock_finish = self.finish_patcher.start()
+
+        self.app_patcher = patch(
+            'conjureup.controllers.steps.tui.app')
+        mock_app = self.app_patcher.start()
+        mock_app.ui = MagicMock(name="app.ui")
+
+        self.common_patcher = patch(
+            'conjureup.controllers.steps.tui.common')
+        self.mock_common = self.common_patcher.start()
+        self.controller = StepsController()
+
+    def tearDown(self):
+        self.utils_patcher.stop()
+        self.finish_patcher.stop()
+        self.app_patcher.stop()
+        self.common_patcher.stop()
+
+    def test_render(self):
+        "call render"
+        self.mock_common.get_step_metadata_filenames.return_value = []
+        self.controller.render()
+
+
+class StepsTUIFinishTestCase(unittest.TestCase):
+    def setUp(self):
+
+        self.controllers_patcher = patch(
+            'conjureup.controllers.steps.tui.controllers')
+        self.mock_controllers = self.controllers_patcher.start()
+
+        self.utils_patcher = patch(
+            'conjureup.controllers.steps.tui.utils')
+        self.mock_utils = self.utils_patcher.start()
+
+        self.render_patcher = patch(
+            'conjureup.controllers.steps.tui.StepsController.render')
+        self.mock_render = self.render_patcher.start()
+        self.app_patcher = patch(
+            'conjureup.controllers.steps.tui.app')
+        self.mock_app = self.app_patcher.start()
+        self.mock_app.ui = MagicMock(name="app.ui")
+        self.common_patcher = patch(
+            'conjureup.controllers.steps.tui.common')
+        self.mock_common = self.common_patcher.start()
+        m_f = self.mock_common.get_step_metadata_filenames
+        m_f.return_value = sentinel.step_metas
+        self.controller = StepsController()
+
+    def tearDown(self):
+        self.controllers_patcher.stop()
+        self.utils_patcher.stop()
+        self.render_patcher.stop()
+        self.app_patcher.stop()
+        self.common_patcher.stop()
+
+    def test_finish(self):
+        "call finish"
+        self.controller.finish()

--- a/test/test_controllers_summary_gui.py
+++ b/test/test_controllers_summary_gui.py
@@ -1,0 +1,78 @@
+#!/usr/bin/env python
+#
+# tests controllers/summary/gui.py
+#
+# Copyright 2016 Canonical, Ltd.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+
+import unittest
+
+from unittest.mock import call, patch, MagicMock, sentinel
+
+from conjureup.controllers.summary.gui import SummaryController
+
+
+class SummaryGUIRenderTestCase(unittest.TestCase):
+    def setUp(self):
+
+        self.finish_patcher = patch(
+            'conjureup.controllers.summary.gui.SummaryController.finish')
+        self.mock_finish = self.finish_patcher.start()
+
+        self.view_patcher = patch(
+            'conjureup.controllers.summary.gui.SummaryView')
+        self.view_patcher.start()
+        self.app_patcher = patch(
+            'conjureup.controllers.summary.gui.app')
+        mock_app = self.app_patcher.start()
+        mock_app.ui = MagicMock(name="app.ui")
+
+        self.controller = SummaryController()
+        self.controller.save_path = sentinel.savepath
+
+    def tearDown(self):
+        self.finish_patcher.stop()
+        self.view_patcher.stop()
+        self.app_patcher.stop()
+
+    def test_render_empty(self):
+        "call render with no results"
+        with patch("conjureup.controllers.summary.gui.common") as m_c:
+            self.controller.render({})
+            m_c.write_results.assert_called_once_with({}, sentinel.savepath)
+
+
+class SummaryGUIFinishTestCase(unittest.TestCase):
+    def setUp(self):
+
+        self.render_patcher = patch(
+            'conjureup.controllers.summary.gui.SummaryController.render')
+        self.mock_render = self.render_patcher.start()
+        self.app_patcher = patch(
+            'conjureup.controllers.summary.gui.app')
+        self.mock_app = self.app_patcher.start()
+        self.mock_app.ui = MagicMock(name="app.ui")
+        self.controller = SummaryController()
+
+    def tearDown(self):
+        self.render_patcher.stop()
+        self.app_patcher.stop()
+
+    def test_finish(self):
+        "finish should stop event loop"
+        with patch("conjureup.controllers.summary.gui.EventLoop") as m_ev:
+            self.controller.finish()
+            m_ev.assert_has_calls([call.remove_alarms(), call.exit(0)])

--- a/test/test_controllers_summary_tui.py
+++ b/test/test_controllers_summary_tui.py
@@ -1,0 +1,50 @@
+#!/usr/bin/env python
+#
+# tests controllers/summary/tui.py
+#
+# Copyright 2016 Canonical, Ltd.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+
+import unittest
+
+from unittest.mock import patch, MagicMock, sentinel
+
+from conjureup.controllers.summary.tui import SummaryController
+
+
+class SummaryTUIRenderTestCase(unittest.TestCase):
+    def setUp(self):
+
+        self.utils_patcher = patch(
+            'conjureup.controllers.summary.tui.utils')
+        self.mock_utils = self.utils_patcher.start()
+
+        self.app_patcher = patch(
+            'conjureup.controllers.summary.tui.app')
+        mock_app = self.app_patcher.start()
+        mock_app.ui = MagicMock(name="app.ui")
+        self.controller = SummaryController()
+        self.controller.save_path = sentinel.savepath
+
+    def tearDown(self):
+        self.utils_patcher.stop()
+        self.app_patcher.stop()
+
+    def test_render_empty(self):
+        "call render with empty results"
+        with patch("conjureup.controllers.summary.tui.common") as m_c:
+            self.controller.render({})
+            m_c.write_results.assert_called_once_with({}, sentinel.savepath)

--- a/test/test_controllers_variants_gui.py
+++ b/test/test_controllers_variants_gui.py
@@ -1,0 +1,104 @@
+#!/usr/bin/env python
+#
+# tests controllers/variants/gui.py
+#
+# Copyright 2016 Canonical, Ltd.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+
+import unittest
+#  from unittest.mock import ANY, call, MagicMock, patch, sentinel
+from unittest.mock import patch, MagicMock
+
+from conjureup.controllers.variants.gui import VariantsController
+
+
+class VariantsGUIRenderTestCase(unittest.TestCase):
+    def setUp(self):
+        self.controller = VariantsController()
+
+        self.utils_patcher = patch(
+            'conjureup.controllers.variants.gui.utils')
+        self.mock_utils = self.utils_patcher.start()
+
+        self.finish_patcher = patch(
+            'conjureup.controllers.variants.gui.VariantsController.finish')
+        self.mock_finish = self.finish_patcher.start()
+
+        self.view_patcher = patch(
+            'conjureup.controllers.variants.gui.VariantView')
+        self.view_patcher.start()
+        self.app_patcher = patch(
+            'conjureup.controllers.variants.gui.app')
+        mock_app = self.app_patcher.start()
+        mock_app.ui = MagicMock(name="app.ui")
+
+    def tearDown(self):
+        self.utils_patcher.stop()
+        self.finish_patcher.stop()
+        self.view_patcher.stop()
+        self.app_patcher.stop()
+
+    def test_render(self):
+        "call render"
+        self.controller.render()
+
+
+class VariantsGUIFinishTestCase(unittest.TestCase):
+    def setUp(self):
+        self.controller = VariantsController()
+
+        self.controllers_patcher = patch(
+            'conjureup.controllers.variants.gui.controllers')
+        self.mock_controllers = self.controllers_patcher.start()
+
+        self.utils_patcher = patch(
+            'conjureup.controllers.variants.gui.utils')
+        self.mock_utils = self.utils_patcher.start()
+
+        self.render_patcher = patch(
+            'conjureup.controllers.variants.gui.VariantsController.render')
+        self.mock_render = self.render_patcher.start()
+        self.app_patcher = patch(
+            'conjureup.controllers.variants.gui.app')
+        self.mock_app = self.app_patcher.start()
+        self.mock_app.ui = MagicMock(name="app.ui")
+
+        self.mock_spell = MagicMock(name='spell')
+
+        self.download_patcher = patch(
+            'conjureup.controllers.variants.gui.download')
+        self.mock_download = self.download_patcher.start()
+
+        self.get_remote_url_patcher = patch(
+            'conjureup.controllers.variants.gui.get_remote_url')
+        self.mock_get_remote_url = self.get_remote_url_patcher.start()
+
+        self.json_patcher = patch(
+            'conjureup.controllers.variants.gui.json')
+        self.mock_json = self.json_patcher.start()
+
+    def tearDown(self):
+        self.controllers_patcher.stop()
+        self.utils_patcher.stop()
+        self.render_patcher.stop()
+        self.app_patcher.stop()
+        self.download_patcher.stop()
+        self.get_remote_url_patcher.stop()
+        self.json_patcher.stop()
+
+    def test_finish(self):
+        "call finish in variants"
+        self.controller.finish(self.mock_spell)

--- a/test/test_controllers_variants_tui.py
+++ b/test/test_controllers_variants_tui.py
@@ -1,0 +1,82 @@
+#!/usr/bin/env python
+#
+# tests controllers/variants/tui.py
+#
+# Copyright 2016 Canonical, Ltd.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+
+import unittest
+#  from unittest.mock import ANY, call, MagicMock, patch, sentinel
+from unittest.mock import patch, MagicMock
+
+from conjureup.controllers.variants.tui import VariantsController
+
+
+class VariantsTUIRenderTestCase(unittest.TestCase):
+    def setUp(self):
+        self.controller = VariantsController()
+
+        self.utils_patcher = patch(
+            'conjureup.controllers.variants.tui.utils')
+        self.mock_utils = self.utils_patcher.start()
+
+        self.finish_patcher = patch(
+            'conjureup.controllers.variants.tui.VariantsController.finish')
+        self.mock_finish = self.finish_patcher.start()
+        self.app_patcher = patch(
+            'conjureup.controllers.variants.tui.app')
+        mock_app = self.app_patcher.start()
+        mock_app.ui = MagicMock(name="app.ui")
+
+    def tearDown(self):
+        self.utils_patcher.stop()
+        self.finish_patcher.stop()
+        self.app_patcher.stop()
+
+    def test_render(self):
+        "call render"
+        self.controller.render()
+
+
+class VariantsTUIFinishTestCase(unittest.TestCase):
+    def setUp(self):
+        self.controller = VariantsController()
+
+        self.controllers_patcher = patch(
+            'conjureup.controllers.variants.tui.controllers')
+        self.mock_controllers = self.controllers_patcher.start()
+
+        self.utils_patcher = patch(
+            'conjureup.controllers.variants.tui.utils')
+        self.mock_utils = self.utils_patcher.start()
+
+        self.render_patcher = patch(
+            'conjureup.controllers.variants.tui.VariantsController.render')
+        self.mock_render = self.render_patcher.start()
+        self.app_patcher = patch(
+            'conjureup.controllers.variants.tui.app')
+        self.mock_app = self.app_patcher.start()
+        self.mock_app.ui = MagicMock(name="app.ui")
+
+    def tearDown(self):
+        self.controllers_patcher.stop()
+        self.utils_patcher.stop()
+        self.render_patcher.stop()
+        self.app_patcher.stop()
+
+    def test_finish(self):
+        "call finish"
+        self.controller.finish()


### PR DESCRIPTION
Ensure that we're at least calling render and finish on each controller
for gui and tui.

Add a few more involved tests here and there.

This should help us catch more simple load-time errors than the lint catches.

The other goal is that this should make it easier to add new tests when we find new bugs, instead of having to write these scaffolds being such a pain that we don't do it…

Signed-off-by: Michael McCracken <mike.mccracken@canonical.com>