### PR TITLE
Split application list to have a fixed footer description

### DIFF
--- a/conjureup/ui/views/applicationlist.py
+++ b/conjureup/ui/views/applicationlist.py
@@ -4,7 +4,7 @@
 import logging
 from functools import partial
 
-from urwid import Columns, Filler, Pile, Text, WidgetWrap, Frame
+from urwid import Columns, Filler, Frame, Pile, Text, WidgetWrap
 
 from conjureup.app_config import app
 from ubuntui.ev import EventLoop


### PR DESCRIPTION

![image](https://cloud.githubusercontent.com/assets/51892/18646923/b5291fa6-7e81-11e6-8470-d9d84b75a227.png)

This keeps the description shown no matter the length of the application
list, also updates the button placement to reflect our design.

Signed-off-by: Adam Stokes <battlemidget@users.noreply.github.com>