### PR TITLE
Series fixes

### DIFF
--- a/bundleplacer/charmstore_api.py
+++ b/bundleplacer/charmstore_api.py
@@ -28,7 +28,7 @@ from bundleplacer.relationtype import RelationType
 
 class CharmStoreID:
 
-    def __init__(self, id_string):
+    def __init__(self, id_string, use_default_series=False):
         if id_string.startswith("cs:"):
             id_string = id_string[3:]
         cs = id_string.split('/')
@@ -37,11 +37,17 @@ class CharmStoreID:
         self.owner = ""
 
         if len(cs) == 1:
-            self.series = DEFAULT_SERIES
+            if use_default_series:
+                self.series = DEFAULT_SERIES
             self.name, self.rev = self.parse_namerev(cs[0])
 
         elif len(cs) == 2:
-            self.series = cs[0]
+            if cs[0].startswith("~"):
+                if use_default_series:
+                    self.series = DEFAULT_SERIES
+                self.owner = cs[0][1:]
+            else:
+                self.series = cs[0]
             self.name, self.rev = self.parse_namerev(cs[1])
 
         elif len(cs) == 3:

--- a/conjureup/juju.py
+++ b/conjureup/juju.py
@@ -403,7 +403,9 @@ def deploy_service(service, default_series, msg_cb=None, exc_cb=None):
                 application_to_resource_map[resource['Name']] = pid
             service.resources = application_to_resource_map
 
-        app_params = {"applications": [service.as_deployargs()]}
+        deploy_args = service.as_deployargs()
+        deploy_args['series'] = service.csid.series
+        app_params = {"applications": [deploy_args]}
 
         app.log.debug("Deploying {}: {}".format(service, app_params))
 

--- a/conjureup/juju.py
+++ b/conjureup/juju.py
@@ -328,10 +328,11 @@ def add_machines(machines, msg_cb=None, exc_cb=None):
                                m.get('constraints', "")),
                            "jobs": ["JobHostUnits"]}
                           for m in machines]
-        app.log.debug(machine_params)
+        app.log.debug("AddMachines: {}".format(machine_params))
         try:
             machine_response = this.CLIENT.Client(
                 request="AddMachines", params={"params": machine_params})
+            app.log.debug("AddMachines returned {}".format(machine_response))
         except Exception as e:
             if exc_cb:
                 exc_cb(e)
@@ -377,8 +378,10 @@ def deploy_service(service, default_series, msg_cb=None, exc_cb=None):
             service.csid = CharmStoreID(info["Id"])
 
         # Add charm to Juju
-        this.CLIENT.Client(request="AddCharm",
-                           params={"url": service.csid.as_str()})
+        app.log.debug("Adding Charm {}".format(service.csid.as_str()))
+        rv = this.CLIENT.Client(request="AddCharm",
+                                params={"url": service.csid.as_str()})
+        app.log.debug("AddCharm returned {}".format(rv))
 
         # We must load any resources prior to deploying
         resources = app.metadata_controller.get_resources(
@@ -388,11 +391,12 @@ def deploy_service(service, default_series, msg_cb=None, exc_cb=None):
             params = {"tag": "application-{}".format(service.csid.name),
                       "url": service.csid.as_str(),
                       "resources": resources}
-            app.log.debug("Adding pending resources: {}".format(params))
+            app.log.debug("AddPendingResources: {}".format(params))
             resource_ids = this.CLIENT.Resources(
                 request="AddPendingResources",
                 params=params)
-            app.log.debug("Pending resources IDs: {}".format(resource_ids))
+            app.log.debug("AddPendingResources returned: {}".format(
+                resource_ids))
             application_to_resource_map = {}
             for idx, resource in enumerate(resources):
                 pid = resource_ids['pending-ids'][idx]
@@ -407,8 +411,9 @@ def deploy_service(service, default_series, msg_cb=None, exc_cb=None):
             service.service_name)
         if msg_cb:
             msg_cb("{}".format(deploy_message))
-        this.CLIENT.Application(request="Deploy",
-                                params=app_params)
+        rv = this.CLIENT.Application(request="Deploy",
+                                     params=app_params)
+        app.log.debug("Deploy returned {}".format(rv))
         if msg_cb:
             msg_cb("{} deployed.".format(service.service_name))
 
@@ -439,8 +444,10 @@ def set_relations(services, msg_cb=None, exc_cb=None):
         for a, b in list(relations):
             params = {"Endpoints": [a, b]}
             try:
-                this.CLIENT.Application(request="AddRelation",
-                                        params=params)
+                app.log.debug("AddRelation: {}".format(params))
+                rv = this.CLIENT.Application(request="AddRelation",
+                                             params=params)
+                app.log.debug("AddRelation returned: {}".format(rv))
             except Exception as e:
                 if exc_cb:
                     exc_cb(e)


### PR DESCRIPTION
Should fix the issue in conjure-up/spells#3 where canonical-kubernetes was not deploying correctly.

This is probably best viewed commit by commit.

1. Some of the debug logging that I added to diagnose this is worth leaving in for future use, so I've done that.
2. I reuse the code from @battlemidget in conjure-up/spells#3 to set the series in every charm deploy call
3. I sync a bug fix from bundleplacer where charm IDs were being parsed incorrectly - that code had apparently never been run on a charm ID that had an owner but no series, like `~containers/easyrsa-2`. It was returning the series as `~containers` in that case. Further, the default series in bundleplacer was 'trusty', but it appears that for juju 2.0, we don't need a default series, so I've hidden that behavior in bundleplacer.