### PR TITLE
compatibility for python3.5 subprocess.run

### DIFF
--- a/conjureup/charm.py
+++ b/conjureup/charm.py
@@ -6,13 +6,14 @@ https://github.com/juju/charmstore/blob/v5/docs/API.md
 import json
 import os.path as path
 import shutil
-from subprocess import DEVNULL, PIPE, CalledProcessError, run
+from subprocess import DEVNULL, PIPE, CalledProcessError
 from tempfile import NamedTemporaryFile
 
 import requests
 import yaml
 
 from conjureup.app_config import app
+from conjureup.utils import run
 
 cs = 'https://api.jujucharms.com/v5'
 

--- a/conjureup/charm.py
+++ b/conjureup/charm.py
@@ -6,14 +6,13 @@ https://github.com/juju/charmstore/blob/v5/docs/API.md
 import json
 import os.path as path
 import shutil
-from subprocess import DEVNULL, PIPE, CalledProcessError
+from subprocess import DEVNULL, PIPE, CalledProcessError, run
 from tempfile import NamedTemporaryFile
 
 import requests
 import yaml
 
 from conjureup.app_config import app
-from conjureup.utils import run
 
 cs = 'https://api.jujucharms.com/v5'
 

--- a/conjureup/controllers/deploy/gui.py
+++ b/conjureup/controllers/deploy/gui.py
@@ -2,7 +2,7 @@ import json
 import os
 from functools import partial
 from operator import attrgetter
-from subprocess import PIPE, run
+from subprocess import PIPE
 
 from conjureup import async, controllers, juju, utils
 from conjureup.api.models import model_info
@@ -37,11 +37,11 @@ class DeployController:
             msg = "Running pre-deployment tasks."
             app.log.debug(msg)
             app.ui.set_footer(msg)
-            return run(pre_deploy_sh,
-                       shell=True,
-                       stdout=PIPE,
-                       stderr=PIPE,
-                       env=app.env)
+            return utils.run(pre_deploy_sh,
+                             shell=True,
+                             stdout=PIPE,
+                             stderr=PIPE,
+                             env=app.env)
         return json.dumps({'message': 'No pre deploy necessary',
                            'returnCode': 0,
                            'isComplete': True})

--- a/conjureup/controllers/deploy/tui.py
+++ b/conjureup/controllers/deploy/tui.py
@@ -4,7 +4,7 @@ import os
 import sys
 from functools import partial
 from operator import attrgetter
-from subprocess import PIPE, run
+from subprocess import PIPE
 
 from conjureup import controllers, juju, utils
 from conjureup.api.models import model_info
@@ -35,10 +35,10 @@ class DeployController:
             utils.pollinate(app.session_id, 'J001')
             utils.info("Running pre deployment tasks.")
             try:
-                sh = run(pre_deploy_sh, shell=True,
-                         stdout=PIPE,
-                         stderr=PIPE,
-                         env=app.env)
+                sh = utils.run(pre_deploy_sh, shell=True,
+                               stdout=PIPE,
+                               stderr=PIPE,
+                               env=app.env)
                 result = json.loads(sh.stdout.decode('utf8'))
                 if result['returnCode'] > 0:
                     utils.error("Failed to run pre-deploy task: "

--- a/conjureup/controllers/lxdsetup/gui.py
+++ b/conjureup/controllers/lxdsetup/gui.py
@@ -1,4 +1,3 @@
-from subprocess import run
 from tempfile import NamedTemporaryFile
 
 from conjureup import controllers, utils
@@ -67,7 +66,7 @@ class LXDSetupController:
                                 delete=False) as tempf:
             app.log.debug("Saving LXD config to {}".format(tempf.name))
             utils.spew(tempf.name, out)
-            sh = run('sudo mv {} /etc/default/lxd-bridge'.format(
+            sh = utils.run('sudo mv {} /etc/default/lxd-bridge'.format(
                 tempf.name), shell=True)
             if sh.returncode > 0:
                 return app.ui.show_exception_message(
@@ -75,7 +74,7 @@ class LXDSetupController:
                         sh.stderr.decode('utf8'))))
 
         app.log.debug("Restarting lxd-bridge")
-        run("sudo systemctl restart lxd-bridge.service", shell=True)
+        utils.run("sudo systemctl restart lxd-bridge.service", shell=True)
 
         utils.pollinate(app.session_id, 'L002')
         controllers.use('newcloud').render(

--- a/conjureup/controllers/newcloud/tui.py
+++ b/conjureup/controllers/newcloud/tui.py
@@ -1,7 +1,7 @@
 import json
 import os
 import sys
-from subprocess import PIPE, run
+from subprocess import PIPE
 
 import petname
 
@@ -30,10 +30,10 @@ class NewCloudController:
             utils.pollinate(app.session_id, 'J001')
             utils.info("Running post-bootstrap tasks.")
             try:
-                sh = run(post_bootstrap_sh, shell=True,
-                         stdout=PIPE,
-                         stderr=PIPE,
-                         env=app.env)
+                sh = utils.run(post_bootstrap_sh, shell=True,
+                               stdout=PIPE,
+                               stderr=PIPE,
+                               env=app.env)
                 result = json.loads(sh.stdout.decode('utf8'))
                 utils.info("Finished post bootstrap task: {}".format(
                     result['message']))

--- a/conjureup/download.py
+++ b/conjureup/download.py
@@ -1,7 +1,7 @@
 import os
 import shutil
 from enum import Enum
-from subprocess import CalledProcessError, run
+from subprocess import CalledProcessError
 
 import requests
 from progressbar import (
@@ -13,6 +13,7 @@ from progressbar import (
 )
 
 from conjureup.app_config import app
+from conjureup.utils import run
 from conjureup.consts import UNSPECIFIED_SPELL
 
 

--- a/conjureup/download.py
+++ b/conjureup/download.py
@@ -13,8 +13,8 @@ from progressbar import (
 )
 
 from conjureup.app_config import app
-from conjureup.utils import run
 from conjureup.consts import UNSPECIFIED_SPELL
+from conjureup.utils import run
 
 
 class EndpointType(Enum):

--- a/conjureup/hooklib/juju.py
+++ b/conjureup/hooklib/juju.py
@@ -1,9 +1,10 @@
 import logging
 import time
 from subprocess import PIPE, CalledProcessError
-from conjureup.utils import run
 
 import yaml
+
+from conjureup.utils import run
 
 from .writer import fail, success
 

--- a/conjureup/hooklib/juju.py
+++ b/conjureup/hooklib/juju.py
@@ -1,6 +1,7 @@
 import logging
 import time
-from subprocess import PIPE, CalledProcessError, run
+from subprocess import PIPE, CalledProcessError
+from conjureup.utils import run
 
 import yaml
 
@@ -13,7 +14,7 @@ def status():
     """ Get juju status
     """
     try:
-        sh = run('juju status --format yaml', shell=True, check=True,
+        sh = run('juju-2.0 status --format yaml', shell=True, check=True,
                  stdout=PIPE)
     except CalledProcessError:
         return None
@@ -28,7 +29,7 @@ def leader(application):
     """
     try:
         sh = run(
-            'juju run --application {} is-leader --format yaml'.format(
+            'juju-2.0 run --application {} is-leader --format yaml'.format(
                 application),
             shell=True, stdout=PIPE, check=True)
     except CalledProcessError:
@@ -74,7 +75,7 @@ def run_action(unit, action):
     """ runs an action on a unit, waits for result
     """
     is_complete = False
-    sh = run('juju run-action {} {}'.format(unit, action),
+    sh = run('juju-2.0 run-action {} {}'.format(unit, action),
              shell=True,
              stdout=PIPE)
     run_action_output = yaml.load(sh.stdout.decode())
@@ -85,7 +86,7 @@ def run_action(unit, action):
         fail("Could not determine action id for test")
 
     while not is_complete:
-        sh = run('juju show-action-output {}'.format(action_id),
+        sh = run('juju-2.0 show-action-output {}'.format(action_id),
                  shell=True,
                  stderr=PIPE,
                  stdout=PIPE)

--- a/conjureup/juju.py
+++ b/conjureup/juju.py
@@ -4,13 +4,7 @@ import os
 import sys
 from concurrent import futures
 from functools import partial, wraps
-from subprocess import (
-    DEVNULL,
-    PIPE,
-    CalledProcessError,
-    Popen,
-    TimeoutExpired
-)
+from subprocess import DEVNULL, PIPE, CalledProcessError, Popen, TimeoutExpired
 
 import yaml
 

--- a/conjureup/juju.py
+++ b/conjureup/juju.py
@@ -9,8 +9,7 @@ from subprocess import (
     PIPE,
     CalledProcessError,
     Popen,
-    TimeoutExpired,
-    run
+    TimeoutExpired
 )
 
 import yaml
@@ -19,7 +18,7 @@ import macumba
 from bundleplacer.charmstore_api import CharmStoreID
 from conjureup import async
 from conjureup.app_config import app
-from conjureup.utils import juju_path
+from conjureup.utils import juju_path, run
 from macumba.v2 import JujuClient
 
 JUJU_ASYNC_QUEUE = "juju-async-queue"
@@ -134,7 +133,7 @@ def bootstrap(controller, cloud, series="xenial", credential=None):
     log: application logger
     credential: credentials key
     """
-    cmd = "juju bootstrap {} {} " \
+    cmd = "juju-2.0 bootstrap {} {} " \
           "--config image-stream=daily ".format(
               controller, cloud)
     cmd += "--config enable-os-upgrade=false "
@@ -199,7 +198,7 @@ def model_available():
     True/False if juju status was successful and a working model is found
     """
     try:
-        run('juju status', shell=True,
+        run('juju-2.0 status', shell=True,
             check=True, stderr=DEVNULL, stdout=DEVNULL)
     except CalledProcessError:
         return False
@@ -210,7 +209,7 @@ def autoload_credentials():
     """ Automatically checks known places for cloud credentials
     """
     try:
-        run('juju autoload-credentials', shell=True, check=True)
+        run('juju-2.0 autoload-credentials', shell=True, check=True)
     except CalledProcessError:
         return False
     return True
@@ -264,7 +263,7 @@ def get_clouds():
     Returns:
     Dictionary of all known clouds including newly created MAAS/Local
     """
-    sh = run('juju list-clouds --format yaml',
+    sh = run('juju-2.0 list-clouds --format yaml',
              shell=True, stdout=PIPE, stderr=PIPE)
     if sh.returncode > 0:
         raise Exception(
@@ -289,7 +288,7 @@ def get_cloud(name):
 def _do_switch(target):
     try:
         app.log.debug('calling juju switch {}'.format(target))
-        run('juju switch {}'.format(target),
+        run('juju-2.0 switch {}'.format(target),
             shell=True, check=True, stdout=DEVNULL, stderr=DEVNULL)
     except CalledProcessError as e:
         raise LookupError("Unable to switch: {}".format(e))
@@ -340,7 +339,7 @@ def deploy(bundle):
             charmstore path.
     """
     try:
-        return run('juju deploy {}'.format(bundle), shell=True,
+        return run('juju-2.0 deploy {}'.format(bundle), shell=True,
                    stdout=DEVNULL, stderr=PIPE)
     except CalledProcessError as e:
         raise e
@@ -506,7 +505,7 @@ def get_controller_info(name=None):
     Arguments:
     name: if set shows info controller, otherwise displays current.
     """
-    cmd = 'juju show-controller --format yaml'
+    cmd = 'juju-2.0 show-controller --format yaml'
     if name is not None:
         cmd += ' {}'.format(name)
     sh = run(cmd, shell=True, stdout=PIPE, stderr=PIPE)
@@ -527,7 +526,7 @@ def get_controllers():
     Returns:
     List of known controllers
     """
-    sh = run('juju list-controllers --format yaml',
+    sh = run('juju-2.0 list-controllers --format yaml',
              shell=True, stdout=PIPE, stderr=PIPE)
     if sh.returncode > 0:
         raise LookupError(
@@ -605,7 +604,7 @@ def get_model(name):
 def add_model(name):
     """ Adds a model to current controller
     """
-    sh = run('juju add-model {}'.format(name),
+    sh = run('juju-2.0 add-model {}'.format(name),
              shell=True, stdout=DEVNULL, stderr=PIPE)
     if sh.returncode > 0:
         raise Exception(
@@ -618,7 +617,7 @@ def get_models():
     Returns:
     List of known models
     """
-    sh = run('juju list-models --format yaml',
+    sh = run('juju-2.0 list-models --format yaml',
              shell=True, stdout=PIPE, stderr=PIPE)
     if sh.returncode > 0:
         raise LookupError(
@@ -637,7 +636,7 @@ def get_current_model():
 def version():
     """ Returns version of Juju
     """
-    sh = run('juju version', shell=True, stdout=PIPE, stderr=PIPE)
+    sh = run('juju-2.0 version', shell=True, stdout=PIPE, stderr=PIPE)
     if sh.returncode > 0:
         raise Exception(
             "Unable to get Juju Version".format(sh.stderr.decode('utf8')))

--- a/conjureup/utils.py
+++ b/conjureup/utils.py
@@ -9,7 +9,7 @@ from subprocess import (
     CalledProcessError,
     Popen,
     check_call,
-    run
+    check_output
 )
 
 import yaml
@@ -22,6 +22,20 @@ from bundleplacer.config import Config
 from conjureup import charm
 from conjureup.app_config import app
 from conjureup.async import submit
+
+
+def run(cmd, **kwargs):
+    """ Compatibility function to support python 3.4
+    """
+    try:
+        from subprocess import run as _run
+        return _run(cmd, **kwargs)
+    except ImportError:
+        if 'check' in kwargs:
+            del kwargs['check']
+            return check_call(cmd, **kwargs)
+        else:
+            return check_output(cmd, **kwargs)
 
 
 def run_script(path, stderr=PIPE, stdout=PIPE):


### PR DESCRIPTION
We want to support Trusty which comes with python3.4 so our run command
needs to be ported to work with both 3.5 and 3.4

Signed-off-by: Adam Stokes <battlemidget@users.noreply.github.com>