### PR TITLE
dont show result in footer

### DIFF
--- a/conjureup/controllers/steps/common.py
+++ b/conjureup/controllers/steps/common.py
@@ -100,7 +100,6 @@ def do_step(step_model, step_widget, message_cb, gui=False):
         raise Exception(result['message'])
 
     step_model.result = result['message']
-    message_cb("{} done, result: {}".format(step_model.title,
-                                            step_model.result))
+    message_cb("{} completed.".format(step_model.title))
 
     return (step_model, step_widget)


### PR DESCRIPTION
For one line results this works ok, but for things like kubernetes
cluster-info that displays multilines this makes the footer expand quite
a bit to display that. Remove the result output here as this is seen in
the summary view and just below the step output itself.

Signed-off-by: Adam Stokes <battlemidget@users.noreply.github.com>