### PR TITLE
Fixes #451

### DIFF
--- a/conjureup/app.py
+++ b/conjureup/app.py
@@ -98,6 +98,16 @@ def _start(*args, **kwargs):
     utils.setup_metadata_controller()
 
     if os.getenv('CONJUREUP_STATUS_ONLY'):
+        # Developer tool only
+        # format is: CONJUREUP_STATUS_ONLY=1/<controller>/<model>
+        try:
+            _, controller, model = os.getenv(
+                'CONJUREUP_STATUS_ONLY').split('/')
+            app.current_controller = controller
+            app.current_model = model
+        except ValueError:
+            utils.error("Unable to parse the controller and model to access")
+            sys.exit(1)
         controllers.use('deploystatus').render()
         return
 

--- a/conjureup/controllers/steps/common.py
+++ b/conjureup/controllers/steps/common.py
@@ -11,9 +11,14 @@ def set_env(inputs):
     """ Sets the application environment with the key/value from the steps
     input so they can be made available in the step shell scripts
     """
+    app.log.debug("Set_env inputs: {}".format(inputs))
     for i in inputs:
         env_key = i['key'].upper()
-        app.env[env_key] = i['input']
+        try:
+            input_key = i['input']
+        except KeyError:
+            input_key = i.get('default', '')
+        app.env[env_key] = input_key
         app.log.debug("Setting environment var: {}={}".format(
             env_key,
             app.env[env_key]))
@@ -65,10 +70,8 @@ def do_step(step_model, step_widget, message_cb, gui=False):
     # exposed in future processing tasks
     app.env['JUJU_PROVIDERTYPE'] = info['provider-type']
 
-    if gui:
-        # These environment variables must be set on the CLI or exported
-        # in shell
-        set_env(step_model.additional_input)
+    # Set environment variables so they can be accessed from the step scripts
+    set_env(step_model.additional_input)
 
     if not os.access(step_model.path, os.X_OK):
         app.log.error("Step {} not executable".format(step_model.path))


### PR DESCRIPTION
We only checked for if running in a gui because we were pulling a new
key into the action 'input' which is the text input box in the
additional input. However, in headless mode we that 'input' key doesn't
exist so we need to at very least check for default or just return an
empty string.

Driveby fixes status only, it was broken because of how we login to the
controllers now rather than switching to each one.

Signed-off-by: Adam Stokes <battlemidget@users.noreply.github.com>