### PR TITLE
Fixes #215

### DIFF
--- a/conjureup/app.py
+++ b/conjureup/app.py
@@ -5,16 +5,16 @@ import argparse
 import os
 import os.path as path
 import sys
+import textwrap
 import uuid
 
 import yaml
-from prettytable import PrettyTable
-import textwrap
 from termcolor import colored
 
 from conjureup import __version__ as VERSION
 from conjureup import async, consts, controllers, utils
 from conjureup.app_config import app
+from conjureup.controllers.steps.common import get_step_metadata_filenames
 from conjureup.download import (
     EndpointType,
     detect_endpoint,
@@ -25,7 +25,7 @@ from conjureup.download import (
 )
 from conjureup.log import setup_logging
 from conjureup.ui import ConjureUI
-from conjureup.controllers.steps.common import get_step_metadata_filenames
+from prettytable import PrettyTable
 from ubuntui.ev import EventLoop
 from ubuntui.palette import STYLES
 

--- a/debian/control
+++ b/debian/control
@@ -22,6 +22,7 @@ Build-Depends: debhelper (>= 9),
                python3-ws4py,
                python3-yaml,
                python3-progressbar,
+               python3-prettytable
 Standards-Version: 3.9.7
 Homepage: https://github.com/ubuntu/conjure-up
 X-Python3-Version: >= 3.5
@@ -48,6 +49,7 @@ Depends: bsdtar,
          python3-ws4py,
          python3-yaml,
          python3-progressbar,
+         python3-prettytable,
          rsyslog,
          ${misc:Depends},
          ${python3:Depends},


### PR DESCRIPTION

![-bin-bash_001](https://cloud.githubusercontent.com/assets/51892/18752048/2c22ff44-80af-11e6-8d31-b1467538c8d4.png)

Displays environment variables used in any of the additional inputs from
post processing steps. Allowing you to set those environment variables
on the CLI for more customized headless installs.

Signed-off-by: Adam Stokes <battlemidget@users.noreply.github.com>