### PR TITLE
Fix tox flake command and fix lint that got thru

### DIFF
--- a/conjureup/controllers/clouds/gui.py
+++ b/conjureup/controllers/clouds/gui.py
@@ -1,5 +1,4 @@
 from conjureup.ui.views.cloud import CloudView
-from conjureup.download import EndpointType
 from conjureup import async
 from conjureup import utils
 from conjureup import controllers

--- a/conjureup/controllers/newcloud/gui.py
+++ b/conjureup/controllers/newcloud/gui.py
@@ -1,7 +1,6 @@
 from . import common
 from conjureup import async
 from conjureup import controllers
-from conjureup.download import EndpointType
 from conjureup import juju
 from conjureup import utils
 from conjureup.api.models import model_info
@@ -134,7 +133,6 @@ class NewCloudController:
         self.__do_bootstrap(credential=credentials_key)
 
         return controllers.use('bundlereadme').render()
-
 
     def render(self, cloud):
         """ Render

--- a/conjureup/controllers/spellpicker/tui.py
+++ b/conjureup/controllers/spellpicker/tui.py
@@ -4,4 +4,3 @@ class SpellPickerController:
         ...
 
 _controller_class = SpellPickerController
-

--- a/conjureup/controllers/steps/common.py
+++ b/conjureup/controllers/steps/common.py
@@ -3,7 +3,6 @@ from conjureup.api.models import model_info
 from conjureup import utils
 import json
 import os
-from collections import deque
 from glob import glob
 
 

--- a/conjureup/controllers/steps/gui.py
+++ b/conjureup/controllers/steps/gui.py
@@ -96,7 +96,7 @@ class StepsController:
             return
 
         step_widgets = deque()
-        
+
         for step_meta_path in self.step_metas:
             step_ex_path, ext = path.splitext(step_meta_path)
             if not path.isfile(step_ex_path) or \

--- a/tools/graph-controllers.py
+++ b/tools/graph-controllers.py
@@ -10,7 +10,7 @@ scope_re = re.compile("^(\s*)def (\w*)\(")
 
 def get_graph_string(filelist):
     s = "[ summary ] -> [ END ]\n"
-    
+
     for fn in filelist:
         if os.path.basename(fn) == 'app.py':
             src = "START"
@@ -32,9 +32,9 @@ def get_graph_string(filelist):
                     use_indent = len(use_match.group(1))
                     if use_indent <= scope_indent:
                         scopes.pop()
-                    s += "[ {} ] - {} -> [ {} ]\n".format(src,
-                                                          "{}:{}".format(scopes[0], i+1),
-                                                          use_match.group(2))
+                    s += "[ {} ] - {} -> [ {} ]\n".format(
+                        src, "{}:{}".format(scopes[0], i+1),
+                        use_match.group(2))
     return s
 
 

--- a/tox.ini
+++ b/tox.ini
@@ -16,7 +16,7 @@ commands =
     nosetests -v test
 
 [testenv:flake]
-commands = flake8 {posargs} conjure test
+commands = flake8 {posargs} conjureup test tools
 deps = flake8
 
 [testenv:docs]


### PR DESCRIPTION
We forgot to rename the conjure module in the .tox test command

Signed-off-by: Michael McCracken <mike.mccracken@canonical.com>