### PR TITLE
Fix metadata lookup due to series being left unset.

### DIFF
--- a/bundleplacer/bundle.py
+++ b/bundleplacer/bundle.py
@@ -206,8 +206,11 @@ class Bundle:
         relations = self._bundle.get('relations', [])
         for servicename, sd in bundle_services.items():
             sm = metadata.get(servicename, {})
-            services.append(create_service(servicename, sd,
-                                           sm, relations))
+            service = create_service(servicename, sd,
+                                     sm, relations)
+            if service.csid.series == "":
+                service.csid.series = self.series
+            services.append(service)
         return services
 
     @property

--- a/bundleplacer/service.py
+++ b/bundleplacer/service.py
@@ -90,7 +90,6 @@ class Service:
         rd = {"charm-url": self.csid.as_str(),
               "application": self.service_name,
               "num-units": self.num_units,
-              "expose": self.expose,
               "constraints": self.constraints}
 
         if self.resources:

--- a/conjureup/juju.py
+++ b/conjureup/juju.py
@@ -368,8 +368,7 @@ def deploy_service(service, default_series, msg_cb=None, exc_cb=None):
 
     @requires_login
     def _deploy_async():
-        if service.csid.series == "":
-            service.csid.series = default_series
+
         if service.csid.rev == "":
             id_no_rev = service.csid.as_str_without_rev()
             mc = app.metadata_controller


### PR DESCRIPTION
bundleplacer sync in the first commit is just housekeeping, it was part of a fix that ended up not being necessary.

second commit fixes #458:

"Always set series for services based on bundle:"

Earlier, we had been setting series based on a default of
'trusty' in the CharmStoreID class, which would be wrong in the case
where an ID didn't have the series and the bundle's series wasn't
'trusty'.

I fixed that and then fixed the resulting deploy bug by setting series in deploy_service() in juju.py
However, we also needed series to be set for metadata lookup. This commit removes the wrong fix in juju.py and does the right thing in bundle.py

Fixes #458.
