### PR TITLE
fix new-cloud path

### DIFF
--- a/conjureup/controllers/clouds/gui.py
+++ b/conjureup/controllers/clouds/gui.py
@@ -1,6 +1,4 @@
-import petname
-
-from conjureup import async, controllers, juju, utils
+from conjureup import controllers
 from conjureup.app_config import app
 from conjureup.controllers.clouds.common import list_clouds
 from conjureup.ui.views.cloud import CloudView
@@ -11,34 +9,19 @@ class CloudsController:
     def __init__(self):
         self.view = None
 
-    def __handle_exception(self, exc):
-        utils.pollinate(app.session_id, "E004")
-        app.ui.show_exception_message(exc)
-
-    def __add_model(self):
-        juju.add_model(app.current_model, app.current_controller)
-
     def finish(self, cloud):
-        """ Load the Model controller passing along the selected cloud.
+        """Show the 'newcloud' screen to enter credentials for a new
+        controller on 'cloud'.  There will not be an existing
+        controller.
 
         Arguments:
         cloud: Cloud to create the controller/model on.
+
         """
-        utils.pollinate(app.session_id, 'CS')
-        existing_controller = juju.get_controller_in_cloud(cloud)
-
-        if existing_controller is None:
-            return controllers.use('newcloud').render(cloud)
-
-        app.current_controller = existing_controller
-        app.current_model = petname.Name()
-        async.submit(self.__add_model,
-                     self.__handle_exception,
-                     queue_name=juju.JUJU_ASYNC_QUEUE)
-
-        return controllers.use('deploy').render()
+        return controllers.use('newcloud').render(cloud)
 
     def render(self):
+        "Pick or create a cloud to bootstrap a new controller on"
         clouds = list_clouds()
         excerpt = app.config.get(
             'description',

--- a/conjureup/controllers/controllerpicker/gui.py
+++ b/conjureup/controllers/controllerpicker/gui.py
@@ -18,10 +18,10 @@ class ControllerPicker:
         juju.add_model(app.current_model, app.current_controller)
 
     def finish(self, controller):
-        utils.pollinate(app.session_id, 'CS')
         if controller is None:
             return controllers.use('clouds').render()
 
+        utils.pollinate(app.session_id, 'CS')
         app.current_controller = controller
         app.current_model = petname.Name()
         async.submit(self.__add_model,

--- a/test/test_controllers_clouds_gui.py
+++ b/test/test_controllers_clouds_gui.py
@@ -16,10 +16,6 @@ class CloudsGUIRenderTestCase(unittest.TestCase):
     def setUp(self):
         self.controller = CloudsController()
 
-        self.utils_patcher = patch(
-            'conjureup.controllers.clouds.gui.utils')
-        self.mock_utils = self.utils_patcher.start()
-
         self.finish_patcher = patch(
             'conjureup.controllers.clouds.gui.CloudsController.finish')
         self.mock_finish = self.finish_patcher.start()
@@ -37,7 +33,6 @@ class CloudsGUIRenderTestCase(unittest.TestCase):
         self.mock_list_clouds.return_value = ['test1', 'test2']
 
     def tearDown(self):
-        self.utils_patcher.stop()
         self.finish_patcher.stop()
         self.view_patcher.stop()
         self.app_patcher.stop()
@@ -57,10 +52,6 @@ class CloudsGUIFinishTestCase(unittest.TestCase):
             'conjureup.controllers.clouds.gui.controllers')
         self.mock_controllers = self.controllers_patcher.start()
 
-        self.utils_patcher = patch(
-            'conjureup.controllers.clouds.gui.utils')
-        self.mock_utils = self.utils_patcher.start()
-
         self.render_patcher = patch(
             'conjureup.controllers.clouds.gui.CloudsController.render')
         self.mock_render = self.render_patcher.start()
@@ -70,38 +61,14 @@ class CloudsGUIFinishTestCase(unittest.TestCase):
         self.mock_app.ui = MagicMock(name="app.ui")
 
         self.cloudname = 'testcloudname'
-        self.juju_patcher = patch(
-            'conjureup.controllers.clouds.gui.juju')
-        self.mock_juju = self.juju_patcher.start()
-
-        self.gcc_patcher = patch(
-            'conjureup.controllers.clouds.gui.juju.get_controller_in_cloud')
-        self.mock_gcc = self.gcc_patcher.start()
-
-        self.petname_patcher = patch(
-            'conjureup.controllers.clouds.gui.petname')
-        self.mock_petname = self.petname_patcher.start()
 
     def tearDown(self):
         self.controllers_patcher.stop()
-        self.utils_patcher.stop()
         self.render_patcher.stop()
         self.app_patcher.stop()
-        self.juju_patcher.stop()
-        self.gcc_patcher.stop()
-        self.mock_petname.stop()
-
-    def test_finish_w_controller(self):
-        "clouds.finish with an existing controller"
-        self.mock_gcc.return_value = 'testcontroller'
-        self.mock_petname.Name.return_value = 'moo'
-        self.controller.finish('testcloud')
-        self.mock_juju.add_model.assert_called_once_with('moo',
-                                                         'testcontroller')
 
     def test_finish_no_controller(self):
         "clouds.finish without existing controller"
-        self.mock_gcc.return_value = None
         self.controller.finish('testcloud')
         self.mock_controllers.use.assert_has_calls([
             call('newcloud'), call().render('testcloud')])


### PR DESCRIPTION
Simplify clouds gui controller:

We no longer get here if there's an existing controller, so we don't
need to check for that.

We now only get here if the user chose 'create new' in the
controllerpicker.