### PR TITLE
Several related initial view / snappy / charmstore search removal changes

### DIFF
--- a/.ackrc
+++ b/.ackrc
@@ -5,3 +5,5 @@
 --ignore-dir=bundleplacer
 --ignore-dir=macumba
 --ignore-dir=conjure-dev
+--ignore-dir=snapcraft/stage
+--ignore-dir=snapcraft/parts

--- a/conjureup/app.py
+++ b/conjureup/app.py
@@ -3,6 +3,7 @@
 
 from conjureup import __version__ as VERSION
 from conjureup import async
+from conjureup import consts
 from conjureup import controllers
 from conjureup import juju
 from conjureup import utils
@@ -18,7 +19,6 @@ from ubuntui.ev import EventLoop
 from ubuntui.palette import STYLES
 
 import argparse
-import json
 import os
 import os.path as path
 import sys
@@ -28,8 +28,12 @@ import yaml
 
 def parse_options(argv):
     parser = argparse.ArgumentParser(prog="conjure-up")
-    parser.add_argument('spell', help="Specify the solution to "
-                        "conjure, e.g. openstack")
+    parser.add_argument('spell', nargs='?',
+                        default=consts.UNSPECIFIED_SPELL,
+                        help="""The name ('openstack-nclxd') or location
+                        ('githubusername/spellrepo') of a conjure-up
+                        spell, or a keyword matching multiple spells
+                        e.g. openstack""")
     parser.add_argument('-d', '--debug', action='store_true',
                         dest='debug',
                         help='Enable debug logging.')
@@ -39,13 +43,12 @@ def parse_options(argv):
     parser.add_argument('-c', dest='global_config_file',
                         help='Location of conjure-up.conf',
                         default='/etc/conjure-up.conf')
-    parser.add_argument(
-        '--spell-definitions', dest='spell_definitions',
-        help='Location of spell definitions',
-        default='/usr/share/conjure-up/spell-definitions.yaml')
-    parser.add_argument('--spell-dir', dest='spell_dir',
-                        help='Location of spells directory',
-                        default='/usr/share/conjure-up')
+    parser.add_argument('--cache_dir', dest='cache_dir',
+                        help='Download directory for spells',
+                        default=os.path.expanduser("~/.cache/conjure-up"))
+    parser.add_argument('--spells-dir', dest='spells_dir',
+                        help='Location of readonly packaged spells directory',
+                        default='/usr/share/conjure-up/spells')
     parser.add_argument('--apt-proxy', dest='apt_http_proxy',
                         help='Specify APT proxy')
     parser.add_argument('--apt-https-proxy', dest='apt_https_proxy',
@@ -77,29 +80,16 @@ def unhandled_input(key):
 
 
 def _start(*args, **kwargs):
+    if app.fetcher is None:
+        controllers.use('recommended').render()
+        return
+
     if app.fetcher != 'charmstore-search':
         utils.setup_metadata_controller()
     if app.argv.status_only:
         controllers.use('deploystatus').render()
     else:
         controllers.use('clouds').render()
-
-
-def install_pkgs(pkgs):
-    """ Installs the debian package associated with curated spell
-    """
-    if not isinstance(pkgs, list):
-        pkgs = [pkgs]
-
-    all_debs_installed = all(utils.check_deb_installed(x) for x
-                             in pkgs)
-    if not all_debs_installed:
-        utils.info(
-            "Installing additional required packages: {}".format(
-                " ".join(pkgs)))
-        os.execl("/usr/share/conjure-up/do-apt-install",
-                 "/usr/share/conjure-up/do-apt-install",
-                 " ".join(pkgs))
 
 
 def get_charmstore_bundles(spell, blessed):
@@ -133,10 +123,8 @@ def main():
     opts = parse_options(sys.argv[1:])
     spell = os.path.basename(os.path.abspath(opts.spell))
 
-    # cached spell dir
-    spell_dir = opts.spell_dir
-    if not os.path.isdir(spell_dir):
-        os.makedirs(spell_dir)
+    if not os.path.isdir(opts.cache_dir):
+        os.makedirs(opts.cache_dir)
 
     app.fetcher = fetcher(opts.spell)
 
@@ -147,9 +135,10 @@ def main():
         sys.exit(1)
 
     # Application Config
+    app.config = {'metadata': None}    
     app.argv = opts
     app.log = setup_logging("conjure-up/{}".format(spell),
-                            os.path.join(spell_dir, 'conjure-up.log'),
+                            os.path.join(opts.cache_dir, 'conjure-up.log'),
                             opts.debug)
 
     # Setup proxy
@@ -166,114 +155,56 @@ def main():
         global_config_filename = os.path.join(os.path.dirname(__file__),
                                               "../etc/conjure-up.conf")
         if not os.path.exists(global_config_filename):
-            utils.error("Could not find: {}, please check your install.".format(
-                app.argv.global_config_file))
+            utils.error("Could not find {}.".format(global_config_filename))
             sys.exit(1)
 
     with open(global_config_filename) as fp:
         global_conf = yaml.safe_load(fp.read())
+        app.global_config = global_conf
+
+    spells_dir = app.argv.spells_dir
+    if not os.path.exists(spells_dir):
+        spells_dir = os.path.join(os.path.dirname(__file__),
+                                  "../spells")
+
+    app.config['spells-dir'] = spells_dir
+    spells_index_path = os.path.join(app.config['spells-dir'],
+                                     'spells-index.yaml')
+    with open(spells_index_path) as fp:
+        app.spells_index = yaml.safe_load(fp.read())
 
     # Bind UI
     app.ui = ConjureUI()
 
-    if app.fetcher == "charmstore-search":
-        utils.info("Loading current {} spells "
-                   "from Juju Charmstore, please wait.".format(spell))
-        app.bundles = get_charmstore_bundles(spell, global_conf['blessed'])
-        app.config = {'metadata': None,
-                      'spell-dir': spell_dir,
-                      'spell': spell}
-
-        # Set a general description of spell
-        definition = None
-        spell_definitions_file = app.argv.spell_definitions
-        if path.isfile(spell_definitions_file):
-            with open(spell_definitions_file) as fp:
-                definitions = yaml.safe_load(fp.read())
-                definition = definitions.get(spell, None)
-        if definition is None:
-            try:
-                definition = next(
-                    bundle['Meta']['bundle-metadata']['Description']
-                    for bundle in app.bundles if 'Description'
-                    in bundle['Meta']['bundle-metadata'])
-            except StopIteration:
-                app.log.error("Could not find a suitable description "
-                              "for spell: {}".format(spell))
-
-        if definition is not None:
-            app.config['description'] = definition
-        else:
-            utils.warning(
-                "Failed to find a description for spell: {}, "
-                "and is a bug that should be filed.".format(spell))
-
-        # Install any required packages for any of the bundles
-        for bundle in app.bundles:
-            extra_info = bundle['Meta']['extra-info/conjure-up']
-            if 'packages' in extra_info:
-                app.log.debug('Found {} to install via apt'.format(
-                    extra_info['packages']))
-                install_pkgs(extra_info['packages'])
-
-    else:
-        app.config = {'metadata': None,
-                      'spell-dir': path.join(spell_dir, spell),
-                      'spell': spell}
+    if app.fetcher is not None:
+        utils.set_chosen_spell(spell, path.join(opts.cache_dir, spell))
 
         remote = get_remote_url(opts.spell)
         purge_top_level = True
         if remote is not None:
 
-            metadata_path = path.join(app.config['spell-dir'],
-                                      'conjure/metadata.json')
-
             if app.fetcher == "local":
                 app.config['spell-dir'] = path.join(
-                    spell_dir,
+                    opts.cache_dir,
                     os.path.basename(
                         os.path.abspath(spell)))
-                metadata_path = path.join(app.config['spell-dir'],
-                                          'conjure/metadata.json')
                 download_local(remote, app.config['spell-dir'])
 
             else:
-                if app.fetcher == "charmstore-search" or \
-                   app.fetcher == "charmstore-direct":
-                    purge_top_level = False
                 download(remote, app.config['spell-dir'], purge_top_level)
         else:
             utils.warning("Could not find spell: {}".format(spell))
             sys.exit(1)
 
-        with open(metadata_path) as fp:
-            metadata = json.load(fp)
-
-        app.config['metadata'] = metadata
-        if app.config['metadata'].get('packages', None):
-            install_pkgs(app.config['metadata']['packages'])
-
-        # Need to provide app.bundles dictionary even for single
-        # spells in the GUI
-        app.bundles = [
-            {
-                'Meta': {
-                    'extra-info/conjure-up': metadata
-                }
-            }
-        ]
-
+        utils.set_spell_metadata()
+            
     if hasattr(app.argv, 'cloud'):
-        if app.fetcher != "charmstore-search":
+        if app.fetcher is not None:
             app.headless = True
             app.ui = None
         else:
-            utils.error("Unable run a keyword search in headless mode, "
-                        "please provide a single bundle path.")
+            utils.error("Please specify a spell for headless mode.")
             sys.exit(1)
-
-    app.env = os.environ.copy()
-    app.env['CONJURE_UP_SPELL'] = spell
 
     if app.argv.status_only:
         if not juju.model_available():
@@ -291,3 +222,5 @@ def main():
                              unhandled_input=unhandled_input)
         EventLoop.set_alarm_in(0.05, _start)
         EventLoop.run()
+
+

--- a/conjureup/app.py
+++ b/conjureup/app.py
@@ -160,11 +160,17 @@ def main():
                                    spell,
                                    str(uuid.uuid4())))
 
-    if not os.path.exists(app.argv.global_config_file):
-        utils.error("Could not find: {}, please check your install.".format(
-            app.argv.global_config_file))
-        sys.exit(1)
-    with open(app.argv.global_config_file) as fp:
+    global_config_filename = app.argv.global_config_file
+    if not os.path.exists(global_config_filename):
+        # fallback to source tree location
+        global_config_filename = os.path.join(os.path.dirname(__file__),
+                                              "../etc/conjure-up.conf")
+        if not os.path.exists(global_config_filename):
+            utils.error("Could not find: {}, please check your install.".format(
+                app.argv.global_config_file))
+            sys.exit(1)
+
+    with open(global_config_filename) as fp:
         global_conf = yaml.safe_load(fp.read())
 
     # Bind UI

--- a/conjureup/app_config.py
+++ b/conjureup/app_config.py
@@ -2,7 +2,6 @@
 """
 from types import SimpleNamespace
 
-
 bootstrap = SimpleNamespace(
     # Is bootstrap running
     running=False,
@@ -20,6 +19,9 @@ app = SimpleNamespace(
 
     # Contains metadata and spell name
     config=None,
+
+    # Contains conjure-up global settings
+    global_config=None,
 
     # List of multiple bundles, usually from a charmstore search
     bundles=None,

--- a/conjureup/consts.py
+++ b/conjureup/consts.py
@@ -1,0 +1,1 @@
+UNSPECIFIED_SPELL = '_unspecified_spell'

--- a/conjureup/controllers/recommended/gui.py
+++ b/conjureup/controllers/recommended/gui.py
@@ -1,0 +1,49 @@
+import os
+
+from conjureup.download import download_local, get_remote_url
+from conjureup.ui.views.recommended import RecommendedSpellView
+from conjureup import utils
+from conjureup import controllers
+from conjureup.app_config import app
+
+
+class RecommendedSpellsController:
+    def __init__(self):
+        self.view = None
+
+    def __handle_exception(self, exc):
+        utils.pollinate(app.session_id, "TODO")
+        app.ui.show_exception_message(exc)
+
+    def finish(self, spellname):
+
+        utils.pollinate(app.session_id, 'CS')
+
+        utils.set_chosen_spell(spellname,
+                               os.path.join(app.argv.cache_dir,
+                                            spellname))
+        download_local(os.path.join(app.config['spells-dir'],
+                                    spellname),
+                       app.config['spell-dir'])
+        utils.set_spell_metadata()
+        return controllers.use('clouds').render()
+
+    def render(self):
+        recs = []
+
+        for _, kd in app.spells_index.items():
+
+            recs += kd['spells']
+
+        view = RecommendedSpellView(app,
+                                    recs,
+                                    self.finish)
+
+        app.ui.set_header(
+            title="Choose a Spell",
+            excerpt="Choose from this list of recommended spells"
+        )
+        app.ui.set_body(view)
+
+
+_controller_class = RecommendedSpellsController

--- a/conjureup/controllers/recommended/tui.py
+++ b/conjureup/controllers/recommended/tui.py
@@ -1,0 +1,7 @@
+class RecommendedSpellsController:
+
+    def render(self):
+        ...
+
+_controller_class = RecommendedSpellsController
+

--- a/conjureup/controllers/variants/gui.py
+++ b/conjureup/controllers/variants/gui.py
@@ -22,15 +22,11 @@ class VariantsController:
 
         spell_name = spell['Meta']['id']['Name']
 
-        # Check cache dir for spells
-        spell_dir = path.join(app.config['spell-dir'],
-                              spell_name)
-
         app.log.debug("Chosen spell: {}".format(spell_name))
         utils.pollinate(app.session_id, 'B001')
 
-        metadata_path = path.join(spell_dir,
-                                  'conjure/metadata.json')
+        metadata_path = path.join(app.config['spell_dir'],
+                                  'metadata.yaml')
 
         remote = get_remote_url(spell['Id'])
         purge_top_level = True
@@ -38,7 +34,7 @@ class VariantsController:
             if app.fetcher == "charmstore-search" or \
                app.fetcher == "charmstore-direct":
                 purge_top_level = False
-            download(remote, spell_dir, purge_top_level)
+            download(remote, app.config['spell_dir'], purge_top_level)
         else:
             utils.warning("Could not find spell: {}".format(spell))
             sys.exit(1)
@@ -46,9 +42,8 @@ class VariantsController:
         with open(metadata_path) as fp:
             metadata = json.load(fp)
 
-        app.config = {'metadata': metadata,
-                      'spell-dir': spell_dir,
-                      'spell': spell_name}
+        app.config.extend({'metadata': metadata,
+                           'spell': spell_name})
 
         utils.setup_metadata_controller()
 

--- a/conjureup/craft.py
+++ b/conjureup/craft.py
@@ -8,7 +8,7 @@ from conjureup.log import setup_logging
 import argparse
 import os
 import sys
-import json
+import yaml
 
 
 def parse_options(argv):
@@ -40,7 +40,7 @@ def main():
                     'Please make sure you are in the correct directory.')
         sys.exit(1)
 
-    if not os.path.isfile('conjure/metadata.json'):
+    if not os.path.isfile('metadata.yaml'):
         utils.error('Unable to find conjure metadata.')
         sys.exit(1)
 
@@ -57,8 +57,8 @@ def main():
         utils.info("Applying conjure-up metadata")
         charm.publish(spell)
         charm.grant(spell)
-        with open('conjure/metadata.json') as fp:
-            metadata = json.load(fp)
+        with open('conjure/metadata.yaml') as fp:
+            metadata = yaml.safe_load(fp.read())
         charm.set_metadata(spell, metadata)
         utils.info("Success.")
     except Exception as e:

--- a/conjureup/download.py
+++ b/conjureup/download.py
@@ -2,6 +2,7 @@ from subprocess import run, CalledProcessError
 import shutil
 import tempfile
 import os
+from conjureup.consts import UNSPECIFIED_SPELL
 from conjureup.app_config import app
 import requests
 from progressbar import (ProgressBar, Bar,
@@ -34,6 +35,8 @@ def fetcher(spell):
         return "vcs"
     if spell.startswith('http'):
         return "direct"
+    if spell == UNSPECIFIED_SPELL:
+        return None
     return "charmstore-search"
 
 

--- a/conjureup/ui/views/recommended.py
+++ b/conjureup/ui/views/recommended.py
@@ -1,0 +1,63 @@
+from urwid import (WidgetWrap, Pile,
+                   Filler)
+from ubuntui.utils import Color, Padding
+from ubuntui.widgets.hr import HR
+from ubuntui.widgets.text import Instruction
+from ubuntui.widgets.buttons import quit_btn, menu_btn
+from ubuntui.ev import EventLoop
+
+
+class RecommendedSpellView(WidgetWrap):
+    def __init__(self, app, recommended_spells, cb):
+        self.app = app
+        self.cb = cb
+        self.recommended_spells = recommended_spells
+        self.config = self.app.config
+        super().__init__(self._build_widget())
+
+    def keypress(self, size, key):
+        if key in ['tab', 'shift tab']:
+            self._swap_focus()
+        return super().keypress(size, key)
+
+    def _swap_focus(self):
+        w_count = len(self._w.body.contents) - 1
+        if self._w.body.focus_position >= 2 and \
+           self._w.body.focus_position < w_count:
+            self._w.body.focus_position = w_count
+        else:
+            self._w.body.focus_position = 2
+
+    def _build_buttons(self):
+        cancel = quit_btn(on_press=self.cancel)
+        buttons = [
+            Padding.line_break(""),
+            Color.button_secondary(cancel,
+                                   focus_map='button_secondary focus'),
+        ]
+        return Pile(buttons)
+
+    def _build_widget(self):
+        total_items = [
+            Padding.center_60(Instruction("Choose a Spell")),
+            Padding.center_60(HR())
+        ]
+        for spell in self.recommended_spells:
+            total_items.append(Padding.center_60(
+                Color.body(
+                    menu_btn(label=spell,
+                             on_press=self.submit),
+                    focus_map='menu_button focus'
+                )
+            ))
+
+        total_items.append(
+            Padding.center_60(HR()))
+        total_items.append(Padding.center_20(self._build_buttons()))
+        return Filler(Pile(total_items), valign='top')
+
+    def submit(self, result):
+        self.cb(result.label)
+
+    def cancel(self, btn):
+        EventLoop.exit(0)

--- a/snapcraft/snapcraft.yaml
+++ b/snapcraft/snapcraft.yaml
@@ -9,7 +9,7 @@ confinement: strict
 
 apps:
   conjure-up:
-    command: conjure-up -c $SNAP/etc/conjure-up.conf --spell-dir $HOME/spells --spell-definitions $SNAP/spell-definitions.yaml
+    command: conjure-up -c $SNAP/etc/conjure-up.conf --spells-dir $SNAP/spells --cache-dir $SNAP_DATA/conjure-up
     plugs: [home]
   python3:
     command: python3
@@ -43,4 +43,4 @@ parts:
     source-type: git
     files:
       etc/conjure-up.conf: etc/conjure-up.conf
-      share/spell-definitions.yaml: spell-definitions.yaml
+      spells: spells

--- a/spells/spells-index.yaml
+++ b/spells/spells-index.yaml
@@ -1,4 +1,6 @@
-# spell keyword mapping
+# spell keyword mapping -- unassigned spells are included in the package but not given a keyword
+_unassigned_spells:
+  spells: []
 openstack:
   spells:
     - openstack-novalxd


### PR DESCRIPTION
This adds the ability to run conjure-up with no args and see a list of recommended bundles that are pre-packaged. Several related changes wrt snappy and the main func were required.

NOTE: due to the way we've configured argparse, this branch now doesn't work *with* args. So it's definitely broken, but I'm pushing it now because it's EOD and it is probably worth building on.