### PR TITLE
remove apt install for additional packages

### DIFF
--- a/conjureup/app.py
+++ b/conjureup/app.py
@@ -135,7 +135,7 @@ def main():
         sys.exit(1)
 
     # Application Config
-    app.config = {'metadata': None}    
+    app.config = {'metadata': None}
     app.argv = opts
     app.log = setup_logging("conjure-up/{}".format(spell),
                             os.path.join(opts.cache_dir, 'conjure-up.log'),
@@ -197,7 +197,7 @@ def main():
             sys.exit(1)
 
         utils.set_spell_metadata()
-            
+
     if hasattr(app.argv, 'cloud'):
         if app.fetcher is not None:
             app.headless = True
@@ -222,5 +222,3 @@ def main():
                              unhandled_input=unhandled_input)
         EventLoop.set_alarm_in(0.05, _start)
         EventLoop.run()
-
-

--- a/conjureup/utils.py
+++ b/conjureup/utils.py
@@ -309,8 +309,6 @@ def set_spell_metadata():
         metadata = yaml.safe_load(fp.read())
 
     app.config['metadata'] = metadata
-    if app.config['metadata'].get('packages', None):
-        install_pkgs(app.config['metadata']['packages'])
 
     # Need to provide app.bundles dictionary even for single
     # spells in the GUI
@@ -321,19 +319,3 @@ def set_spell_metadata():
             }
         }
     ]
-
-
-def install_pkgs(pkgs):
-    """ Installs the debian package associated with curated spell
-    """
-    if not isinstance(pkgs, list):
-        pkgs = [pkgs]
-
-    all_debs_installed = all(check_deb_installed(x) for x
-                             in pkgs)
-    if not all_debs_installed:
-        info("Installing additional required packages: {}".format(
-                " ".join(pkgs)))
-        os.execl("/usr/share/conjure-up/do-apt-install",
-                 "/usr/share/conjure-up/do-apt-install",
-                 " ".join(pkgs))

--- a/share/do-apt-install
+++ b/share/do-apt-install
@@ -1,3 +1,0 @@
-#!/bin/sh
-
-sudo apt install -qyf $1 > /dev/null 2>&1 && conjure-up -d $@


### PR DESCRIPTION
This will not be applicable inside a snap, we should think about the
best way to handle additional requirements for a spell to work. For
example, a custom bridge is required for our openstack on novalxd spell
to completely work.

Signed-off-by: Adam Stokes <adam.stokes@ubuntu.com>