### PR TITLE
Fixes #295

### DIFF
--- a/conjureup/app.py
+++ b/conjureup/app.py
@@ -9,6 +9,7 @@ import textwrap
 import uuid
 
 import yaml
+from prettytable import PrettyTable
 from termcolor import colored
 
 from conjureup import __version__ as VERSION
@@ -25,7 +26,6 @@ from conjureup.download import (
 )
 from conjureup.log import setup_logging
 from conjureup.ui import ConjureUI
-from prettytable import PrettyTable
 from ubuntui.ev import EventLoop
 from ubuntui.palette import STYLES
 

--- a/conjureup/controllers/clouds/gui.py
+++ b/conjureup/controllers/clouds/gui.py
@@ -16,9 +16,7 @@ class CloudsController:
         app.ui.show_exception_message(exc)
 
     def __add_model(self):
-        juju.switch_controller(app.current_controller)
-        juju.add_model(app.current_model)
-        juju.switch_model(app.current_model)
+        juju.add_model(app.current_model, app.current_controller)
 
     def finish(self, cloud):
         """ Load the Model controller passing along the selected cloud.

--- a/conjureup/controllers/clouds/tui.py
+++ b/conjureup/controllers/clouds/tui.py
@@ -22,12 +22,10 @@ class CloudsController:
             return controllers.use('newcloud').render(app.argv.cloud)
 
         app.current_controller = existing_controller
-        juju.switch_controller(app.current_controller)
         app.current_model = petname.Name()
         utils.info("Creating new juju model named '{}', "
                    "please wait.".format(app.current_model))
-        juju.add_model(app.current_model)
-        juju.switch_model(app.current_model)
+        juju.add_model(app.current_model, app.current_controller)
 
         return controllers.use('deploy').render()
 

--- a/conjureup/controllers/controllerpicker/gui.py
+++ b/conjureup/controllers/controllerpicker/gui.py
@@ -15,9 +15,7 @@ class ControllerPicker:
         app.ui.show_exception_message(exc)
 
     def __add_model(self):
-        juju.switch_controller(app.current_controller)
-        juju.add_model(app.current_model)
-        juju.switch_model(app.current_model)
+        juju.add_model(app.current_model, app.current_controller)
 
     def finish(self, controller):
         utils.pollinate(app.session_id, 'CS')

--- a/conjureup/controllers/deploy/gui.py
+++ b/conjureup/controllers/deploy/gui.py
@@ -27,7 +27,7 @@ class DeployController:
         """ runs pre deploy script if exists
         """
         app.env['JUJU_PROVIDERTYPE'] = model_info(
-            juju.get_current_model())['provider-type']
+            app.current_model)['provider-type']
 
         pre_deploy_sh = os.path.join(app.config['spell-dir'],
                                      'steps/00_pre-deploy')

--- a/conjureup/controllers/deploy/tui.py
+++ b/conjureup/controllers/deploy/tui.py
@@ -26,7 +26,8 @@ class DeployController:
         """ runs pre deploy script if exists
         """
         # Set provider type for post-bootstrap
-        app.env['JUJU_PROVIDERTYPE'] = model_info('default')['provider-type']
+        app.env['JUJU_PROVIDERTYPE'] = model_info(
+            app.current_model)['provider-type']
 
         pre_deploy_sh = os.path.join(app.config['spell-dir'],
                                      'steps/00_pre-deploy')

--- a/conjureup/controllers/newcloud/gui.py
+++ b/conjureup/controllers/newcloud/gui.py
@@ -39,7 +39,6 @@ class NewCloudController:
         utils.pollinate(app.session_id, 'J004')
         EventLoop.remove_alarms()
         app.ui.set_footer('Bootstrap complete...')
-        juju.switch_controller(app.current_controller)
         self.__post_bootstrap_exec()
 
     def __do_bootstrap(self, cloud=None, credential=None):
@@ -66,7 +65,7 @@ class NewCloudController:
     def __post_bootstrap_exec(self):
         """ Executes post-bootstrap.sh if exists
         """
-        info = model_info(juju.get_current_model())
+        info = model_info(app.current_model)
         # Set our provider type environment var so that it is
         # exposed in future processing tasks
         app.env['JUJU_PROVIDERTYPE'] = info['provider-type']
@@ -106,9 +105,6 @@ class NewCloudController:
                 'bootstrap processing phase: {}.'.format(result)))
         utils.pollinate(app.session_id, 'J002')
         app.ui.set_footer('')
-        app.log.debug("Switching to controller: {}".format(
-            app.current_controller))
-        juju.switch_controller(app.current_controller)
         controllers.use('deploy').render()
 
     def finish(self, credentials=None, back=False):

--- a/conjureup/juju.py
+++ b/conjureup/juju.py
@@ -29,7 +29,7 @@ this.USER_TAG = None
 def requires_login(f):
     def _decorator(*args, **kwargs):
         if not this.IS_AUTHENTICATED:
-            login(True)
+            login(force=True)
         return f(*args, **kwargs)
     return wraps(f)(_decorator)
 
@@ -511,26 +511,6 @@ def get_accounts():
         env = yaml.load(c)
         return env['controllers']
     raise Exception("Unable to find accounts")
-
-
-def model_by_owner(controller, user):
-    """ List model associated with user
-
-    Arguments:
-    user: username to query
-    controller: controller to work in
-
-    Returns:
-    Dictionary containing model information for user
-    """
-    models = get_models(controller)
-    for m in models:
-        if m['owner'] == user:
-            return m
-    raise LookupError(
-        "Unable to find user: {}".format(
-            user
-        ))
 
 
 def get_model(controller, name):

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,3 +11,4 @@ petname
 six
 configobj
 progressbar2
+prettytable

--- a/test/test_controllers_clouds_gui.py
+++ b/test/test_controllers_clouds_gui.py
@@ -6,7 +6,7 @@
 
 
 import unittest
-from unittest.mock import ANY, MagicMock, call, patch
+from unittest.mock import MagicMock, call, patch
 
 from conjureup.controllers.clouds.gui import CloudsController
 
@@ -78,6 +78,10 @@ class CloudsGUIFinishTestCase(unittest.TestCase):
             'conjureup.controllers.clouds.gui.juju.get_controller_in_cloud')
         self.mock_gcc = self.gcc_patcher.start()
 
+        self.petname_patcher = patch(
+            'conjureup.controllers.clouds.gui.petname')
+        self.mock_petname = self.petname_patcher.start()
+
     def tearDown(self):
         self.controllers_patcher.stop()
         self.utils_patcher.stop()
@@ -85,15 +89,15 @@ class CloudsGUIFinishTestCase(unittest.TestCase):
         self.app_patcher.stop()
         self.juju_patcher.stop()
         self.gcc_patcher.stop()
+        self.mock_petname.stop()
 
     def test_finish_w_controller(self):
         "clouds.finish with an existing controller"
         self.mock_gcc.return_value = 'testcontroller'
+        self.mock_petname.Name.return_value = 'moo'
         self.controller.finish('testcloud')
-        self.mock_juju.assert_has_calls([
-            ANY,
-            ANY,
-            call.add_model(ANY, 'testcontroller')])
+        self.mock_juju.add_model.assert_called_once_with('moo',
+                                                         'testcontroller')
 
     def test_finish_no_controller(self):
         "clouds.finish without existing controller"

--- a/test/test_controllers_clouds_gui.py
+++ b/test/test_controllers_clouds_gui.py
@@ -6,7 +6,7 @@
 
 
 import unittest
-from unittest.mock import MagicMock, call, patch
+from unittest.mock import ANY, MagicMock, call, patch
 
 from conjureup.controllers.clouds.gui import CloudsController
 
@@ -91,7 +91,9 @@ class CloudsGUIFinishTestCase(unittest.TestCase):
         self.mock_gcc.return_value = 'testcontroller'
         self.controller.finish('testcloud')
         self.mock_juju.assert_has_calls([
-            call.switch_controller('testcontroller')])
+            ANY,
+            ANY,
+            call.add_model(ANY, 'testcontroller')])
 
     def test_finish_no_controller(self):
         "clouds.finish without existing controller"

--- a/test/test_controllers_clouds_tui.py
+++ b/test/test_controllers_clouds_tui.py
@@ -6,7 +6,7 @@
 
 
 import unittest
-from unittest.mock import MagicMock, call, patch
+from unittest.mock import ANY, MagicMock, call, patch
 
 from conjureup.controllers.clouds.tui import CloudsController
 
@@ -94,7 +94,7 @@ class CloudsTUIFinishTestCase(unittest.TestCase):
         self.mock_gcc.return_value = 'testcontroller'
         self.controller.finish()
         self.mock_juju.assert_has_calls([
-            call.switch_controller('testcontroller')])
+            call.add_model(ANY, 'testcontroller')])
 
     def test_finish_no_controller(self):
         "clouds.finish without existing controller"


### PR DESCRIPTION
Gives the ability to run multiple conjure-up installs, allows the user
to switch controllers/models without interupting the current conjure-up
deployment, basically isolating each deployment.

Signed-off-by: Adam Stokes <battlemidget@users.noreply.github.com>