### PR TITLE
add spell selector hover descriptions

### DIFF
--- a/conjureup/ui/views/spellpicker.py
+++ b/conjureup/ui/views/spellpicker.py
@@ -71,7 +71,7 @@ class SpellPickerView(WidgetWrap):
 
     def _build_buttons(self):
         cancel = menu_btn(on_press=self.cancel,
-                          label="\nQUIT\n")
+                          label="\n  QUIT\n")
         buttons = [
             Padding.line_break(""),
             Color.menu_button(cancel,
@@ -83,7 +83,7 @@ class SpellPickerView(WidgetWrap):
     def _build_footer(self):
         self.spell_description = Text("")
         footer_pile = Pile([
-            Padding.center_80(self.spell_description),
+            Padding.center_60(self.spell_description),
             Padding.line_break(""),
             Color.frame_footer(
                 Columns([

--- a/conjureup/ui/views/spellpicker.py
+++ b/conjureup/ui/views/spellpicker.py
@@ -1,4 +1,4 @@
-from urwid import Filler, Pile, WidgetWrap, Frame, Text, Columns
+from urwid import Columns, Filler, Frame, Pile, Text, WidgetWrap
 
 from ubuntui.ev import EventLoop
 from ubuntui.utils import Color, Padding
@@ -7,6 +7,7 @@ from ubuntui.widgets.hr import HR
 
 
 class SpellPickerWidget(WidgetWrap):
+
     def __init__(self, spell, cb):
         self._spell = spell
         self.cb = cb

--- a/conjureup/ui/views/spellpicker.py
+++ b/conjureup/ui/views/spellpicker.py
@@ -63,10 +63,11 @@ class SpellPickerView(WidgetWrap):
     def _swap_focus(self):
         if not self.buttons_pile_selected:
             self.buttons_pile_selected = True
-            self.buttons_pile.focus_position = 0
+            self.frame.focus_position = 'footer'
+            self.buttons_pile.focus_position = 1
         else:
             self.buttons_pile_selected = False
-            self.pile.focus_position = 1
+            self.frame.focus_position = 'body'
 
     def _build_buttons(self):
         cancel = menu_btn(on_press=self.cancel,

--- a/conjureup/ui/views/spellpicker.py
+++ b/conjureup/ui/views/spellpicker.py
@@ -1,9 +1,26 @@
-from urwid import Filler, Pile, WidgetWrap
+from urwid import Filler, Pile, WidgetWrap, Frame, Text, Columns
 
 from ubuntui.ev import EventLoop
 from ubuntui.utils import Color, Padding
-from ubuntui.widgets.buttons import menu_btn, quit_btn
+from ubuntui.widgets.buttons import menu_btn
 from ubuntui.widgets.hr import HR
+
+
+class SpellPickerWidget(WidgetWrap):
+    def __init__(self, spell, cb):
+        self._spell = spell
+        self.cb = cb
+        super().__init__(self.build_widget())
+
+    def build_widget(self):
+        """ Provides a rendered spell widget suitable for pile
+        """
+        return Color.body(
+            menu_btn(label=self._spell['name'],
+                     on_press=self.cb,
+                     user_data=self._spell),
+            focus_map='menu_button focus'
+        )
 
 
 class SpellPickerView(WidgetWrap):
@@ -11,50 +28,73 @@ class SpellPickerView(WidgetWrap):
     def __init__(self, app, spells, cb):
         self.app = app
         self.cb = cb
-        self.spells = spells
+        self.spells = [SpellPickerWidget(spell, self.submit)
+                       for spell in spells]
         self.config = self.app.config
-        super().__init__(self._build_widget())
+        self.frame = Frame(body=self._build_widget(),
+                           footer=self._build_footer())
+        super().__init__(self.frame)
+        self.handle_focus_changed()
 
     def keypress(self, size, key):
+        rv = super().keypress(size, key)
         if key in ['tab', 'shift tab']:
             self._swap_focus()
-        return super().keypress(size, key)
+        self.handle_focus_changed()
+        return rv
+
+    def handle_focus_changed(self):
+        self.selected_spell_w = None
+        fw = self.pile.focus
+        if not isinstance(fw, SpellPickerWidget):
+            return
+
+        if fw != self.selected_spell_w:
+            self.selected_spell_w = fw
+            if fw is None:
+                self.spell_description.set_text("No spell selected")
+            else:
+                self.spell_description.set_text(fw._spell['description'])
 
     def _swap_focus(self):
-        w_count = len(self._w.body.contents) - 1
-        if self._w.body.focus_position >= 2 and \
-           self._w.body.focus_position < w_count:
-            self._w.body.focus_position = w_count
+        self.current_focused_frame = None
+        if self.current_focused_frame is None:
+            self.current_focused_frame = self.frame.footer
+            self.frame.footer.focus_position = 0
         else:
-            self._w.body.focus_position = 2
+            self.current_focused_frame = self.body.footer
+            self.frame.body.focus_position = 0
 
     def _build_buttons(self):
-        cancel = quit_btn(on_press=self.cancel)
+        cancel = menu_btn(on_press=self.cancel,
+                          label="\nQUIT\n")
         buttons = [
             Padding.line_break(""),
-            Color.button_secondary(cancel,
-                                   focus_map='button_secondary focus'),
+            Color.menu_button(cancel,
+                              focus_map='button_primary focus')
         ]
         return Pile(buttons)
 
-    def _build_widget(self):
-        total_items = [
-            Padding.center_60(HR())
-        ]
-        for spell in self.spells:
-            total_items.append(Padding.center_60(
-                Color.body(
-                    menu_btn(label=spell['name'],
-                             on_press=self.submit,
-                             user_data=spell),
-                    focus_map='menu_button focus'
-                )
-            ))
+    def _build_footer(self):
+        self.spell_description = Text("")
+        footer_pile = Pile([
+            Padding.center_80(self.spell_description),
+            Padding.line_break(""),
+            Color.frame_footer(
+                Columns([
+                    ('fixed', 2, Text("")),
+                    ('fixed', 13, self._build_buttons())
+                ]))
+        ])
+        return footer_pile
 
-        total_items.append(
-            Padding.center_60(HR()))
-        total_items.append(Padding.center_20(self._build_buttons()))
-        return Filler(Pile(total_items), valign='top')
+    def _build_widget(self):
+        total_items = [HR()]
+        total_items += [spell for spell in self.spells]
+        total_items += [HR()]
+
+        self.pile = Pile(total_items)
+        return Padding.center_60(Filler(self.pile, valign='top'))
 
     def submit(self, btn, result):
         self.cb(result['key'])

--- a/conjureup/ui/views/spellpicker.py
+++ b/conjureup/ui/views/spellpicker.py
@@ -34,6 +34,9 @@ class SpellPickerView(WidgetWrap):
         self.config = self.app.config
         self.frame = Frame(body=self._build_widget(),
                            footer=self._build_footer())
+
+        self.buttons_pile_selected = False
+
         super().__init__(self.frame)
         self.handle_focus_changed()
 
@@ -58,13 +61,12 @@ class SpellPickerView(WidgetWrap):
                 self.spell_description.set_text(fw._spell['description'])
 
     def _swap_focus(self):
-        self.current_focused_frame = None
-        if self.current_focused_frame is None:
-            self.current_focused_frame = self.frame.footer
-            self.frame.footer.focus_position = 0
+        if not self.buttons_pile_selected:
+            self.buttons_pile_selected = True
+            self.buttons_pile.focus_position = 0
         else:
-            self.current_focused_frame = self.body.footer
-            self.frame.body.focus_position = 0
+            self.buttons_pile_selected = False
+            self.pile.focus_position = 1
 
     def _build_buttons(self):
         cancel = menu_btn(on_press=self.cancel,
@@ -74,7 +76,8 @@ class SpellPickerView(WidgetWrap):
             Color.menu_button(cancel,
                               focus_map='button_primary focus')
         ]
-        return Pile(buttons)
+        self.buttons_pile = Pile(buttons)
+        return self.buttons_pile
 
     def _build_footer(self):
         self.spell_description = Text("")


### PR DESCRIPTION
The hover part works now where it'll change the spell's description.

@mikemccracken I attempted to mess with the frame's focus position on pressing the tab key but I'm apparently missing something.

![image](https://cloud.githubusercontent.com/assets/51892/18315408/e932c000-74e4-11e6-9641-eca5e1370fd6.png)

Signed-off-by: Adam Stokes <battlemidget@users.noreply.github.com>