### PR TITLE
Explicitly specify series in deploys

### DIFF
--- a/conjureup/controllers/deploy/gui.py
+++ b/conjureup/controllers/deploy/gui.py
@@ -89,6 +89,7 @@ class DeployController:
             app.ui.set_footer(*args)
 
         juju.deploy_service(application,
+                            app.metadata_controller.series,
                             msg_cb=msg_both,
                             exc_cb=partial(self._handle_exception, "ED"))
 
@@ -96,6 +97,7 @@ class DeployController:
         "deploys all un-deployed applications"
         for application in self.undeployed_applications:
             juju.deploy_service(application,
+                                app.metadata_controller.series,
                                 app.ui.set_footer,
                                 partial(self._handle_exception, "ED"))
 

--- a/conjureup/controllers/deploy/tui.py
+++ b/conjureup/controllers/deploy/tui.py
@@ -57,7 +57,9 @@ class DeployController:
         """ handles deployment
         """
         for service in self.applications:
-            juju.deploy_service(service, utils.info,
+            juju.deploy_service(service,
+                                app.metadata_controller.series,
+                                utils.info,
                                 partial(self.__handle_exception, "ED"))
 
         f = juju.set_relations(self.applications,

--- a/conjureup/juju.py
+++ b/conjureup/juju.py
@@ -346,11 +346,14 @@ def add_machines(machines, msg_cb=None, exc_cb=None):
                         queue_name=JUJU_ASYNC_QUEUE)
 
 
-def deploy_service(service, msg_cb=None, exc_cb=None):
+def deploy_service(service, default_series, msg_cb=None, exc_cb=None):
     """Juju deploy service.
 
     If the service's charm ID doesn't have a revno, will query charm
-    store to get latest revno for the charm
+    store to get latest revno for the charm.
+
+    If the service's charm ID has a series, use that, otherwise use
+    the provided default series.
 
     Arguments:
     service: Service to deploy
@@ -364,6 +367,8 @@ def deploy_service(service, msg_cb=None, exc_cb=None):
 
     @requires_login
     def _deploy_async():
+        if service.csid.series == "":
+            service.csid.series = default_series
         if service.csid.rev == "":
             id_no_rev = service.csid.as_str_without_rev()
             mc = app.metadata_controller


### PR DESCRIPTION
Use series in charm ID if it's there, otherwise set the series in the
charm ID based on the bundle's series.

Signed-off-by: Michael McCracken <mike.mccracken@canonical.com>