### PR TITLE
fix deb packaging

### DIFF
--- a/debian/conjure-up.install
+++ b/debian/conjure-up.install
@@ -1,3 +1,2 @@
 conjure-up-rsyslog.conf         usr/share/conjure-up
 etc/*
-spells                          usr/share/conjure-up


### PR DESCRIPTION
we were still looking for spells directory in the debian install file,
removed that so package would build successfully again.

Signed-off-by: Adam Stokes <battlemidget@users.noreply.github.com>