### PR TITLE
bring spells into the project

### DIFF
--- a/share/spell-definitions.yaml
+++ b/share/spell-definitions.yaml
@@ -1,5 +1,0 @@
-# basic keyword definitions
-openstack: |
-  Quickly and reliably build an enterprise-scale cloud run on Ubuntu - the most popular operating system for OpenStack.
-kubernetes: |
-  Kubernetes is an open-source platform for deploying, scaling, and operations of application containers across a cluster of hosts. Kubernetes is portable in that it works with public, private, and hybrid clouds. Extensible through a pluggable infrastructure. Self healing in that it will automatically restart and place containers on healthy nodes if a node ever goes away.

--- a/spells/apache-processing-mapreduce/metadata.yaml
+++ b/spells/apache-processing-mapreduce/metadata.yaml
@@ -1,0 +1,10 @@
+friendly-name: Apache Hadoop MapReduce
+options-whitelist:
+  namenode:
+  - ganglia_metrics
+  resourcemanager:
+  - ganglia_metrics
+  slave:
+  - ganglia_metrics
+version: 1
+bundle-location: https://api.jujucharms.com/charmstore/v5/apache-processing-mapreduce/archive/bundle.yaml

--- a/spells/apache-processing-mapreduce/steps/00_deploy-done
+++ b/spells/apache-processing-mapreduce/steps/00_deploy-done
@@ -1,0 +1,47 @@
+#!/usr/bin/env python3
+
+# Global imports
+import sys
+
+# Conjure-up specific
+sys.path.insert(0, '/usr/share/conjure-up/hooklib')
+import juju  # noqa
+from writer import log, success, fail, error  # noqa
+
+NUM_AGENTS = 13
+
+
+def main():
+    log.debug("Running deploy-done for Apache MapReduce installation.")
+    agent_states = juju.agent_states()
+
+    errored_units = [(unit_name, message) for unit_name, state, message
+                     in agent_states if state == "error"]
+    if len(errored_units) > 0:
+        errs = "\n".join(["{}: {}".format(n, m) for n, m in errored_units])
+        error('Deployment errors:\n{}'.format(errs))
+
+    machines = juju.machine_states()
+    errored_machines = [(name, err) for name, status, err in machines
+                        if status == "error"]
+    if len(errored_machines) > 0:
+        errs = "\n".join(["{}: {}".format(n, m) for n, m in errored_machines])
+        error("Machine creation errors:\n{}".format(errs))
+
+    # 13 total agents for this spell
+    if len(agent_states) < NUM_AGENTS:
+        fail('{} applications are still deploying'.format(
+            NUM_AGENTS - len(agent_states)))
+
+    # Ganglia does not use the normal status-set 'active' so we skip their
+    # workload status when checking all agent states.
+    active_states = [state == 'active' for _, state, _ in agent_states
+                     if state != 'unknown']
+    if len(active_states) > 0 and all(active_states):
+        success('Applications are ready')
+
+    fail('Applications not ready yet')
+
+
+if __name__ == "__main__":
+    main()

--- a/spells/apache-processing-mapreduce/steps/step-01_namenode_smoketest
+++ b/spells/apache-processing-mapreduce/steps/step-01_namenode_smoketest
@@ -1,0 +1,6 @@
+#!/usr/bin/env python3
+
+import utils
+
+if __name__ == "__main__":
+    utils.run_smoke_test('namenode')

--- a/spells/apache-processing-mapreduce/steps/step-01_namenode_smoketest.yaml
+++ b/spells/apache-processing-mapreduce/steps/step-01_namenode_smoketest.yaml
@@ -1,0 +1,4 @@
+title: Hadoop Namenode
+description: |
+  Run a smoke test to validate Apache Hadoop Namenode component.
+viewable: True

--- a/spells/apache-processing-mapreduce/steps/step-02_resourcemanager_test
+++ b/spells/apache-processing-mapreduce/steps/step-02_resourcemanager_test
@@ -1,0 +1,6 @@
+#!/usr/bin/env python3
+
+import utils
+
+if __name__ == "__main__":
+    utils.run_smoke_test('resourcemanager')

--- a/spells/apache-processing-mapreduce/steps/step-02_resourcemanager_test.yaml
+++ b/spells/apache-processing-mapreduce/steps/step-02_resourcemanager_test.yaml
@@ -1,0 +1,4 @@
+title: Hadoop ResourceManager
+description: |
+  Run a smoke test to validate Apache Hadoop ResourceManager component.
+viewable: True

--- a/spells/apache-processing-mapreduce/steps/step-03_ganglia
+++ b/spells/apache-processing-mapreduce/steps/step-03_ganglia
@@ -1,0 +1,22 @@
+#!/usr/bin/env python3
+import sys
+from subprocess import run, DEVNULL, PIPE
+# Conjure-up specific
+sys.path.insert(0, '/usr/share/conjure-up/hooklib')
+import juju  # noqa
+from writer import log, success, fail, error  # noqa
+
+
+if __name__ == "__main__":
+    status = juju.status()
+    applications = status['applications']['ganglia']
+    ganglia_ip = applications['units']['ganglia/0']['public-address']
+    if ganglia_ip:
+        sh = run('juju expose ganglia', shell=True,
+                 stderr=PIPE,
+                 stdout=DEVNULL)
+        if sh.returncode > 0:
+            error("Failed to expose Ganglia UI: {}".format(sh.stderr.decode()))
+        success("Ganglia UI Monitoring is now configured "
+                "and can be viewed at http://{}/ganglia".format(ganglia_ip))
+    fail("Unable to determine Ganglia UI URL")

--- a/spells/apache-processing-mapreduce/steps/step-03_ganglia.yaml
+++ b/spells/apache-processing-mapreduce/steps/step-03_ganglia.yaml
@@ -1,0 +1,4 @@
+title: Ganglia Monitoring
+description: |
+  Configure Ganglia UI for monitoring
+viewable: True

--- a/spells/apache-processing-mapreduce/steps/utils.py
+++ b/spells/apache-processing-mapreduce/steps/utils.py
@@ -1,0 +1,54 @@
+from subprocess import run, PIPE
+import yaml
+import sys
+import time
+
+# Conjure-up specific
+sys.path.insert(0, '/usr/share/conjure-up/hooklib')
+import juju  # noqa
+from writer import log, success, fail, error  # noqa
+
+
+def run_smoke_test(service):
+    is_complete = False
+    sh = run('juju run-action {}/0 smoke-test'.format(service),
+             shell=True,
+             stdout=PIPE)
+    run_action_output = yaml.load(sh.stdout.decode())
+    log.debug("{}: {}".format(sh.args, run_action_output))
+    action_id = run_action_output.get('Action queued with id', None)
+    log.debug("Found action: {}".format(action_id))
+    if not action_id:
+        fail("Could not determine action id for smoke-test")
+
+    while not is_complete:
+        sh = run('juju show-action-output {}'.format(action_id),
+                 shell=True,
+                 stderr=PIPE,
+                 stdout=PIPE)
+        log.debug(sh)
+        try:
+            output = yaml.load(sh.stdout.decode())
+            log.debug(output)
+        except Exception as e:
+            log.debug(e)
+        if output['status'] == 'running' or output['status'] == 'pending':
+            time.sleep(5)
+            continue
+        if output['status'] == 'failed':
+            fail("The smoke-test failed, "
+                 "please have a look at `juju show-action-status`")
+        if output['status'] == 'completed':
+            completed_msg = "{} smoke-test passed".format(service)
+            results = output.get('results', None)
+            if not results:
+                is_complete = True
+                success(completed_msg)
+            if results.get('outcome', None):
+                is_complete = True
+                completed_msg = "{}: (result) {}".format(
+                    completed_msg,
+                    results.get('outcome'))
+                success(completed_msg)
+    fail("There is an unknown issue with running the smoke-test, "
+         "please have a look at `juju show-action-status`")

--- a/spells/elk-stack/metadata.yaml
+++ b/spells/elk-stack/metadata.yaml
@@ -1,0 +1,3 @@
+friendly-name: Elastic Stack
+version: 1
+bundle-location: https://api.jujucharms.com/charmstore/v5/~containers/elk-stack/archive/bundle.yaml

--- a/spells/elk-stack/steps/00_deploy-done
+++ b/spells/elk-stack/steps/00_deploy-done
@@ -1,0 +1,46 @@
+#!/usr/bin/env python3
+
+# Global imports
+import sys
+
+# Conjure-up specific
+sys.path.insert(0, '/usr/share/conjure-up/hooklib')
+import juju  # noqa
+from writer import log, success, fail, error  # noqa
+
+NUM_AGENTS = 4
+
+
+def main():
+    log.debug("Running deploy-done for ELK Stack installation.")
+    agent_states = juju.agent_states()
+
+    errored_units = [(unit_name, message) for unit_name, state, message
+                     in agent_states if state == "error"]
+    if len(errored_units) > 0:
+        errs = "\n".join(["{}: {}".format(n, m) for n, m in errored_units])
+        error('Deployment errors:\n{}'.format(errs))
+
+    machines = juju.machine_states()
+    errored_machines = [(name, err) for name, status, err in machines
+                        if status == "error"]
+    if len(errored_machines) > 0:
+        errs = "\n".join(["{}: {}".format(n, m) for n, m in errored_machines])
+        error("Machine creation errors:\n{}".format(errs))
+
+    if len(agent_states) < NUM_AGENTS:
+        fail('{} applications are still deploying'.format(
+            NUM_AGENTS - len(agent_states)))
+
+    # Ganglia does not use the normal status-set 'active' so we skip their
+    # workload status when checking all agent states.
+    active_states = [state == 'active' for _, state, _ in agent_states
+                     if state != 'unknown']
+    if len(active_states) > 0 and all(active_states):
+        success('Applications are ready')
+
+    fail('Applications not ready yet')
+
+
+if __name__ == "__main__":
+    main()

--- a/spells/elk-stack/steps/step-01_elk_test
+++ b/spells/elk-stack/steps/step-01_elk_test
@@ -1,0 +1,6 @@
+#!/usr/bin/env python3
+
+import utils
+
+if __name__ == "__main__":
+    utils.run_test('logstash')

--- a/spells/elk-stack/steps/step-01_elk_test.yaml
+++ b/spells/elk-stack/steps/step-01_elk_test.yaml
@@ -1,0 +1,4 @@
+title: ELK Test
+description: |
+  Test your Elastic Stack deployment
+viewable: True

--- a/spells/elk-stack/steps/step-03_kibana
+++ b/spells/elk-stack/steps/step-03_kibana
@@ -1,0 +1,22 @@
+#!/usr/bin/env python3
+import sys
+from subprocess import run, DEVNULL, PIPE
+# Conjure-up specific
+sys.path.insert(0, '/usr/share/conjure-up/hooklib')
+import juju  # noqa
+from writer import log, success, fail, error  # noqa
+
+
+if __name__ == "__main__":
+    status = juju.status()
+    applications = status['applications']['kibana']
+    ip = applications['units']['kibana/0']['public-address']
+    if ip:
+        sh = run('juju expose kibana', shell=True,
+                 stderr=PIPE,
+                 stdout=DEVNULL)
+        if sh.returncode > 0:
+            error("Failed to expose Kibana UI: {}".format(sh.stderr.decode()))
+        success("Kibana is now configured "
+                "and can be viewed at http://{}".format(ip))
+    fail("Unable to determine Kibana URL")

--- a/spells/elk-stack/steps/step-03_kibana.yaml
+++ b/spells/elk-stack/steps/step-03_kibana.yaml
@@ -1,0 +1,4 @@
+title: Kibana UI
+description: |
+  Configure Kibana UI
+viewable: True

--- a/spells/elk-stack/steps/utils.py
+++ b/spells/elk-stack/steps/utils.py
@@ -1,0 +1,54 @@
+from subprocess import run, PIPE
+import yaml
+import sys
+import time
+
+# Conjure-up specific
+sys.path.insert(0, '/usr/share/conjure-up/hooklib')
+import juju  # noqa
+from writer import log, success, fail, error  # noqa
+
+
+def run_test(service):
+    is_complete = False
+    sh = run('juju run-action {}/0 generate-noise'.format(service),
+             shell=True,
+             stdout=PIPE)
+    run_action_output = yaml.load(sh.stdout.decode())
+    log.debug("{}: {}".format(sh.args, run_action_output))
+    action_id = run_action_output.get('Action queued with id', None)
+    log.debug("Found action: {}".format(action_id))
+    if not action_id:
+        fail("Could not determine action id for test")
+
+    while not is_complete:
+        sh = run('juju show-action-output {}'.format(action_id),
+                 shell=True,
+                 stderr=PIPE,
+                 stdout=PIPE)
+        log.debug(sh)
+        try:
+            output = yaml.load(sh.stdout.decode())
+            log.debug(output)
+        except Exception as e:
+            log.debug(e)
+        if output['status'] == 'running' or output['status'] == 'pending':
+            time.sleep(5)
+            continue
+        if output['status'] == 'failed':
+            fail("The test failed, "
+                 "please have a look at `juju show-action-status`")
+        if output['status'] == 'completed':
+            completed_msg = "{} test passed".format(service)
+            results = output.get('results', None)
+            if not results:
+                is_complete = True
+                success(completed_msg)
+            if results.get('outcome', None):
+                is_complete = True
+                completed_msg = "{}: (result) {}".format(
+                    completed_msg,
+                    results.get('outcome'))
+                success(completed_msg)
+    fail("There is an unknown issue with running the test, "
+         "please have a look at `juju show-action-status`")

--- a/spells/observable-kubernetes/metadata.yaml
+++ b/spells/observable-kubernetes/metadata.yaml
@@ -1,0 +1,5 @@
+cloud-blacklist:
+- localhost
+friendly-name: Kubernetes
+version: 1
+bundle-location: https://api.jujucharms.com/charmstore/v5/observable-kubernetes/archive/bundle.yaml

--- a/spells/observable-kubernetes/steps/00_deploy-done
+++ b/spells/observable-kubernetes/steps/00_deploy-done
@@ -1,0 +1,28 @@
+#!/usr/bin/env python3
+
+# Global imports
+import sys
+
+# Conjure-up specific
+sys.path.insert(0, '/usr/share/conjure-up/hooklib')
+import juju  # noqa
+from writer import log, success, fail, error  # noqa
+
+
+def main():
+    log.debug("Running deploy-done for Kubernetes installation.")
+    agent_states = juju.agent_states()
+    agent_states_no_es = []
+    for row in agent_states:
+        if 'elasticsearch' not in row[0]:
+            agent_states_no_es.append(row)
+    if any([state == 'error' for _, state, _ in agent_states]):
+        error('Error in one of the applications deployment')
+
+    if all([state == 'active' for _, state, _ in agent_states_no_es]):
+        success('Applications are ready')
+    fail('Applications not ready yet')
+
+
+if __name__ == "__main__":
+    main()

--- a/spells/observable-kubernetes/steps/00_pre-deploy
+++ b/spells/observable-kubernetes/steps/00_pre-deploy
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+. /usr/share/conjure-up/hooklib/common.sh
+
+if [ $JUJU_PROVIDERTYPE = "lxd" ] || [ $JUJU_PROVIDERTYPE = "localhost" ]; then
+    profilename=$(juju switch | cut -d: -f2)
+    debug "processing $profilename"
+    sed "s/##MODEL##/$profilename/" $SCRIPTPATH/lxd-profile.yaml | lxc profile edit "juju-$profilename"
+
+    RET=$?
+    if [ $RET -ne 0 ]; then
+        exposeResult "Failed to update lxd profile $profilename" $RET "false"
+    else
+        exposeResult "Complete" 0 "true"
+    fi
+
+fi
+
+exposeResult "Finished pre deploy tasks..." 0 "true"

--- a/spells/observable-kubernetes/steps/lxd-profile.yaml
+++ b/spells/observable-kubernetes/steps/lxd-profile.yaml
@@ -1,0 +1,19 @@
+name: juju-##MODEL##
+config:
+  linux.kernel_modules: overlay, nf_nat
+  security.nesting: "true"
+  security.privileged: "true"
+description: Profile supporting docker in containers
+devices:
+  aadisable:
+    path: /sys/module/apparmor/parameters/enabled
+    source: /dev/null
+    type: disk
+  fuse:
+    path: /dev/fuse
+    type: unix-char
+  eth0:
+    name: eth0
+    nictype: bridged
+    parent: lxdbr0
+    type: nic

--- a/spells/observable-kubernetes/steps/step-01_get-kubectl
+++ b/spells/observable-kubernetes/steps/step-01_get-kubectl
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+. /usr/share/conjure-up/hooklib/common.sh
+
+KUBECTL_PATH=$HOME/conjure-up/kubernetes
+mkdir -p $KUBECTL_PATH || true
+
+# TODO: Convert to an actionable item
+leaderUnit=$(getLeader kubernetes)
+debug "Found leader: $leaderUnit"
+juju scp $leaderUnit:kubectl_package.tar.gz $KUBECTL_PATH/.
+cd $KUBECTL_PATH && tar zxf kubectl_package.tar.gz
+
+exposeResult "Cluster can now be accessed with $KUBECTL_PATH/kubectl application" 0 "true"

--- a/spells/observable-kubernetes/steps/step-01_get-kubectl.yaml
+++ b/spells/observable-kubernetes/steps/step-01_get-kubectl.yaml
@@ -1,0 +1,3 @@
+title: Kubernetes Cluster Controller
+description: Get kubectl for controlling a Kubernetes Cluster
+viewable: True

--- a/spells/openstack-novalxd/bundle.yaml
+++ b/spells/openstack-novalxd/bundle.yaml
@@ -1,0 +1,135 @@
+relations:
+- - nova-compute:amqp
+  - rabbitmq-server:amqp
+- - neutron-gateway:amqp
+  - rabbitmq-server:amqp
+- - keystone:shared-db
+  - mysql:shared-db
+- - nova-cloud-controller:identity-service
+  - keystone:identity-service
+- - glance:identity-service
+  - keystone:identity-service
+- - neutron-api:identity-service
+  - keystone:identity-service
+- - neutron-openvswitch:neutron-plugin-api
+  - neutron-api:neutron-plugin-api
+- - neutron-api:shared-db
+  - mysql:shared-db
+- - neutron-api:amqp
+  - rabbitmq-server:amqp
+- - neutron-gateway:neutron-plugin-api
+  - neutron-api:neutron-plugin-api
+- - glance:shared-db
+  - mysql:shared-db
+- - glance:amqp
+  - rabbitmq-server:amqp
+- - nova-cloud-controller:image-service
+  - glance:image-service
+- - nova-compute:image-service
+  - glance:image-service
+- - nova-cloud-controller:cloud-compute
+  - nova-compute:cloud-compute
+- - nova-cloud-controller:amqp
+  - rabbitmq-server:amqp
+- - nova-cloud-controller:quantum-network-service
+  - neutron-gateway:quantum-network-service
+- - nova-compute:neutron-plugin
+  - neutron-openvswitch:neutron-plugin
+- - neutron-openvswitch:amqp
+  - rabbitmq-server:amqp
+- - openstack-dashboard:identity-service
+  - keystone:identity-service
+- - nova-cloud-controller:shared-db
+  - mysql:shared-db
+- - nova-cloud-controller:neutron-api
+  - neutron-api:neutron-api
+- - ceph-mon:client
+  - nova-compute:ceph
+- - ceph-mon:client
+  - glance:ceph
+- - ceph-radosgw:mon
+  - ceph-mon:radosgw
+- - ceph-osd:mon
+  - ceph-mon:osd
+- - ceph-radosgw:identity-service
+  - keystone:identity-service
+- - nova-compute:lxd
+  - lxd:lxd
+series: xenial
+services:
+  ceph-mon:
+    charm: cs:xenial/ceph-mon
+    num_units: 3
+    options:
+      fsid: 5a791d94-980b-11e4-b6f6-3c970e8b1cf7
+      monitor-secret: AQAi5a9UeJXUExAA+By9u+GPhl8/XiUQ4nwI3A==
+  ceph-osd:
+    charm: cs:xenial/ceph-osd
+    num_units: 3
+    options:
+      osd-devices: /srv/osd
+      use-direct-io: False
+  ceph-radosgw:
+    charm: cs:xenial/ceph-radosgw
+    num_units: 1
+    options:
+      use-embedded-webserver: true
+  glance:
+    charm: cs:xenial/glance
+    num_units: 1
+  keystone:
+    charm: cs:xenial/keystone
+    num_units: 1
+    options:
+      admin-password: openstack
+  mysql:
+    charm: cs:xenial/percona-cluster
+    num_units: 1
+    options:
+      max-connections: 20000
+      dataset-size: 256M
+  neutron-api:
+    charm: cs:xenial/neutron-api
+    num_units: 1
+    options:
+      neutron-security-groups: true
+      overlay-network-type: "gre vxlan"
+  neutron-gateway:
+    charm: cs:xenial/neutron-gateway
+    num_units: 1
+    options:
+      ext-port: eth1
+  neutron-openvswitch:
+    charm: cs:xenial/neutron-openvswitch
+    num_units: 0
+  nova-cloud-controller:
+    charm: cs:xenial/nova-cloud-controller
+    num_units: 1
+    options:
+      network-manager: Neutron
+  nova-compute:
+    charm: cs:xenial/nova-compute
+    num_units: 1
+    options:
+      enable-live-migration: False
+      enable-resize: False
+      virt-type: lxd
+  ntp:
+    charm: cs:xenial/ntp
+    num_units: 0
+  lxd:
+    charm: cs:xenial/lxd
+    options:
+      block-devices: None
+  openstack-dashboard:
+    charm: cs:xenial/openstack-dashboard
+    num_units: 1
+  rabbitmq-server:
+    charm: cs:xenial/rabbitmq-server
+    num_units: 1
+tags:
+  - conjure-up-openstack
+description: |
+  This spell summons an OpenStack Cloud (Mitaka release), configured to use LXD (the lightweight container hypervisor), on Ubuntu 16.04, providing Dashboard, Compute, Network, Object Storage, Identity and Image services.
+
+  This can be deployed on a Single machine for quick Proof-of-Concepts and local development of OpenStack components and services.

--- a/spells/openstack-novalxd/metadata.yaml
+++ b/spells/openstack-novalxd/metadata.yaml
@@ -1,0 +1,16 @@
+cloud-whitelist:
+- localhost
+friendly-name: OpenStack with NovaLXD
+options-whitelist:
+  keystone:
+  - admin-password
+  lxd:
+  - block-devices
+  mysql:
+  - max-connections
+  neutron-gateway:
+  - ext-port
+  nova-compute:
+  - virt-type
+packages:
+- openstack

--- a/spells/openstack-novalxd/steps/00_deploy-done
+++ b/spells/openstack-novalxd/steps/00_deploy-done
@@ -1,0 +1,39 @@
+#!/usr/bin/env python3
+
+# Global imports
+import sys
+
+# Conjure-up specific
+sys.path.insert(0, '/usr/share/conjure-up/hooklib')
+import juju  # noqa
+from writer import log, success, fail, error  # noqa
+
+
+def main():
+    log.debug("Running deploy-done for OpenStack installation.")
+    agent_states = juju.agent_states()
+
+    errored_units = [(unit_name, message) for unit_name, state, message
+                     in agent_states if state == "error"]
+    if len(errored_units) > 0:
+        errs = "\n".join(["{}: {}".format(n, m) for n, m in errored_units])
+        error('Deployment errors:\n{}'.format(errs))
+
+    machines = juju.machine_states()
+    errored_machines = [(name, err) for name, status, err in machines
+                        if status == "error"]
+    if len(errored_machines) > 0:
+        errs = "\n".join(["{}: {}".format(n, m) for n, m in errored_machines])
+        error("Machine creation errors:\n{}".format(errs))
+
+    if len(agent_states) == 0:
+        fail('Applications are still deploying')
+
+    if all([state == 'active' for _, state, _ in agent_states]):
+        success('Applications are ready')
+
+    fail('Applications not ready yet')
+
+
+if __name__ == "__main__":
+    main()

--- a/spells/openstack-novalxd/steps/00_pre-deploy
+++ b/spells/openstack-novalxd/steps/00_pre-deploy
@@ -1,0 +1,53 @@
+#!/usr/bin/env python3
+
+import sys
+import os
+import time
+from subprocess import run, PIPE, CalledProcessError
+
+# Conjure-up specific
+sys.path.insert(0, '/usr/share/conjure-up/hooklib')
+import juju  # noqa
+from writer import log, success, fail, error  # noqa
+
+SCRIPTPATH = os.path.dirname(os.path.abspath(__file__))
+
+
+def main():
+    provider_type = os.environ.get('JUJU_PROVIDERTYPE', None)
+
+    if provider_type == "lxd":
+        log.debug("Running pre-deploy for OpenStack")
+        # Give LXD enough time to learn about the profile
+        time.sleep(5)
+        try:
+            profilename = run('juju switch | cut -d: -f2',
+                              shell=True,
+                              stdout=PIPE,
+                              stderr=PIPE)
+            profilename = profilename.stdout.decode().strip()
+        except CalledProcessError as e:
+            error(e)
+
+        log.debug("Processing lxd profile: {}".format(profilename))
+
+        try:
+            profile_edit = run(
+                'sed "s/##MODEL##/{profile}/" '
+                '{scriptpath}/lxd-profile.yaml | '
+                'lxc profile edit "juju-{profile}"'.format(
+                    profile=profilename,
+                    scriptpath=SCRIPTPATH),
+                shell=True,
+                stdout=PIPE,
+                stderr=PIPE)
+        except CalledProcessError as e:
+            error(e)
+
+        if profile_edit.returncode > 0:
+            error(profile_edit.stderr)
+
+    success("Successful pre-deploy.")
+
+if __name__ == "__main__":
+    main()

--- a/spells/openstack-novalxd/steps/lxd-profile.yaml
+++ b/spells/openstack-novalxd/steps/lxd-profile.yaml
@@ -1,0 +1,28 @@
+name: juju-##MODEL##
+config:
+  boot.autostart: "true"
+  security.nesting: "true"
+  security.privileged: "true"
+  linux.kernel_modules: openvswitch,nbd,ip_tables,ip6_tables
+devices:
+  eth0:
+    mtu: "9000"
+    name: eth0
+    nictype: bridged
+    parent: lxdbr0
+    type: nic
+  eth1:
+    mtu: "9000"
+    name: eth1
+    nictype: bridged
+    parent: openstack0
+    type: nic
+  mem:
+    path: /dev/mem
+    type: unix-char
+  root:
+    path: /
+    type: disk
+  tun:
+    path: /dev/net/tun
+    type: unix-char

--- a/spells/openstack-novalxd/steps/novarc
+++ b/spells/openstack-novalxd/steps/novarc
@@ -1,0 +1,5 @@
+export OS_USERNAME=admin
+export OS_PASSWORD=openstack
+export OS_TENANT_NAME=admin
+export OS_REGION_NAME=RegionOne
+export OS_AUTH_URL=${OS_AUTH_PROTOCOL:-http}://`juju run --unit  keystone/0 "unit-get private-address"`:5000/v2.0

--- a/spells/openstack-novalxd/steps/step-02_glance
+++ b/spells/openstack-novalxd/steps/step-02_glance
@@ -1,0 +1,43 @@
+#!/bin/bash
+
+. /usr/share/conjure-up/hooklib/common.sh
+
+if [[ $JUJU_PROVIDERTYPE =~ "lxd" ]]; then
+    imagetype=root.tar.xz
+    diskformat=raw
+    imagesuffix="-lxd"
+else
+    imagetype=disk1.img
+    diskformat=root-tar
+    imagesuffix=""
+fi
+
+mkdir -p $HOME/glance-images || true
+if [ ! -f $HOME/glance-images/xenial-server-cloudimg-amd64-$imagetype ]; then
+    debug "Downloading xenial image..."
+    wget -qO ~/glance-images/xenial-server-cloudimg-amd64-$imagetype https://cloud-images.ubuntu.com/xenial/current/xenial-server-cloudimg-amd64-$imagetype
+fi
+if [ ! -f $HOME/glance-images/trusty-server-cloudimg-amd64-$imagetype ]; then
+    debug "Downloading trusty image..."
+    wget -qO ~/glance-images/trusty-server-cloudimg-amd64-$imagetype https://cloud-images.ubuntu.com/trusty/current/trusty-server-cloudimg-amd64-$imagetype
+fi
+
+. $SCRIPTPATH/novarc
+if ! glance image-list --property-filter name="trusty$imagesuffix" | grep -q "trusty$imagesuffix" ; then
+    debug "Importing trusty$imagesuffix"
+    glance image-create --name="trusty$imagesuffix" \
+           --container-format=bare \
+           --disk-format=$diskformat \
+           --property architecture="x86_64" \
+           --visibility=public --file=$HOME/glance-images/trusty-server-cloudimg-amd64-$imagetype > /dev/null 2>&1
+fi
+if ! glance image-list --property-filter name="xenial$imagesuffix" | grep -q "xenial$imagesuffix" ; then
+    debug "Importing xenial$imagesuffix"
+    glance image-create --name="xenial$imagesuffix" \
+           --container-format=bare \
+           --disk-format=$diskformat \
+           --property architecture="x86_64" \
+           --visibility=public --file=$HOME/glance-images/xenial-server-cloudimg-amd64-$imagetype > /dev/null 2>&1
+fi
+
+exposeResult "Glance images are imported and can be accessible via Horizon." 0 "true"

--- a/spells/openstack-novalxd/steps/step-02_glance.yaml
+++ b/spells/openstack-novalxd/steps/step-02_glance.yaml
@@ -1,0 +1,4 @@
+title: Glance
+description: |
+    Import glance images that will be readily available to start compute instances.
+viewable: True

--- a/spells/openstack-novalxd/steps/step-03_keypair
+++ b/spells/openstack-novalxd/steps/step-03_keypair
@@ -1,0 +1,68 @@
+#!/usr/bin/env python3
+
+# Global imports
+import sys
+import os
+import os.path as path
+from subprocess import run, DEVNULL, PIPE
+
+# Conjure-up specific
+sys.path.insert(0, '/usr/share/conjure-up/hooklib')
+import juju  # noqa
+from writer import log, success, fail, error  # noqa
+import utils  # noqa
+
+SCRIPTPATH = path.dirname(path.abspath(__file__))
+NOVARC = path.join(SCRIPTPATH, 'novarc')
+
+
+def ssh_genkey(ssh_privkey):
+    """ Generates sshkey
+    """
+    cmd = "ssh-keygen -N '' -f {0}".format(ssh_privkey)
+    out = run(cmd, shell=True, stdout=DEVNULL, stderr=PIPE)
+    if out.returncode != 0:
+            fail("Unable to generate key: {0}".format(out.stderr.decode()))
+
+
+def main():
+    credentials = utils.parse_openstack_creds(NOVARC)
+
+    ssh_pubkey = path.expanduser(os.environ.get(
+        'SSHPUBLICKEY',
+        path.expanduser('~/.ssh/id_rsa.pub')))
+    ssh_privkey = path.join(path.expanduser('~/.ssh'),
+                            path.splitext(ssh_pubkey)[0])
+
+    if not path.isfile(ssh_privkey):
+        log.debug("No ssh private key found, generating our own.")
+        ssh_genkey(ssh_privkey)
+
+    log.debug("Checking for ssh public key: {}".format(ssh_pubkey))
+    if path.isfile(ssh_pubkey):
+        cmd = ("openstack keypair show ubuntu-keypair")
+        ret = run(cmd, shell=True,
+                  stdout=DEVNULL,
+                  stderr=PIPE,
+                  env=credentials)
+        if ret.returncode == 0:
+            success("SSH keypair already available to "
+                    "you in your OpenStack cloud.")
+
+        cmd = ("openstack keypair create --public-key {} "
+               "ubuntu-keypair".format(ssh_pubkey))
+        ret = run(cmd, shell=True,
+                  stdout=DEVNULL,
+                  stderr=PIPE,
+                  env=credentials)
+        if ret.returncode > 0:
+            fail("Unable to add public ssh key, maybe "
+                 "ssh-keygen needs to be run")
+        success("SSH Keypair complete")
+
+    fail("Could not find any ssh keys to import, please run "
+         "ssh-keygen in another terminal before re-executing this step.")
+
+
+if __name__ == "__main__":
+    main()

--- a/spells/openstack-novalxd/steps/step-03_keypair.yaml
+++ b/spells/openstack-novalxd/steps/step-03_keypair.yaml
@@ -1,0 +1,10 @@
+title: SSH
+description: |
+  Import SSH keypairs into OpenStack. This allows you to access the newly deployed instances via SSH with your current user. If you are not sure about the location of a ssh key leave it as is and we will create one automatically.
+viewable: True
+required: True
+additional-input:
+  - label: SSH public key path
+    key: SSHPUBLICKEY
+    type: text
+    default: ~/.ssh/id_rsa.pub

--- a/spells/openstack-novalxd/steps/step-04_neutron
+++ b/spells/openstack-novalxd/steps/step-04_neutron
@@ -1,0 +1,78 @@
+#!/bin/bash
+
+. /usr/share/conjure-up/hooklib/common.sh
+
+fail_cleanly() {
+    exposeResult "$1" 1 "false"
+}
+
+# Get host namserver
+get_host_ns() {
+    perl -lne 's/^nameserver\s+// or next; s/\s.*//; print && exit' /etc/resolv.conf
+}
+
+. $SCRIPTPATH/novarc
+if ! neutron net-show ext-net > /dev/null 2>&1; then
+    debug "adding ext-net"
+    if ! neutron net-create --router:external ext-net > /dev/null 2>&1; then
+        debug "could not net-create ext-net"
+    fi
+fi
+
+if ! neutron subnet-show ext-subnet > /dev/null 2>&1; then
+    debug "adding ext-subnet"
+    if ! neutron subnet-create --name ext-subnet ext-net 10.99.0.0/24 \
+             --gateway 10.99.0.1 --disable-dhcp \
+             --allocation-pool start=10.99.0.3,end=10.99.0.254 > /dev/null 2>&1; then
+        debug "could not subnet-create ext-subnet"
+    fi
+fi
+
+if ! neutron net-show ubuntu-net > /dev/null 2>&1; then
+    debug "adding ubuntu-net"
+    if ! neutron net-create ubuntu-net --shared > /dev/null 2>&1; then
+        debug "could not net-create"
+    fi
+fi
+
+if ! neutron subnet-show ubuntu-subnet > /dev/null 2>&1; then
+    debug "adding ubuntu-subnet"
+    if ! neutron subnet-create --name ubuntu-subnet \
+            --gateway 10.101.0.1 \
+            --dns-nameserver $(get_host_ns) ubuntu-net 10.101.0.0/24 > /dev/null 2>&1; then
+        debug "could not add ubuntusubnet"
+    fi
+fi
+
+if ! neutron router-show ubuntu-router > /dev/null 2>&1; then
+    debug "adding ubuntu-router"
+    if ! neutron router-create ubuntu-router > /dev/null 2>&1; then
+        debug "couldnt create ubuntu-router"
+    fi
+fi
+
+if ! neutron router-interface-add ubuntu-router ubuntu-subnet > /dev/null 2>&1; then
+    debug "Could not add router-interface"
+fi
+
+debug "setting router gateway"
+if ! neutron router-gateway-set ubuntu-router ext-net > /dev/null 2>&1; then
+    debug "Could not set router gateway"
+fi
+
+# create pool of at least 5 floating ips
+debug "creating floating ips"
+existingips=$(neutron floatingip-list -f csv | tail -n +2| wc -l)
+to_create=$((10 - existingips))
+i=0
+while [ $i -ne $to_create ]; do
+    neutron floatingip-create ext-net > /dev/null 2>&1
+    i=$((i + 1))
+done
+
+# configure security groups
+debug "setting security roles"
+neutron security-group-rule-create --direction ingress --ethertype IPv4 --protocol icmp --remote-ip-prefix 0.0.0.0/0 default > /dev/null 2>&1 || true
+neutron security-group-rule-create --direction ingress --ethertype IPv4 --protocol tcp --port-range-min 22 --port-range-max 22 --remote-ip-prefix 0.0.0.0/0 default > /dev/null 2>&1 || true
+
+exposeResult "Neutron networking is now configured and is available to you during instance creation." 0 "true"

--- a/spells/openstack-novalxd/steps/step-04_neutron.yaml
+++ b/spells/openstack-novalxd/steps/step-04_neutron.yaml
@@ -1,0 +1,4 @@
+title: Neutron
+description: |
+  Configure Neutron networking. This step will setup a usable OpenStack network so that your instances may communicate with the outside world.
+viewable: True

--- a/spells/openstack-novalxd/steps/step-05_horizon
+++ b/spells/openstack-novalxd/steps/step-05_horizon
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+. /usr/share/conjure-up/hooklib/common.sh
+
+dashboard_address() {
+    unitAddress openstack-dashboard 0
+}
+
+exposeResult "Login to Horizon: http://$(dashboard_address)/horizon l: admin p: openstack" 0 "true"

--- a/spells/openstack-novalxd/steps/step-05_horizon.yaml
+++ b/spells/openstack-novalxd/steps/step-05_horizon.yaml
@@ -1,0 +1,4 @@
+title: Horizon
+description: |
+  Configure Horizon and generate a URL and credentials to access the dashboard with.
+viewable: True

--- a/spells/openstack-novalxd/steps/utils.py
+++ b/spells/openstack-novalxd/steps/utils.py
@@ -1,0 +1,39 @@
+from subprocess import run, PIPE
+from writer import log  # noqa
+
+
+def slurp(path):
+    """ Reads data from path
+    :param str path: path of file
+    """
+    try:
+        with open(path) as f:
+            return f.read().strip()
+    except IOError:
+        raise IOError
+
+
+def parse_openstack_creds(creds_file):
+    """ Parses openstack-{admin,ubuntu}-rc for openstack
+    credentials
+
+    Arguments:
+    creds_file: path to openstack novarc file
+    """
+
+    def sanitize_quotes(key):
+        if key[0] == key[-1] and key[0] in ("'", '"'):
+            return key[1:-1]
+        else:
+            return key
+
+    cmd = ['bash', '-c', 'source {} && env'.format(creds_file)]
+    ret = run(cmd, stdout=PIPE)
+    cred_map = {}
+    for k in ret.stdout.decode().split("\n"):
+        try:
+            first, rest = k.split("=")
+            cred_map[first] = sanitize_quotes(rest)
+        except ValueError:
+            log.debug("Skipping {}".format(k))
+    return cred_map

--- a/spells/realtime-syslog-analytics/metadata.yaml
+++ b/spells/realtime-syslog-analytics/metadata.yaml
@@ -1,0 +1,6 @@
+friendly-name: Realtime Syslog Analytics
+options-whitelist:
+  spark:
+  - spark_execution_mode
+version: 1
+bundle-location: https://api.jujucharms.com/charmstore/v5/realtime-syslog-analytics/archive/bundle.yaml

--- a/spells/realtime-syslog-analytics/steps/00_deploy-done
+++ b/spells/realtime-syslog-analytics/steps/00_deploy-done
@@ -1,0 +1,48 @@
+#!/usr/bin/env python3
+
+# Global imports
+import sys
+
+# Conjure-up specific
+sys.path.insert(0, '/usr/share/conjure-up/hooklib')
+import juju  # noqa
+from writer import log, success, fail, error  # noqa
+
+NUM_AGENTS = 8
+
+
+def main():
+    log.debug("Running deploy-done for Realtime "
+              "syslog analytics installation.")
+    agent_states = juju.agent_states()
+
+    errored_units = [(unit_name, message) for unit_name, state, message
+                     in agent_states if state == "error"]
+    if len(errored_units) > 0:
+        errs = "\n".join(["{}: {}".format(n, m) for n, m in errored_units])
+        error('Deployment errors:\n{}'.format(errs))
+
+    machines = juju.machine_states()
+    errored_machines = [(name, err) for name, status, err in machines
+                        if status == "error"]
+    if len(errored_machines) > 0:
+        errs = "\n".join(["{}: {}".format(n, m) for n, m in errored_machines])
+        error("Machine creation errors:\n{}".format(errs))
+
+    # 13 total agents for this spell
+    if len(agent_states) < NUM_AGENTS:
+        fail('{} applications are still deploying'.format(
+            NUM_AGENTS - len(agent_states)))
+
+    # Ganglia does not use the normal status-set 'active' so we skip their
+    # workload status when checking all agent states.
+    active_states = [state == 'active' for _, state, _ in agent_states
+                     if state != 'unknown']
+    if len(active_states) > 0 and all(active_states):
+        success('Applications are ready')
+
+    fail('Applications not ready yet')
+
+
+if __name__ == "__main__":
+    main()

--- a/spells/realtime-syslog-analytics/steps/step-01_namenode_smoketest
+++ b/spells/realtime-syslog-analytics/steps/step-01_namenode_smoketest
@@ -1,0 +1,6 @@
+#!/usr/bin/env python3
+
+import utils
+
+if __name__ == "__main__":
+    utils.run_smoke_test('namenode')

--- a/spells/realtime-syslog-analytics/steps/step-01_namenode_smoketest.yaml
+++ b/spells/realtime-syslog-analytics/steps/step-01_namenode_smoketest.yaml
@@ -1,0 +1,4 @@
+title: Hadoop Namenode Test
+description: |
+  Run a smoke test to validate Apache Hadoop Namenode component.
+viewable: True

--- a/spells/realtime-syslog-analytics/steps/step-02_resourcemanager_test
+++ b/spells/realtime-syslog-analytics/steps/step-02_resourcemanager_test
@@ -1,0 +1,6 @@
+#!/usr/bin/env python3
+
+import utils
+
+if __name__ == "__main__":
+    utils.run_smoke_test('resourcemanager')

--- a/spells/realtime-syslog-analytics/steps/step-02_resourcemanager_test.yaml
+++ b/spells/realtime-syslog-analytics/steps/step-02_resourcemanager_test.yaml
@@ -1,0 +1,4 @@
+title: Hadoop ResourceManager Test
+description: |
+  Run a smoke test to validate Apache Hadoop ResourceManager component.
+viewable: True

--- a/spells/realtime-syslog-analytics/steps/step-03_spark_test
+++ b/spells/realtime-syslog-analytics/steps/step-03_spark_test
@@ -1,0 +1,6 @@
+#!/usr/bin/env python3
+
+import utils
+
+if __name__ == "__main__":
+    utils.run_smoke_test('spark')

--- a/spells/realtime-syslog-analytics/steps/step-03_spark_test.yaml
+++ b/spells/realtime-syslog-analytics/steps/step-03_spark_test.yaml
@@ -1,0 +1,4 @@
+title: Apache Spark Test
+description: |
+  Run a smoke test to validate Apache Spark component.
+viewable: True

--- a/spells/realtime-syslog-analytics/steps/step-04_zeppelin_test
+++ b/spells/realtime-syslog-analytics/steps/step-04_zeppelin_test
@@ -1,0 +1,6 @@
+#!/usr/bin/env python3
+
+import utils
+
+if __name__ == "__main__":
+    utils.run_smoke_test('zeppelin')

--- a/spells/realtime-syslog-analytics/steps/step-04_zeppelin_test.yaml
+++ b/spells/realtime-syslog-analytics/steps/step-04_zeppelin_test.yaml
@@ -1,0 +1,4 @@
+title: Apache Zeppelin Test
+description: |
+  Run a smoke test to validate Apache Zeppelin component.
+viewable: True

--- a/spells/realtime-syslog-analytics/steps/step-05_zeppelin
+++ b/spells/realtime-syslog-analytics/steps/step-05_zeppelin
@@ -1,0 +1,23 @@
+#!/usr/bin/env python3
+import sys
+from subprocess import run, DEVNULL, PIPE
+# Conjure-up specific
+sys.path.insert(0, '/usr/share/conjure-up/hooklib')
+import juju  # noqa
+from writer import log, success, fail, error  # noqa
+
+
+if __name__ == "__main__":
+    status = juju.status()
+    applications = status['applications']['spark']
+    zeppelin_ip = applications['units']['spark/0']['public-address']
+    if zeppelin_ip:
+        sh = run('juju expose zeppelin', shell=True,
+                 stderr=PIPE,
+                 stdout=DEVNULL)
+        if sh.returncode > 0:
+            error("Failed to expose Zeppelin UI: {}".format(
+                sh.stderr.decode()))
+        success("Zeppelin UI is now configured "
+                "and can be viewed at http://{}:9090".format(zeppelin_ip))
+    fail("Unable to determine Zeppelin UI URL")

--- a/spells/realtime-syslog-analytics/steps/step-05_zeppelin.yaml
+++ b/spells/realtime-syslog-analytics/steps/step-05_zeppelin.yaml
@@ -1,0 +1,4 @@
+title: Zeppelin Web UI
+description: |
+  Configure Zeppelin UI for interactive data analytics
+viewable: True

--- a/spells/realtime-syslog-analytics/steps/utils.py
+++ b/spells/realtime-syslog-analytics/steps/utils.py
@@ -1,0 +1,54 @@
+from subprocess import run, PIPE
+import yaml
+import sys
+import time
+
+# Conjure-up specific
+sys.path.insert(0, '/usr/share/conjure-up/hooklib')
+import juju  # noqa
+from writer import log, success, fail, error  # noqa
+
+
+def run_smoke_test(service):
+    is_complete = False
+    sh = run('juju run-action {}/0 smoke-test'.format(service),
+             shell=True,
+             stdout=PIPE)
+    run_action_output = yaml.load(sh.stdout.decode())
+    log.debug("{}: {}".format(sh.args, run_action_output))
+    action_id = run_action_output.get('Action queued with id', None)
+    log.debug("Found action: {}".format(action_id))
+    if not action_id:
+        fail("Could not determine action id for smoke-test")
+
+    while not is_complete:
+        sh = run('juju show-action-output {}'.format(action_id),
+                 shell=True,
+                 stderr=PIPE,
+                 stdout=PIPE)
+        log.debug(sh)
+        try:
+            output = yaml.load(sh.stdout.decode())
+            log.debug(output)
+        except Exception as e:
+            log.debug(e)
+        if output['status'] == 'running' or output['status'] == 'pending':
+            time.sleep(5)
+            continue
+        if output['status'] == 'failed':
+            fail("The smoke-test failed, "
+                 "please have a look at `juju show-action-status`")
+        if output['status'] == 'completed':
+            completed_msg = "{} smoke-test passed".format(service)
+            results = output.get('results', None)
+            if not results:
+                is_complete = True
+                success(completed_msg)
+            if results.get('outcome', None):
+                is_complete = True
+                completed_msg = "{}: (result) {}".format(
+                    completed_msg,
+                    results.get('outcome'))
+                success(completed_msg)
+    fail("There is an unknown issue with running the smoke-test, "
+         "please have a look at `juju show-action-status`")

--- a/spells/spells-index.yaml
+++ b/spells/spells-index.yaml
@@ -15,7 +15,7 @@ bigdata:
     - realtime-syslog-analytics
   description: |
     Distributed computing infrastructure for processing vast amounts of data in parallel on large clusters of machines.
-"business intelligence":
+analytics:
   spells:
     - elk-stack
   description: |

--- a/spells/spells-index.yaml
+++ b/spells/spells-index.yaml
@@ -1,0 +1,22 @@
+# spell keyword mapping
+openstack:
+  spells:
+    - openstack-novalxd
+  description: |
+    Quickly and reliably build an enterprise-scale cloud run on Ubuntu - the most popular operating system for OpenStack.
+kubernetes:
+  spells:
+    - observable-kubernetes
+  description: |
+    Kubernetes is an open-source platform for deploying, scaling, and operations of application containers across a cluster of hosts. Kubernetes is portable in that it works with public, private, and hybrid clouds. Extensible through a pluggable infrastructure. Self healing in that it will automatically restart and place containers on healthy nodes if a node ever goes away.
+bigdata:
+  spells:
+    - apache-processing-mapreduce
+    - realtime-syslog-analytics
+  description: |
+    Distributed computing infrastructure for processing vast amounts of data in parallel on large clusters of machines.
+"business intelligence":
+  spells:
+    - elk-stack
+  description: |
+    The Elastic Stack — that is Elasticsearch, Logstash, Kibana — are open source projects that help you take data from any source, any format and search, analyze, and visualize it in real time.


### PR DESCRIPTION
With the upcoming release of snaps we are going to start keeping the
spells inside the project dir so that they are included with each snap
release. This makes it easier to distribute and with snappy's auto
upgrade feature and versioned data directories we can easily keep users
in sync with the latest 'curated' spells.

Signed-off-by: Adam Stokes <adam.stokes@ubuntu.com>