### PR TITLE
expose lxc,lxd,juju binaries in a snap

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,37 +11,17 @@ Then **conjure-up** is for you!
 This is the runtime application for processing spells to get those **big software**
 solutions up and going with as little hindrance as possible.
 
-# how to use
+# installation
 
 ## Xenial and above
 
-It is included in the archive.
-
-## Bleeding edge
-
-Brave? Try the bleeding edge version and file bugs to keep us honest.
-
 ```
-$ sudo apt-add-repository ppa:conjure-up/daily-git
+$ sudo dpkg-reconfigure -p medium lxd
+$ lxc finger
+$ snap install conjure-up --devmode
 ```
 
-Or install our **pre-releases**
-
-```
-$ sudo apt-add-repository ppa:conjure-up/next
-```
-
-Add the latest Juju
-
-```
-$ sudo apt-add-repository ppa:juju/devel
-```
-
-### Install the packages
-```
-$ sudo apt update
-$ sudo apt install conjure-up
-```
+# how to use
 
 ### Run the installer interactively
 
@@ -53,7 +33,7 @@ few config options before deploying. Or, just hold down the enter button and
 it'll choose sensible defaults for you.
 
 ```
-$ conjure-up openstack
+$ conjure-up
 ```
 
 ### Run the installer non-interactively (headless mode)
@@ -63,7 +43,7 @@ on your keyboard? Not a problem, easily get your **big software** up and running
 with all the sensible defaults in place.
 
 ```
-$ conjure-up ~containers/observable-kubernetes to azure
+$ conjure-up elk-stack aws
 ```
 
 # authors

--- a/snapcraft/snapcraft.yaml
+++ b/snapcraft/snapcraft.yaml
@@ -15,6 +15,12 @@ apps:
     command: python3
   shell:
     command: bash
+  juju:
+    command: juju
+  lxd:
+    command: lxd
+  lxc:
+    command: lxc
 
 parts:
   conjure:
@@ -30,7 +36,7 @@ parts:
       - jq
       - charm-tools
       - charm
-  juju:
+  juju-copy:
     plugin: nil
     stage-packages:
       - juju


### PR DESCRIPTION
You can now run /snap/bin/conjure-up.juju status to see your juju status
output.

Also update readme.

Signed-off-by: Adam Stokes <adam.stokes@ubuntu.com>