### PR TITLE
make logging output more consistent

### DIFF
--- a/conjureup/app.py
+++ b/conjureup/app.py
@@ -9,6 +9,7 @@ import textwrap
 import uuid
 
 import yaml
+from prettytable import PrettyTable
 from termcolor import colored
 
 from conjureup import __version__ as VERSION
@@ -25,7 +26,6 @@ from conjureup.download import (
 )
 from conjureup.log import setup_logging
 from conjureup.ui import ConjureUI
-from prettytable import PrettyTable
 from ubuntui.ev import EventLoop
 from ubuntui.palette import STYLES
 

--- a/conjureup/hooklib/writer.py
+++ b/conjureup/hooklib/writer.py
@@ -9,7 +9,7 @@ CACHEDIR = os.getenv('CONJURE_UP_CACHEDIR',
 SPELL_NAME = os.getenv('CONJURE_UP_SPELL', '_unspecified_spell')
 LOGFILE = os.path.join(CACHEDIR, '{spell}.log'.format(spell=SPELL_NAME))
 
-log = setup_logging(SPELL_NAME, LOGFILE, True)
+log = setup_logging("conjure-up/{}".format(SPELL_NAME), LOGFILE, True)
 
 
 def success(msg):

--- a/conjureup/log.py
+++ b/conjureup/log.py
@@ -4,6 +4,25 @@ import stat
 from logging.handlers import SysLogHandler, TimedRotatingFileHandler
 
 
+class _log:
+
+    def __init__(self, app, logger):
+        self.app = app
+        self.logger = logger
+
+    def debug(self, msg):
+        self.logger.debug("{}: {}".format(self.app, msg))
+
+    def error(self, msg):
+        self.logger.error("{}: {}".format(self.app, msg))
+
+    def info(self, msg):
+        self.logger.info("{}: {}".format(self.app, msg))
+
+    def exception(self, msg):
+        self.logger.exception("{}: {}".format(self.app, msg))
+
+
 def setup_logging(app, logfile, debug=False):
     cmdslog = TimedRotatingFileHandler(logfile,
                                        when='D',
@@ -30,4 +49,4 @@ def setup_logging(app, logfile, debug=False):
             syslog_h.set_name(app)
             logger.addHandler(syslog_h)
 
-    return logger
+    return _log(app, logger)

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,3 +11,4 @@ petname
 six
 configobj
 progressbar2
+prettytable


### PR DESCRIPTION
In python 3.5 you can prepend `appname`:`log msg` and the syslog
handler will replace it's normal `python3[PID]` with `appname[PID]`.
This is useful for debugging where we want users to be able to grep for
`conjure-up` and get relevant messages from journald.

Signed-off-by: Adam Stokes <battlemidget@users.noreply.github.com>