### PR TITLE
Add conjureup0 network bridge

### DIFF
--- a/debian/conjure-up.install
+++ b/debian/conjure-up.install
@@ -1,2 +1,4 @@
 conjure-up-rsyslog.conf         usr/share/conjure-up
 etc/*
+init/bridge.start               usr/lib/conjure-up
+init/bridge.stop                usr/lib/conjure-up

--- a/debian/conjure-up.service
+++ b/debian/conjure-up.service
@@ -1,0 +1,15 @@
+[Unit]
+Description=conjure-up - network bridge
+Documentation=man:conjure-up(1)
+After=network-online.target
+Before=lxd.service
+Requires=network-online.target
+
+[Service]
+Type=oneshot
+RemainAfterExit=yes
+ExecStart=/usr/lib/conjure-up/bridge.start
+ExecStop=/usr/lib/conjure-up/bridge.stop
+
+[Install]
+WantedBy=multi-user.target

--- a/debian/rules
+++ b/debian/rules
@@ -11,7 +11,15 @@ export PYBUILD_INSTALL_ARGS_python3=--install-data=usr/ \
 	--no-compile -O0
 
 %:
-	dh $@ --with python3 --buildsystem=pybuild
+	dh $@ --with python3 --buildsystem=pybuild --with systemd
+
+override_dh_installinit:
+	dh_systemd_enable -pconjure-up --name=conjure-up conjure-up.service
+	dh_installinit -pconjure-up --no-start --noscripts
+	dh_systemd_start -pconjure-up --no-restart-on-upgrade
+
+override_dh_systemd_start:
+	echo "Not running dh_systemd_start"
 
 override_dh_install:
 	mkdir -p $(PKGDIR)/usr/share/man/man1

--- a/init/bridge.start
+++ b/init/bridge.start
@@ -1,0 +1,15 @@
+#!/bin/sh
+
+ip link add dev conjureup0 type bridge
+ip addr add 10.99.0.1/24 dev conjureup0
+ip link set dev conjureup0 up
+
+echo 1 > /proc/sys/net/ipv4/ip_forward
+
+iptables -I FORWARD -i conjureup0 -j ACCEPT
+iptables -I FORWARD -o conjureup0 -j ACCEPT
+iptables -t nat -A POSTROUTING -s 10.99.0.1/24 ! -d 10.99.0.1/24 -j MASQUERADE
+iptables -I INPUT -i conjureup0 -p tcp -m tcp --dport 53 -j ACCEPT
+iptables -I INPUT -i conjureup0 -p udp -m udp --dport 53 -j ACCEPT
+iptables -I INPUT -i conjureup0 -p tcp -m tcp --dport 67 -j ACCEPT
+iptables -I INPUT -i conjureup0 -p udp -m udp --dport 67 -j ACCEPT

--- a/init/bridge.stop
+++ b/init/bridge.stop
@@ -1,0 +1,14 @@
+#!/bin/sh
+
+ip addr flush dev conjureup0
+ip link set dev conjureup0 down
+
+iptables -D FORWARD -i conjureup0 -j ACCEPT
+iptables -D FORWARD -o conjureup0 -j ACCEPT
+
+iptables -D INPUT -i conjureup0 -p tcp -m tcp --dport 53 -j ACCEPT
+iptables -D INPUT -i conjureup0 -p udp -m udp --dport 53 -j ACCEPT
+iptables -D INPUT -i conjureup0 -p tcp -m tcp --dport 67 -j ACCEPT
+iptables -D INPUT -i conjureup0 -p udp -m udp --dport 67 -j ACCEPT
+
+iptables -t nat -D POSTROUTING -s 10.99.0.1/24 ! -d 10.99.0.1/24 -j MASQUERADE


### PR DESCRIPTION
Previously, we handled this bridge creation during the installation of
the openstack package. However, now that conjure-up can be invoked
without any spell initially this disrupts the user experience by putting
them back into the shell to install another deb package to get that
network bridge setup.

This includes a default network bridge which spells can make use of if necessary.

Signed-off-by: Adam Stokes <battlemidget@users.noreply.github.com>