### PR TITLE
Update add-credential view

### DIFF
--- a/conjureup/controllers/newcloud/gui.py
+++ b/conjureup/controllers/newcloud/gui.py
@@ -185,6 +185,7 @@ class NewCloudController:
             title="New cloud setup",
         )
         app.ui.set_body(view)
+        app.ui.set_footer("")
 
 
 _controller_class = NewCloudController

--- a/conjureup/ui/views/newcloud.py
+++ b/conjureup/ui/views/newcloud.py
@@ -1,10 +1,9 @@
-from urwid import Columns, Filler, Pile, Text, WidgetWrap
+from urwid import Columns, Filler, Frame, Pile, Text, WidgetWrap
 
 from ubuntui.utils import Color, Padding
-from ubuntui.widgets.buttons import back_btn, confirm_btn
+from ubuntui.widgets.buttons import menu_btn
 from ubuntui.widgets.hr import HR
 from ubuntui.widgets.input import StringEditor
-from ubuntui.widgets.text import Instruction
 
 
 class NewCloudView(WidgetWrap):
@@ -14,42 +13,15 @@ class NewCloudView(WidgetWrap):
         self.cloud = cloud
         self.input_items = schema
         self.cb = cb
-        self.confirm_button = Color.button_primary(
-            confirm_btn(on_press=self.submit,
-                        label="Add credential"),
-            focus_map='button_primary focus')
-        self.cancel_button = Color.button_secondary(
-            back_btn(on_press=self.cancel),
-            focus_map='button_secondary focus')
+        self.frame = Frame(body=self._build_widget(),
+                           footer=self._build_footer())
+        self.buttons_selected = False
+        super().__init__(self.frame)
 
-        _pile = [
-            Padding.center_60(Instruction(
-                "Enter your {} credentials:".format(self.cloud.upper()))),
-            Padding.center_60(HR()),
-            Padding.center_60(self.build_inputs()),
-            Padding.line_break(""),
-            Text(""),  # confirm button placeholder
-            Padding.center_20(self.cancel_button)
-        ]
-        self.pile = Pile(_pile)
-        super().__init__(Filler(self.pile, valign="top"))
-        self.validate()
-
-    def _swap_focus(self):
-        if self._w.body.focus_position == 2:
-            self._w.body.focus_position = 4
-        else:
-            self._w.body.focus_position = 2
-
-    def keypress(self, size, key):
-        if key in ['tab', 'shift tab']:
-            self._swap_focus()
-        rv = super().keypress(size, key)
-        self.validate()
-        return rv
-
-    def build_inputs(self):
-        items = []
+    def _build_widget(self):
+        total_items = [Text(
+            "Enter your {} credentials:".format(self.cloud.upper()))]
+        total_items += [HR()]
         for k in self.input_items.keys():
             display = k
             if k.startswith('_'):
@@ -65,24 +37,68 @@ class NewCloudView(WidgetWrap):
                                        focus_map='string_input focus')
                 ], dividechars=1
             )
-            items.append(col)
-            items.append(Padding.line_break(""))
-        return Pile(items)
+            total_items.append(col)
+            total_items.append(Padding.line_break(""))
+        total_items.append(Text(""))
+        self.pile = Pile(total_items)
+        return Padding.center_60(Filler(self.pile, valign="top"))
+
+    def _build_footer(self):
+        cancel = menu_btn(on_press=self.cancel,
+                          label="\n  BACK\n")
+        confirm = menu_btn(on_press=self.submit,
+                           label="\n ADD CREDENTIAL\n")
+        self.buttons = Columns([
+            ('fixed', 2, Text("")),
+            ('fixed', 13, Color.menu_button(
+                cancel,
+                focus_map='button_primary focus')),
+            Text(""),
+            ('fixed', 20, Color.menu_button(
+                confirm,
+                focus_map='button_primary focus')),
+            ('fixed', 2, Text(""))
+        ])
+
+        footer = Color.frame_footer(Pile([
+            Padding.line_break(""),
+            self.buttons
+        ]))
+        return footer
+
+    def _swap_focus(self):
+        if not self.buttons_selected:
+            self.buttons_selected = True
+            self.frame.focus_position = 'footer'
+            self.buttons.focus_position = 3
+        else:
+            self.buttons_selected = False
+            self.frame.focus_position = 'body'
+
+    def keypress(self, size, key):
+        if key in ['tab', 'shift tab']:
+            self._swap_focus()
+        rv = super().keypress(size, key)
+        return rv
 
     def validate(self):
+        """ Will provide an error text if any fields are blank
+        """
         values = [i.value for i in self.input_items.values()
                   if isinstance(i, StringEditor)]
 
         if None in values:
-            self.pile.contents[-2] = (Padding.center_20(
-                Text("Please fill all required fields.")),
+            self.pile.contents[-1] = (
+                Padding.center_60(
+                    Color.error_major(
+                        Text("Please fill all required fields."))),
                 self.pile.options())
-        else:
-            self.pile.contents[-2] = (Padding.center_20(self.confirm_button),
-                                      self.pile.options())
+            return False
+        return True
 
     def cancel(self, btn):
         self.cb(back=True)
 
     def submit(self, result):
-        self.cb(self.input_items)
+        if self.validate():
+            self.cb(self.input_items)


### PR DESCRIPTION

![image](https://cloud.githubusercontent.com/assets/51892/18515681/23d8c72a-7a64-11e6-8985-636957dbd7ff.png)

This places 2 buttons in the frame footer in addition to updating the
validate() to only happen once the 'ADD CREDENTIAL' button is pressed.

Prior to that there was no way of going back to the input fields to
change any values as self.validate() was being called regardless

Signed-off-by: Adam Stokes <battlemidget@users.noreply.github.com>