### PR TITLE
strip out unused files from snap build

### DIFF
--- a/snapcraft/snapcraft.yaml
+++ b/snapcraft/snapcraft.yaml
@@ -28,19 +28,14 @@ parts:
       - lxd-client
       - lxd
       - jq
-      - charm-tools
-      - charm
-  juju:
-    plugin: nil
-    stage-packages:
       - juju
     snap:
-      - usr/bin/juju*
-      - usr/lib/juju*
+      - -usr/share
+      - -usr/include
+      - -home/*/Projects/conjure/snapcraft/parts
   conjure-configs:
     plugin: copy
     source: https://github.com/ubuntu/conjure-up.git
-    source-type: git
     files:
       etc/conjure-up.conf: etc/conjure-up.conf
       spells: spells


### PR DESCRIPTION
Reduces snap by 30 megs

Signed-off-by: Adam Stokes <adam.stokes@ubuntu.com>