### PR TITLE
Avoid showing config button for nothing

### DIFF
--- a/conjureup/ui/views/applicationconfigure.py
+++ b/conjureup/ui/views/applicationconfigure.py
@@ -6,7 +6,7 @@ import logging
 
 from urwid import Filler, Pile, Text, WidgetWrap
 
-from conjureup.app_config import app
+from conjureup import utils
 from conjureup.ui.widgets.option_widget import OptionWidget
 from ubuntui.utils import Padding
 from ubuntui.widgets.buttons import PlainButton
@@ -42,18 +42,9 @@ class ApplicationConfigureView(WidgetWrap):
         ws = []
         service_id = self.application.csid.as_str_without_rev()
         options = self.metadata_controller.get_options(service_id)
-        metadata = app.config.get('metadata', None)
-        if metadata is None:
-            return []
 
-        options_whitelist = metadata.get('options-whitelist', None)
-        if options_whitelist is None:
-            return []
-
-        svc_opts_whitelist = options_whitelist.get(
-            self.application.service_name,
-            [])
-
+        svc_opts_whitelist = utils.get_options_whitelist(
+            self.application.service_name)
         hidden = [n for n in options.keys() if n not in svc_opts_whitelist]
         log.info("Hiding options not in the whitelist: {}".format(hidden))
         for opname in svc_opts_whitelist:

--- a/conjureup/ui/views/applicationlist.py
+++ b/conjureup/ui/views/applicationlist.py
@@ -19,11 +19,11 @@ log = logging.getLogger('conjure')
 class ApplicationWidget(WidgetWrap):
 
     def __init__(self, application, maxlen, controller, deploy_cb,
-                 show_config=True):
+                 hide_config=False):
         self.application = application
         self.controller = controller
         self.deploy_cb = deploy_cb
-        self.show_config = show_config
+        self.hide_config = hide_config
         self._selectable = True
         super().__init__(self.build_widgets(maxlen))
         self.columns.focus_position = len(self.columns.contents) - 1
@@ -54,7 +54,7 @@ class ApplicationWidget(WidgetWrap):
                                     self.application)),
                 focus_map='button_primary focus'))
         ]
-        if self.show_config:
+        if not self.hide_config:
             cws[3] = (20, Color.button_secondary(
                 PlainButton("Configure",
                             partial(self.controller.do_configure,
@@ -211,11 +211,11 @@ class ApplicationListView(WidgetWrap):
         for a in self.applications:
             ws.append(Text(""))
             wl = get_options_whitelist(a.service_name)
-            show_config = len(wl) > 0
+            hide_config = a.subordinate and len(wl) == 0
             ws.append(ApplicationWidget(a, max_app_name_len,
                                         self.controller,
                                         self.do_deploy,
-                                        show_config=show_config))
+                                        hide_config=hide_config))
 
         self.description_w = Text("App description")
         self.pile = Pile(ws)

--- a/conjureup/utils.py
+++ b/conjureup/utils.py
@@ -336,3 +336,20 @@ def find_spells_matching(key):
             if spell['key'] == key:
                 return [spell]
     return []
+
+
+def get_options_whitelist(service_name):
+    """returns list of whitelisted option names.
+    If there is no whitelist, returns []
+    """
+    metadata = app.config.get('metadata', None)
+    if metadata is None:
+        return []
+
+    options_whitelist = metadata.get('options-whitelist', None)
+    if options_whitelist is None:
+        return []
+
+    svc_opts_whitelist = options_whitelist.get(service_name, [])
+
+    return svc_opts_whitelist


### PR DESCRIPTION
If there are no whitelisted options for a service, don't show the button
that brings up the config screen.

Fixes #415.

Signed-off-by: Michael McCracken <mike.mccracken@canonical.com>