### PR TITLE
Add openstack-base spell

### DIFF
--- a/spells/openstack-base/bundle.yaml
+++ b/spells/openstack-base/bundle.yaml
@@ -1,0 +1,238 @@
+machines:
+  '0':
+    constraints: arch=amd64
+    series: xenial
+  '1':
+    constraints: arch=amd64
+    series: xenial
+  '2':
+    constraints: arch=amd64
+    series: xenial
+  '3':
+    constraints: arch=amd64
+    series: xenial
+relations:
+- - nova-compute:amqp
+  - rabbitmq-server:amqp
+- - neutron-gateway:amqp
+  - rabbitmq-server:amqp
+- - keystone:shared-db
+  - mysql:shared-db
+- - nova-cloud-controller:identity-service
+  - keystone:identity-service
+- - glance:identity-service
+  - keystone:identity-service
+- - neutron-api:identity-service
+  - keystone:identity-service
+- - neutron-openvswitch:neutron-plugin-api
+  - neutron-api:neutron-plugin-api
+- - neutron-api:shared-db
+  - mysql:shared-db
+- - neutron-api:amqp
+  - rabbitmq-server:amqp
+- - neutron-gateway:neutron-plugin-api
+  - neutron-api:neutron-plugin-api
+- - glance:shared-db
+  - mysql:shared-db
+- - glance:amqp
+  - rabbitmq-server:amqp
+- - nova-cloud-controller:image-service
+  - glance:image-service
+- - nova-compute:image-service
+  - glance:image-service
+- - nova-cloud-controller:cloud-compute
+  - nova-compute:cloud-compute
+- - nova-cloud-controller:amqp
+  - rabbitmq-server:amqp
+- - nova-cloud-controller:quantum-network-service
+  - neutron-gateway:quantum-network-service
+- - nova-compute:neutron-plugin
+  - neutron-openvswitch:neutron-plugin
+- - neutron-openvswitch:amqp
+  - rabbitmq-server:amqp
+- - openstack-dashboard:identity-service
+  - keystone:identity-service
+- - nova-cloud-controller:shared-db
+  - mysql:shared-db
+- - nova-cloud-controller:neutron-api
+  - neutron-api:neutron-api
+- - cinder:image-service
+  - glance:image-service
+- - cinder:amqp
+  - rabbitmq-server:amqp
+- - cinder:identity-service
+  - keystone:identity-service
+- - cinder:cinder-volume-service
+  - nova-cloud-controller:cinder-volume-service
+- - cinder-ceph:storage-backend
+  - cinder:storage-backend
+- - ceph-mon:client
+  - nova-compute:ceph
+- - cinder:shared-db
+  - mysql:shared-db
+- - ceph-mon:client
+  - cinder-ceph:ceph
+- - ceph-mon:client
+  - glance:ceph
+- - ceph-osd:mon
+  - ceph-mon:osd
+- - ntp:juju-info
+  - nova-compute:juju-info
+- - ntp:juju-info
+  - neutron-gateway:juju-info
+- - ceph-radosgw:mon
+  - ceph-mon:radosgw
+- - ceph-radosgw:identity-service
+  - keystone:identity-service
+series: xenial
+services:
+  ceph-mon:
+    annotations:
+      gui-x: '750'
+      gui-y: '500'
+    charm: cs:xenial/ceph-mon-1
+    num_units: 3
+    to:
+    - lxc:1
+    - lxc:2
+    - lxc:3
+  ceph-osd:
+    annotations:
+      gui-x: '1000'
+      gui-y: '500'
+    charm: cs:xenial/ceph-osd-2
+    num_units: 3
+    options:
+      osd-devices: /dev/sdb
+      osd-reformat: 'yes'
+    to:
+    - '1'
+    - '2'
+    - '3'
+  ceph-radosgw:
+    annotations:
+      gui-x: '1000'
+      gui-y: '250'
+    charm: cs:xenial/ceph-radosgw-3
+    num_units: 1
+    options:
+      use-embedded-webserver: true
+    to:
+    - lxc:0
+  cinder:
+    annotations:
+      gui-x: '750'
+      gui-y: '0'
+    charm: cs:xenial/cinder-1
+    num_units: 1
+    options:
+      block-device: None
+      glance-api-version: 2
+    to:
+    - lxc:1
+  cinder-ceph:
+    annotations:
+      gui-x: '750'
+      gui-y: '250'
+    charm: cs:xenial/cinder-ceph-1
+    num_units: 0
+  glance:
+    annotations:
+      gui-x: '250'
+      gui-y: '0'
+    charm: cs:xenial/glance-1
+    num_units: 1
+    to:
+    - lxc:2
+  keystone:
+    annotations:
+      gui-x: '500'
+      gui-y: '0'
+    charm: cs:xenial/keystone-1
+    num_units: 1
+    options:
+      admin-password: openstack
+    to:
+    - lxc:3
+  mysql:
+    annotations:
+      gui-x: '0'
+      gui-y: '250'
+    charm: cs:xenial/percona-cluster-1
+    num_units: 1
+    options:
+      max-connections: 20000
+    to:
+    - lxc:0
+  neutron-api:
+    annotations:
+      gui-x: '500'
+      gui-y: '500'
+    charm: cs:xenial/neutron-api-1
+    num_units: 1
+    options:
+      neutron-security-groups: true
+    to:
+    - lxc:1
+  neutron-gateway:
+    annotations:
+      gui-x: '0'
+      gui-y: '0'
+    charm: cs:xenial/neutron-gateway-1
+    num_units: 1
+    options:
+      ext-port: eth1
+    to:
+    - '0'
+  neutron-openvswitch:
+    annotations:
+      gui-x: '250'
+      gui-y: '500'
+    charm: cs:xenial/neutron-openvswitch-2
+    num_units: 0
+  nova-cloud-controller:
+    annotations:
+      gui-x: '0'
+      gui-y: '500'
+    charm: cs:xenial/nova-cloud-controller-1
+    num_units: 1
+    options:
+      network-manager: Neutron
+    to:
+    - lxc:2
+  nova-compute:
+    annotations:
+      gui-x: '250'
+      gui-y: '250'
+    charm: cs:xenial/nova-compute-1
+    num_units: 3
+    options:
+      enable-live-migration: true
+      enable-resize: true
+      migration-auth-type: ssh
+    to:
+    - '1'
+    - '2'
+    - '3'
+  ntp:
+    annotations:
+      gui-x: '1000'
+      gui-y: '0'
+    charm: cs:xenial/ntp-0
+    num_units: 0
+  openstack-dashboard:
+    annotations:
+      gui-x: '500'
+      gui-y: '-250'
+    charm: cs:xenial/openstack-dashboard-1
+    num_units: 1
+    to:
+    - lxc:3
+  rabbitmq-server:
+    annotations:
+      gui-x: '500'
+      gui-y: '250'
+    charm: cs:xenial/rabbitmq-server-3
+    num_units: 1
+    to:
+    - lxc:0

--- a/spells/openstack-base/metadata.yaml
+++ b/spells/openstack-base/metadata.yaml
@@ -1,0 +1,12 @@
+cloud-whitelist:
+- maas
+friendly-name: OpenStack Base for MAAS
+options-whitelist:
+  keystone:
+  - admin-password
+  mysql:
+  - max-connections
+  neutron-gateway:
+  - ext-port
+  nova-compute:
+  - virt-type

--- a/spells/openstack-base/steps/00_deploy-done
+++ b/spells/openstack-base/steps/00_deploy-done
@@ -1,0 +1,30 @@
+#!/usr/bin/env python3
+from conjureup.hooklib.writer import success, fail, error
+from conjureup.hooklib import juju
+import logging
+
+log = logging.getLogger('conjureup')
+
+log.debug("Running deploy-done for OpenStack installation.")
+agent_states = juju.agent_states()
+
+errored_units = [(unit_name, message) for unit_name, state, message
+                 in agent_states if state == "error"]
+if len(errored_units) > 0:
+    errs = "\n".join(["{}: {}".format(n, m) for n, m in errored_units])
+    error('Deployment errors:\n{}'.format(errs))
+
+machines = juju.machine_states()
+errored_machines = [(name, err) for name, status, err in machines
+                    if status == "error"]
+if len(errored_machines) > 0:
+    errs = "\n".join(["{}: {}".format(n, m) for n, m in errored_machines])
+    error("Machine creation errors:\n{}".format(errs))
+
+if len(agent_states) == 0:
+    fail('Applications are still deploying')
+
+if all([state == 'active' for _, state, _ in agent_states]):
+    success('Applications are ready')
+
+fail('Applications not ready yet')

--- a/spells/openstack-base/steps/common.sh
+++ b/spells/openstack-base/steps/common.sh
@@ -1,0 +1,214 @@
+# common.sh - common utility functions for conjure processing tasks
+
+# Path to executing script
+SCRIPT=$(realpath $0)
+
+# Directory housing script
+SCRIPTPATH=$(dirname $SCRIPT)
+
+# loggers
+#
+# Arguments:
+# $1: logger name, ie. openstack, bigdata
+# $@: rest of log message
+debug() {
+    name=$CONJURE_UP_SPELL
+    logger -t "conjure-up/$name" "[DEBUG] $@"
+}
+
+info() {
+    name=$CONJURE_UP_SPELL
+    logger -t "conjure-up/$name" "[INFO] $@"
+}
+
+log() {
+    if [ $CONJURE_UP_HEADLESS ]; then
+        echo -e "\e[32m\e[1m[ info ]\e[0m $@]"
+    fi
+}
+
+# Gets current juju state for machine
+#
+# Arguments:
+# $1: service name
+#
+# Returns:
+# machine status
+agentState()
+{
+    juju status --format json | jq ".machines[\"$1\"][\"juju-status\"][\"current\"]"
+}
+
+# Gets current workload state for service
+#
+# Arguments:
+# $1: service name
+# $2: unit number
+#
+# Returns:
+# unit status
+agentStateUnit()
+{
+    juju status --format json | jq ".applications[\"$1\"][\"units\"][\"$1/$2\"][\"workload-status\"][\"current\"]"
+}
+
+# Gets current leader of a service
+#
+# Arguments:
+# $1: service name
+#
+# Returns:
+# unit leader
+getLeader()
+{
+    py_script="
+import sys
+import yaml
+
+leader_yaml=yaml.load(sys.stdin)
+for leader in leader_yaml:
+    if leader['Stdout'].strip() == 'True':
+        print(leader['UnitId'])
+"
+
+    juju run --application $1 is-leader --format yaml | env python3 -c "$py_script"
+}
+
+# Exports the variables required for communicating with your cloud.
+#
+# Arguments:
+# $1: username
+# $2: password
+# $3: tenant name
+# $4: keystone auth url
+# $5: region name
+configOpenrc()
+{
+    export OS_USERNAME=$1
+    export OS_PASSWORD=$2
+    export OS_TENANT_NAME=$3
+    export OS_AUTH_URL=$4
+    export OS_REGION_NAME=$5
+}
+
+# Get public address of unit
+#
+# Arguments:
+# $1: service
+# $2: unit number
+#
+# Returns:
+# IP Address of unit
+unitAddress()
+{
+    juju status --format json | jq -r ".applications[\"$1\"][\"units\"][\"$1/$2\"][\"public-address\"]"
+}
+
+# Get workload status of unit
+#
+# Arguments:
+# $1: service
+# $2: unit number
+#
+# Returns:
+# String of status
+unitStatus()
+{
+    juju status --format json | jq -r ".applications[\"$1\"][\"units\"][\"$1/$2\"][\"workload-status\"][\"current\"]"
+}
+
+# Get juju status of unit
+#
+# Arguments:
+# $1: service
+# $2: unit number
+#
+# Returns:
+# String of status
+unitJujuStatus()
+{
+    juju status --format json | jq -r ".applications[\"$1\"][\"units\"][\"$1/$2\"][\"juju-status\"][\"current\"]"
+}
+
+
+# Get machine for unit, ie 0/lxc/1
+#
+# Arguments:
+# 1: service
+# 2: unit number
+#
+# Returns:
+# machine identifier
+unitMachine()
+{
+    juju status --format json | jq -r ".applications[\"$1\"][\"units\"][\"$1/$2\"][\"machine\"]"
+}
+
+# Waits for machine to start
+#
+# Arguments:
+# machine: machine number
+waitForMachine()
+{
+    for machine; do
+        while [ "$(agentState $machine)" != started ]; do
+            sleep 5
+        done
+    done
+}
+
+# Waits for service to start
+#
+# Arguments:
+# service: service name
+waitForService()
+{
+
+    for service; do
+        while [ "$(agentStateUnit "$service" 0)" != active ]; do
+            sleep 5
+        done
+    done
+}
+
+# Parses result into json output
+#
+# Arguments:
+# $1: return message
+# $2: return code
+# $3: true/false
+exposeResult()
+{
+    printf '{"message": "%s", "returnCode": %d, "isComplete": %s}' "$1" $2 "$3"
+    exit 0
+}
+
+# Checks an array of applications for an error flag
+#
+# Arguments:
+# $1: array of applications
+checkUnitsForErrors() {
+    applications=$1
+    for i in "${applications[@]}"
+    do
+        if [ $(unitStatus $i 0) = "error" ]; then
+            debug "$i, gave a charm error."
+            exposeResult "Error with $i, please check juju status" 1 "false"
+        fi
+    done
+}
+
+# Checks an array of applications for an active flag
+#
+# Arguments:
+# $1: array of applications
+checkUnitsForActive() {
+    applications=$1
+    for i in "${applications[@]}"
+    do
+        debug "Checking agent state of $i: $(unitStatus $i 0)"
+        if [ $(unitStatus $i 0) != "active" ]; then
+            exposeResult "$i not quite ready yet" 0 "false"
+        fi
+    done
+}

--- a/spells/openstack-base/steps/novarc
+++ b/spells/openstack-base/steps/novarc
@@ -1,0 +1,5 @@
+export OS_USERNAME=admin
+export OS_PASSWORD=openstack
+export OS_TENANT_NAME=admin
+export OS_REGION_NAME=RegionOne
+export OS_AUTH_URL=${OS_AUTH_PROTOCOL:-http}://`juju run --unit  keystone/0 "unit-get private-address"`:5000/v2.0

--- a/spells/openstack-base/steps/step-02_glance
+++ b/spells/openstack-base/steps/step-02_glance
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+. common.sh
+
+imagetype=disk1.img
+diskformat=root-tar
+imagesuffix=""
+
+mkdir -p $HOME/glance-images || true
+if [ ! -f $HOME/glance-images/xenial-server-cloudimg-amd64-$imagetype ]; then
+    debug "Downloading xenial image..."
+    wget -qO ~/glance-images/xenial-server-cloudimg-amd64-$imagetype https://cloud-images.ubuntu.com/xenial/current/xenial-server-cloudimg-amd64-$imagetype
+fi
+
+. $SCRIPTPATH/novarc
+if ! glance image-list --property-filter name="xenial$imagesuffix" | grep -q "xenial$imagesuffix" ; then
+    debug "Importing xenial$imagesuffix"
+    glance image-create --name="xenial$imagesuffix" \
+           --container-format=bare \
+           --disk-format=$diskformat \
+           --property architecture="x86_64" \
+           --visibility=public --file=$HOME/glance-images/xenial-server-cloudimg-amd64-$imagetype > /dev/null 2>&1
+fi
+
+exposeResult "Glance images are imported and can be accessible via Horizon." 0 "true"

--- a/spells/openstack-base/steps/step-02_glance.yaml
+++ b/spells/openstack-base/steps/step-02_glance.yaml
@@ -1,0 +1,4 @@
+title: Glance
+description: |
+    Import glance images that will be readily available to start compute instances.
+viewable: True

--- a/spells/openstack-base/steps/step-03_keypair
+++ b/spells/openstack-base/steps/step-03_keypair
@@ -1,0 +1,61 @@
+#!/usr/bin/env python3
+
+# Global imports
+import os
+import os.path as path
+from subprocess import run, DEVNULL, PIPE
+import logging
+# Conjure-up specific
+from conjureup.hooklib.writer import success, fail
+import utils
+
+log = logging.getLogger('conjureup')
+SCRIPTPATH = path.dirname(path.abspath(__file__))
+NOVARC = path.join(SCRIPTPATH, 'novarc')
+
+
+def ssh_genkey(ssh_privkey):
+    """ Generates sshkey
+    """
+    cmd = "ssh-keygen -N '' -f {0}".format(ssh_privkey)
+    out = run(cmd, shell=True, stdout=DEVNULL, stderr=PIPE)
+    if out.returncode != 0:
+            fail("Unable to generate key: {0}".format(out.stderr.decode()))
+
+
+credentials = utils.parse_openstack_creds(NOVARC)
+
+ssh_pubkey = path.expanduser(os.environ.get(
+    'SSHPUBLICKEY',
+    path.expanduser('~/.ssh/id_rsa.pub')))
+ssh_privkey = path.join(path.expanduser('~/.ssh'),
+                        path.splitext(ssh_pubkey)[0])
+
+if not path.isfile(ssh_privkey):
+    log.debug("No ssh private key found, generating our own.")
+    ssh_genkey(ssh_privkey)
+
+log.debug("Checking for ssh public key: {}".format(ssh_pubkey))
+if path.isfile(ssh_pubkey):
+    cmd = ("openstack keypair show ubuntu-keypair")
+    ret = run(cmd, shell=True,
+              stdout=DEVNULL,
+              stderr=PIPE,
+              env=credentials)
+    if ret.returncode == 0:
+        success("SSH keypair already available to "
+                "you in your OpenStack cloud.")
+
+    cmd = ("openstack keypair create --public-key {} "
+           "ubuntu-keypair".format(ssh_pubkey))
+    ret = run(cmd, shell=True,
+              stdout=DEVNULL,
+              stderr=PIPE,
+              env=credentials)
+    if ret.returncode > 0:
+        fail("Unable to add public ssh key, maybe "
+             "ssh-keygen needs to be run")
+    success("SSH Keypair complete")
+
+fail("Could not find any ssh keys to import, please run "
+     "ssh-keygen in another terminal before re-executing this step.")

--- a/spells/openstack-base/steps/step-03_keypair.yaml
+++ b/spells/openstack-base/steps/step-03_keypair.yaml
@@ -1,0 +1,10 @@
+title: SSH
+description: |
+  Import SSH keypairs into OpenStack. This allows you to access the newly deployed instances via SSH with your current user. If you are not sure about the location of a ssh key leave it as is and we will create one automatically.
+viewable: True
+required: True
+additional-input:
+  - label: SSH public key path
+    key: SSHPUBLICKEY
+    type: text
+    default: ~/.ssh/id_rsa.pub

--- a/spells/openstack-base/steps/step-04_neutron
+++ b/spells/openstack-base/steps/step-04_neutron
@@ -1,0 +1,78 @@
+#!/bin/bash
+
+. common.sh
+
+fail_cleanly() {
+    exposeResult "$1" 1 "false"
+}
+
+# Get host namserver
+get_host_ns() {
+    perl -lne 's/^nameserver\s+// or next; s/\s.*//; print && exit' /etc/resolv.conf
+}
+
+. $SCRIPTPATH/novarc
+if ! neutron net-show ext-net > /dev/null 2>&1; then
+    debug "adding ext-net"
+    if ! neutron net-create --router:external ext-net > /dev/null 2>&1; then
+        debug "could not net-create ext-net"
+    fi
+fi
+
+if ! neutron subnet-show ext-subnet > /dev/null 2>&1; then
+    debug "adding ext-subnet"
+    if ! neutron subnet-create --name ext-subnet ext-net 10.99.0.0/24 \
+             --gateway 10.99.0.1 --disable-dhcp \
+             --allocation-pool start=10.99.0.3,end=10.99.0.254 > /dev/null 2>&1; then
+        debug "could not subnet-create ext-subnet"
+    fi
+fi
+
+if ! neutron net-show ubuntu-net > /dev/null 2>&1; then
+    debug "adding ubuntu-net"
+    if ! neutron net-create ubuntu-net --shared > /dev/null 2>&1; then
+        debug "could not net-create"
+    fi
+fi
+
+if ! neutron subnet-show ubuntu-subnet > /dev/null 2>&1; then
+    debug "adding ubuntu-subnet"
+    if ! neutron subnet-create --name ubuntu-subnet \
+            --gateway 10.101.0.1 \
+            --dns-nameserver $(get_host_ns) ubuntu-net 10.101.0.0/24 > /dev/null 2>&1; then
+        debug "could not add ubuntusubnet"
+    fi
+fi
+
+if ! neutron router-show ubuntu-router > /dev/null 2>&1; then
+    debug "adding ubuntu-router"
+    if ! neutron router-create ubuntu-router > /dev/null 2>&1; then
+        debug "couldnt create ubuntu-router"
+    fi
+fi
+
+if ! neutron router-interface-add ubuntu-router ubuntu-subnet > /dev/null 2>&1; then
+    debug "Could not add router-interface"
+fi
+
+debug "setting router gateway"
+if ! neutron router-gateway-set ubuntu-router ext-net > /dev/null 2>&1; then
+    debug "Could not set router gateway"
+fi
+
+# create pool of at least 5 floating ips
+debug "creating floating ips"
+existingips=$(neutron floatingip-list -f csv | tail -n +2| wc -l)
+to_create=$((10 - existingips))
+i=0
+while [ $i -ne $to_create ]; do
+    neutron floatingip-create ext-net > /dev/null 2>&1
+    i=$((i + 1))
+done
+
+# configure security groups
+debug "setting security roles"
+neutron security-group-rule-create --direction ingress --ethertype IPv4 --protocol icmp --remote-ip-prefix 0.0.0.0/0 default > /dev/null 2>&1 || true
+neutron security-group-rule-create --direction ingress --ethertype IPv4 --protocol tcp --port-range-min 22 --port-range-max 22 --remote-ip-prefix 0.0.0.0/0 default > /dev/null 2>&1 || true
+
+exposeResult "Neutron networking is now configured and is available to you during instance creation." 0 "true"

--- a/spells/openstack-base/steps/step-04_neutron.yaml
+++ b/spells/openstack-base/steps/step-04_neutron.yaml
@@ -1,0 +1,4 @@
+title: Neutron
+description: |
+  Configure Neutron networking. This step will setup a usable OpenStack network so that your instances may communicate with the outside world.
+viewable: True

--- a/spells/openstack-base/steps/step-05_horizon
+++ b/spells/openstack-base/steps/step-05_horizon
@@ -1,0 +1,15 @@
+#!/usr/bin/env python3
+
+from conjureup.hooklib.writer import success, fail
+from conjureup.hooklib import juju
+
+
+status = juju.status()
+applications = status['applications']['openstack-dashboard']
+horizon_ip = applications['units']['openstack-dashboard/0']['public-address']
+
+if horizon_ip:
+    success(
+        "Login to Horizon: http://{}/horizon l: admin p: openstack".format(
+            horizon_ip))
+fail("Unable to determine Horizon URL")

--- a/spells/openstack-base/steps/step-05_horizon.yaml
+++ b/spells/openstack-base/steps/step-05_horizon.yaml
@@ -1,0 +1,4 @@
+title: Horizon
+description: |
+  Configure Horizon and generate a URL and credentials to access the dashboard with.
+viewable: True

--- a/spells/openstack-base/steps/utils.py
+++ b/spells/openstack-base/steps/utils.py
@@ -1,0 +1,39 @@
+from subprocess import run, PIPE
+from writer import log  # noqa
+
+
+def slurp(path):
+    """ Reads data from path
+    :param str path: path of file
+    """
+    try:
+        with open(path) as f:
+            return f.read().strip()
+    except IOError:
+        raise IOError
+
+
+def parse_openstack_creds(creds_file):
+    """ Parses openstack-{admin,ubuntu}-rc for openstack
+    credentials
+
+    Arguments:
+    creds_file: path to openstack novarc file
+    """
+
+    def sanitize_quotes(key):
+        if key[0] == key[-1] and key[0] in ("'", '"'):
+            return key[1:-1]
+        else:
+            return key
+
+    cmd = ['bash', '-c', 'source {} && env'.format(creds_file)]
+    ret = run(cmd, stdout=PIPE)
+    cred_map = {}
+    for k in ret.stdout.decode().split("\n"):
+        try:
+            first, rest = k.split("=")
+            cred_map[first] = sanitize_quotes(rest)
+        except ValueError:
+            log.debug("Skipping {}".format(k))
+    return cred_map

--- a/spells/spells-index.yaml
+++ b/spells/spells-index.yaml
@@ -3,6 +3,10 @@ _unassigned_spells:
   spells: []
 openstack:
   spells:
+    - key: openstack-base
+      name: OpenStack Base for MAAS
+      description: |
+        Deploys a basic OpenStack Cloud (Mitaka release) on Ubuntu 16.04 LTS, providing Dashboard, Compute, Network, Block Storage, Object Storage, Identity and Image services, using a minimum of 4 physical servers in MAAS.
     - key: openstack-novalxd
       name: OpenStack with NovaLXD
       description: |


### PR DESCRIPTION
This spell was only tested up to the deploy screen, I don't have enough machines available in MAAS ATM to test a full deploy.

This PR uses the shell versions of the steps, only lightly modified from the openstack-novalxd versions.

The openstack-base spell at https://github.com/battlemidget/openstack-bundles uses python steps, so @battlemidget should look and see if those are more up to date.


Signed-off-by: Michael McCracken <mike.mccracken@canonical.com>