### PR TITLE
dont check for root

### DIFF
--- a/conjureup/app.py
+++ b/conjureup/app.py
@@ -138,12 +138,6 @@ def main():
 
     app.fetcher = fetcher(opts.spell)
 
-    if os.geteuid() == 0:
-        utils.info("")
-        utils.info("This should _not_ be run as root or with sudo.")
-        utils.info("")
-        sys.exit(1)
-
     # Application Config
     app.argv = opts
     app.log = setup_logging("conjure-up/{}".format(spell),


### PR DESCRIPTION
This doesn't really apply any longer now that we are building conjure-up
as a snap.

Signed-off-by: Adam Stokes <adam.stokes@ubuntu.com>