### PR TITLE
make lxd configuration a user task

### DIFF
--- a/conjureup/controllers/lxdsetup/gui.py
+++ b/conjureup/controllers/lxdsetup/gui.py
@@ -4,6 +4,7 @@ from conjureup import controllers
 from conjureup.app_config import app
 from subprocess import run
 from tempfile import NamedTemporaryFile
+from ubuntui.ev import EventLoop
 
 
 class LXDSetupController:
@@ -37,15 +38,20 @@ class LXDSetupController:
             lines.append("{}={}".format(k, network[k]))
         return "\n".join(lines)
 
-    def finish(self, lxdnetwork=None, back=False):
+    def finish(self, needs_lxd_setup=False, lxdnetwork=None, back=False):
         """ Processes the new LXD setup and loads the controller to
         finish bootstrapping the model.
 
         Arguments:
         back: if true loads previous controller
+        needs_lxd_setup: if true prompt user to run lxd init
         """
         if back:
             return controllers.use('clouds').render()
+
+        if needs_lxd_setup:
+            EventLoop.remove_alarms()
+            EventLoop.exit(1)
 
         if lxdnetwork is None:
             return app.ui.show_exception_message(

--- a/conjureup/controllers/lxdsetup/tui.py
+++ b/conjureup/controllers/lxdsetup/tui.py
@@ -1,8 +1,13 @@
-class LXDSetupController:
-    def finish(self):
-        pass
+from conjureup import utils
+import sys
 
+
+class LXDSetupController:
     def render(self):
-        pass
+        utils.info("")
+        utils.info("Unable to find a LXD bridge, please run `lxd init` "
+                   "and then re-run conjure-up.")
+        utils.info("")
+        sys.exit(1)
 
 _controller_class = LXDSetupController

--- a/conjureup/controllers/newcloud/tui.py
+++ b/conjureup/controllers/newcloud/tui.py
@@ -61,6 +61,13 @@ class NewCloudController:
                               "`juju add-credential {}`.".format(self.cloud))
                 sys.exit(1)
 
+        if self.cloud == 'localhost':
+            if not utils.check_bridge_exists():
+                return controllers.use('lxdsetup').render()
+
+            app.log.debug("Found an IPv4 address, "
+                          "assuming LXD is configured.")
+
         utils.info("Bootstrapping Juju controller")
         juju.bootstrap(controller=app.current_controller,
                        cloud=self.cloud,

--- a/conjureup/ui/views/lxdsetup.py
+++ b/conjureup/ui/views/lxdsetup.py
@@ -5,7 +5,7 @@ from ubuntui.widgets.hr import HR
 from urwid import (WidgetWrap, Pile, Text, Columns, Filler)
 from collections import OrderedDict
 from ubuntui.widgets.input import (StringEditor, YesNo)
-import os
+# import os
 
 # Network format
 #
@@ -106,11 +106,16 @@ class LXDSetupView(WidgetWrap):
                  "which usually means this is your first time running "
                  "LXD."),
             Padding.line_break(""),
+            # Text("If you wish to do so now pressing confirm will drop you out "  # noqa
+            #      "of the installer and walk you through configuring your "
+            #      "network for LXD. Once complete the installer will "
+            #      "start again from the beginning where you can choose "
+            #      "to deploy the bundle via LXD.")
             Text("If you wish to do so now pressing confirm will drop you out "
-                 "of the installer and walk you through configuring your "
-                 "network for LXD. Once complete the installer will "
-                 "start again from the beginning where you can choose "
-                 "to deploy the bundle via LXD.")
+                 "of the installer and you will be required to run "
+                 "`lxd init` to configure the network for LXD. Once complete "
+                 "re-run conjure-up and continue the installation.")
+
         ]
         return Pile(items)
 
@@ -140,7 +145,7 @@ class LXDSetupView(WidgetWrap):
         self.cb(back=True)
 
     def submit(self, result):
-        # self.cb(self.input_items)
-        os.execl("/usr/share/conjure-up/run-lxd-config",
-                 "/usr/share/conjure-up/run-lxd-config",
-                 self.app.config['spell'])
+        # os.execl("/usr/share/conjure-up/run-lxd-config",
+        #          "/usr/share/conjure-up/run-lxd-config",
+        #          self.app.config['spell'])
+        self.cb(needs_lxd_setup=True)


### PR DESCRIPTION
For now we need to have the user configure LXD prior to running
conjure-up due to the nature of a snap and its restrictions.

Fixes #309
Fixes #262

Signed-off-by: Adam Stokes <adam.stokes@ubuntu.com>