### PR TITLE
Fix bootstrap error in newcloud/gui

### DIFF
--- a/conjureup/controllers/newcloud/gui.py
+++ b/conjureup/controllers/newcloud/gui.py
@@ -142,6 +142,9 @@ class NewCloudController:
         if app.current_controller is None:
             app.current_controller = petname.Name()
 
+        if app.current_model is None:
+            app.current_model = 'default'
+
         # LXD is a special case as we want to make sure a bridge
         # is configured. If not we'll bring up a new view to allow
         # a user to configure a LXD bridge with suggested network


### PR DESCRIPTION
In our TUI we were setting the app.current_model = 'default' it just
didn't carry over to the gui portion. This fixes that and a quick run
through a single bootstrap via conjure-up works as expected

Signed-off-by: Adam Stokes <battlemidget@users.noreply.github.com>