### PR TITLE
deb packaging updates

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ install-dependencies:
 uninstall-dependencies:
 	sudo apt-get remove conjure-build-deps
 
-release: clean test
+release: clean clean-snapcraft test
 	@sed -i -r "s/(^__version__\s=\s)(.*)/\1\"$(VERSION)\"/" conjureup/__init__.py
 	@sed -i -r "s/(^version:\s)(.*)/\1$(VERSION)/" snapcraft/snapcraft.yaml
 	@(cd snapcraft && snapcraft)
@@ -44,13 +44,15 @@ clean:
 	@rm -rf dist
 	@rm -rf conjure-dev
 	@if [ -L /usr/share/conjure-up/hooklib ]; then sudo unlink $(PACKAGE_SHARE_HOOKLIB_PATH) && sudo mv $(PACKAGE_SHARE_HOOKLIB_PATH).orig $(PACKAGE_SHARE_HOOKLIB_PATH); fi
+
+clean-snapcraft:
 	@(cd snapcraft && snapcraft clean)
 
 .PHONY: test
 test:
 	@tox
 
-DPKGBUILDARGS = -us -uc -i'.git.*|.tox|.bzr.*|.editorconfig|.travis-yaml|macumba\/debian|maasclient\/debian'
+DPKGBUILDARGS = -us -uc -i'.git.*|.tox|.bzr.*|.editorconfig|.travis-yaml|macumba\/debian|maasclient\/debian' -i'snapcraft'
 deb-src: clean
 	@debuild -S -sa $(DPKGBUILDARGS)
 

--- a/conjureup/craft.py
+++ b/conjureup/craft.py
@@ -1,6 +1,7 @@
 """ conjure-craft entrypoint
 """
 
+from conjureup import __version__ as VERSION
 from conjureup import utils
 from conjureup import charm
 from conjureup.app_config import app
@@ -16,6 +17,8 @@ def parse_options(argv):
     parser.add_argument('-d', '--debug', action='store_true',
                         dest='debug',
                         help='Enable debug logging.')
+    parser.add_argument(
+        '--version', action='version', version='%(prog)s {}'.format(VERSION))
 
     subparsers = parser.add_subparsers(help='conjure-craft subcommands help')
     # subparsers.add_parser('init',

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,4 @@
-conjure-up (2.0.0.7) UNRELEASED; urgency=medium
+conjure-up (2.0.0.8) UNRELEASED; urgency=medium
 
   * 2.0 Development
 

--- a/debian/conjure-up.install
+++ b/debian/conjure-up.install
@@ -1,3 +1,3 @@
-conjure-up-rsyslog.conf        usr/share/conjure-up
+conjure-up-rsyslog.conf         usr/share/conjure-up
 etc/*
-share/*                        usr/share/conjure-up/.
+spells                          usr/share/conjure-up

--- a/debian/conjure-up.links
+++ b/debian/conjure-up.links
@@ -1,2 +1,0 @@
-/usr/share/conjure-up/conjure-up /usr/bin/conjure-up
-/usr/share/conjure-up/conjure-craft /usr/bin/conjure-craft

--- a/debian/control
+++ b/debian/control
@@ -19,7 +19,8 @@ Build-Depends: debhelper (>= 9),
                python3-termcolor,
                python3-urwid,
                python3-ws4py,
-               python3-yaml
+               python3-yaml,
+               python3-progressbar
 Standards-Version: 3.9.7
 Homepage: https://github.com/ubuntu/conjure-up
 X-Python3-Version: >= 3.5
@@ -45,6 +46,7 @@ Depends: bsdtar,
          python3-urwid,
          python3-ws4py,
          python3-yaml,
+         python3-progressbar,
          rsyslog,
          ${misc:Depends},
          ${python3:Depends},

--- a/debian/copyright
+++ b/debian/copyright
@@ -1,6 +1,6 @@
 Format: http://www.debian.org/doc/packaging-manuals/copyright-format/1.0/
 Upstream-Name: conjure-up
-Source: https://github.com/ubuntu/conjure-up
+Source: https://github.com/conjure-up/conjure-up
 
 Files: *
 Copyright: 2015-2016, Canonical Ltd.

--- a/debian/rules
+++ b/debian/rules
@@ -3,10 +3,10 @@
 PKGDIR=debian/conjure-up
 
 export PYBUILD_NAME=conjure-up
-export PYBUILD_INSTALL_DIR=usr/share/conjure-up
-export PYBUILD_INSTALL_ARGS_python3=--install-lib=usr/share/conjure-up \
-	--install-data=usr/ \
-	--install-scripts=usr/share/conjure-up \
+export PYTHONPATH=$(PKGDIR)/usr/lib/python3/dist-packages
+export PYBUILD_INSTALL_ARGS_python3=--install-data=usr/ \
+	--install-lib=usr/lib/python3/dist-packages \
+	--install-scripts=usr/bin \
 	--root=$(PKGDIR) \
 	--no-compile -O0
 
@@ -15,7 +15,7 @@ export PYBUILD_INSTALL_ARGS_python3=--install-lib=usr/share/conjure-up \
 
 override_dh_install:
 	mkdir -p $(PKGDIR)/usr/share/man/man1
-	help2man $(PKGDIR)/usr/share/conjure-up/conjure-up -n "apt install juju bundles" --no-info -o $(PKGDIR)/usr/share/man/man1/conjure-up.1
+	help2man $(PKGDIR)/usr/bin/conjure-up -n "conjure-up" --no-info -o $(PKGDIR)/usr/share/man/man1/conjure-up.1
 	dh_install
 
 override_dh_auto_test:

--- a/setup.py
+++ b/setup.py
@@ -19,8 +19,7 @@ setuptools.setup(
     packages=find_420_friendly_packages(),
     entry_points={
         "console_scripts": [
-            "conjure-up = conjureup.app:main",
-            "conjure-craft = conjureup.craft:main"
+            "conjure-up = conjureup.app:main"
         ]
     }
 )


### PR DESCRIPTION
- clean up deb packaging
- moved conjure-up to python's default search paths so that our spells can
  make use of the conjure-up python library hooks without the need of
  messing with sys.path.
- disable conjure-craft for now as we rework how spells are stored and queried.

Signed-off-by: Adam Stokes <battlemidget@users.noreply.github.com>