### PR TITLE
Fix 462

### DIFF
--- a/conjureup/app.py
+++ b/conjureup/app.py
@@ -79,8 +79,12 @@ def parse_options(argv):
         '--version', action='version', version='%(prog)s {}'.format(VERSION))
 
     parser.add_argument('cloud', nargs='?',
-                        help="Name of a Juju controller type to "
-                        "target, such as ['aws', 'localhost' ...]")
+                        help="Name of a Juju cloud to "
+                        "target, such as ['aws', 'localhost' ...]. "
+                        "If no controller exists there, one may be created")
+    parser.add_argument('controller', nargs='?',
+                        help="Name of a juju controller to target. "
+                        "If not provided, a new one is created.")
     return parser.parse_args(argv)
 
 

--- a/conjureup/controllers/clouds/tui.py
+++ b/conjureup/controllers/clouds/tui.py
@@ -16,10 +16,20 @@ class CloudsController:
                 os.execl("/usr/share/conjure-up/run-lxd-config",
                          "/usr/share/conjure-up/run-lxd-config",
                          back)
+        if app.argv.controller:
+            existing_controller = app.argv.controller
+            if juju.get_controller(existing_controller) is None:
+                utils.error("Specified controller '{}' "
+                            "could not be found in cloud '{}'.".format(
+                                existing_controller, app.argv.cloud))
+                sys.exit(1)
+        else:
+            existing_controller = juju.get_controller_in_cloud(app.argv.cloud)
 
-        existing_controller = juju.get_controller_in_cloud(app.argv.cloud)
         if existing_controller is None:
             return controllers.use('newcloud').render(app.argv.cloud)
+
+        utils.info("Using controller '{}'".format(existing_controller))
 
         app.current_controller = existing_controller
         app.current_model = petname.Name()

--- a/conjureup/controllers/newcloud/tui.py
+++ b/conjureup/controllers/newcloud/tui.py
@@ -71,9 +71,18 @@ class NewCloudController:
                           "assuming LXD is configured.")
 
         utils.info("Bootstrapping Juju controller")
-        juju.bootstrap(controller=app.current_controller,
-                       cloud=self.cloud,
-                       credential=common.try_get_creds(self.cloud))
+        p = juju.bootstrap(controller=app.current_controller,
+                           cloud=self.cloud,
+                           credential=common.try_get_creds(self.cloud))
+        if p.returncode != 0:
+            pathbase = os.path.join(
+                app.config['spell-dir'],
+                '{}-bootstrap').format(app.current_controller)
+            with open(pathbase + ".err") as errf:
+                utils.error("Error bootstrapping controller: "
+                            "{}".format("".join(errf.readlines())))
+            sys.exit(1)
+
         self.do_post_bootstrap()
         self.finish()
 

--- a/test/test_controllers_clouds_tui.py
+++ b/test/test_controllers_clouds_tui.py
@@ -92,6 +92,7 @@ class CloudsTUIFinishTestCase(unittest.TestCase):
     def test_finish_w_controller(self):
         "clouds.finish with an existing controller"
         self.mock_gcc.return_value = 'testcontroller'
+        self.mock_app.argv.controller = None
         self.controller.finish()
         self.mock_juju.assert_has_calls([
             call.add_model(ANY, 'testcontroller')])
@@ -100,6 +101,7 @@ class CloudsTUIFinishTestCase(unittest.TestCase):
         "clouds.finish without existing controller"
         self.mock_gcc.return_value = None
         self.mock_app.argv.cloud = 'testcloud'
+        self.mock_app.argv.controller = None
         self.controller.finish()
         self.mock_controllers.use.assert_has_calls([
             call('newcloud'), call().render('testcloud')])

--- a/test/test_controllers_newcloud_tui.py
+++ b/test/test_controllers_newcloud_tui.py
@@ -48,18 +48,21 @@ class NewCloudTUIRenderTestCase(unittest.TestCase):
     def test_render_non_localhost_no_creds(self):
         "non-localhost cloud raises if no creds"
         self.mock_common.try_get_creds.return_value = False
+        self.mock_juju.bootstrap.return_value.returncode = 0
         with self.assertRaises(SystemExit):
             self.controller.render('testcloud')
 
     def test_render_non_localhost_with_creds(self):
         "non-localhost cloud ok if has creds"
         self.mock_common.try_get_creds.return_value = True
+        self.mock_juju.bootstrap.return_value.returncode = 0
         self.controller.render('testcloud')
         print(self.mock_common.mock_calls)
 
     def test_render(self):
         self.mock_common.try_get_creds.return_value = True
         self.mock_app.current_controller = sentinel.controllername
+        self.mock_juju.bootstrap.return_value.returncode = 0
         self.controller.render('localhost')
         self.mock_juju.bootstrap.assert_called_once_with(
             controller=sentinel.controllername,


### PR DESCRIPTION
Two changes:

1. add an arg to specify a controller within a cloud - Fixes #462.
2. check and show errors from bootstrap on TUI path

note that if you try to 'conjure-up spellname maas', it will complain that it doesn't know about maas. This is because we don't have a good way of passing the server name into maas. You need to bootstrap first, or just use the GUI to bootstrap onto a maas.