### PR TITLE
Fixes and error handling

### DIFF
--- a/bundleplacer/charmstore_api.py
+++ b/bundleplacer/charmstore_api.py
@@ -297,7 +297,9 @@ class MetadataController:
             for r in resources:
                 r['Origin'] = 'store'
             return resources
-        return None
+        else:
+            raise Exception("API error getting resource info for "
+                            "charm={} url={}".format(charm, resource_url))
 
     def handle_search_error(self, e):
         self.error_cb(e)

--- a/conjureup/juju.py
+++ b/conjureup/juju.py
@@ -415,6 +415,12 @@ def deploy_service(service, default_series, msg_cb=None, exc_cb=None):
         rv = this.CLIENT.Application(request="Deploy",
                                      params=app_params)
         app.log.debug("Deploy returned {}".format(rv))
+
+        for result in rv.get('results', []):
+            if 'error' in result:
+                raise Exception("Error deploying: {}".format(
+                    result['error'].get('message', 'error')))
+
         if msg_cb:
             msg_cb("{}: deployed, installing.".format(service.service_name))
 

--- a/conjureup/juju.py
+++ b/conjureup/juju.py
@@ -376,16 +376,16 @@ def deploy_service(service, default_series, msg_cb=None, exc_cb=None):
             info = mc.get_charm_info(id_no_rev, lambda _: None)
             service.csid = CharmStoreID(info["Id"])
 
-        # Add charm to Juju
         app.log.debug("Adding Charm {}".format(service.csid.as_str()))
         rv = this.CLIENT.Client(request="AddCharm",
                                 params={"url": service.csid.as_str()})
         app.log.debug("AddCharm returned {}".format(rv))
 
-        # We must load any resources prior to deploying
-        resources = app.metadata_controller.get_resources(
-            service.csid.as_str_without_rev())
-        app.log.debug("Resources: {}".format(resources))
+        charm_id = service.csid.as_str()
+        resources = app.metadata_controller.get_resources(charm_id)
+
+        app.log.debug("Resources for charm id '{}': {}".format(charm_id,
+                                                               resources))
         if resources:
             params = {"tag": "application-{}".format(service.csid.name),
                       "url": service.csid.as_str(),


### PR DESCRIPTION
Ensures that errors in resource list getting and deploying stop the world and are shown quickly.

Fixes conjure-up/spells#8 by using full charm ID for getting resources, because the spell in question had a very old revno of zeppelin that didn't have any resources.