### PR TITLE
Fixes #454

### DIFF
--- a/conjureup/app.py
+++ b/conjureup/app.py
@@ -206,14 +206,17 @@ def main():
     spells_dir = app.argv.spells_dir
 
     app.config['spells-dir'] = spells_dir
+    spells_registry_branch = os.getenv('CONJUREUP_REGISTRY_BRANCH', 'master')
     if not os.path.exists(spells_dir):
         utils.info("No spells found, syncing from registry, please wait.")
-        download_or_sync_registry(app.global_config['registry']['repo'],
-                                  spells_dir)
+        download_or_sync_registry(
+            app.global_config['registry']['repo'],
+            spells_dir, branch=spells_registry_branch)
     else:
         app.log.debug("Refreshing spell registry")
-        download_or_sync_registry(app.global_config['registry']['repo'],
-                                  spells_dir, True)
+        download_or_sync_registry(
+            app.global_config['registry']['repo'],
+            spells_dir, update=True, branch=spells_registry_branch)
 
     spells_index_path = os.path.join(app.config['spells-dir'],
                                      'spells-index.yaml')

--- a/conjureup/download.py
+++ b/conjureup/download.py
@@ -156,21 +156,31 @@ def get_remote_url(path):
     return None
 
 
-def download_or_sync_registry(remote_registry, spells_dir, update=False):
+def download_or_sync_registry(remote_registry, spells_dir,
+                              update=False, branch='master'):
     """ If first time run this git clones the spell registry, otherwise
     will pull the latest spells down.
+
+    To specify a different branch to use you must set the environment variable
+    CONJUREUP_REGISTRY_BRANCH=<branchname>. This should be used for testing
+    new spells before they make it into the master branch.
 
     Arguments:
     remote_registry: git location of spells registry
     spells_dir: cache location of local spells directory
+    update: update the source directory
+    branch: switch to branch
 
     Returns:
     True if successful, False otherwise
     """
     if not os.path.exists(spells_dir):
-        run("git clone -q --depth 1 {} {}".format(remote_registry, spells_dir),
+        run("git clone -q --depth 1 --no-single-branch {} {}".format(
+            remote_registry, spells_dir),
             shell=True, check=True)
     if os.path.exists(spells_dir) and update:
         run("cd {} && git pull -q".format(spells_dir),
             shell=True, check=True)
+    run("cd {} && git checkout -q {}".format(spells_dir, branch),
+        shell=True)
     return False


### PR DESCRIPTION
Allows us to specify a remote branch when testing new spells prior to
them being merged into master.

Signed-off-by: Adam Stokes <battlemidget@users.noreply.github.com>