### PR TITLE
Group additional input items

### DIFF
--- a/conjureup/ui/widgets/step.py
+++ b/conjureup/ui/widgets/step.py
@@ -165,13 +165,13 @@ class StepWidget(WidgetWrap):
                 (Columns(column_input, dividechars=3),
                  self.step_pile.options()))
 
-            self.button = submit_btn(label="Run", on_press=self.submit)
-            self.step_pile.contents.append(
-                (Padding.right_20(
-                    Color.button_primary(self.button,
-                                         focus_map='button_primary focus')),
-                 self.step_pile.options()))
-            self.step_pile.contents.append((HR(), self.step_pile.options()))
+        self.button = submit_btn(label="Run", on_press=self.submit)
+        self.step_pile.contents.append(
+            (Padding.right_20(
+                Color.button_primary(self.button,
+                                     focus_map='button_primary focus')),
+             self.step_pile.options()))
+        self.step_pile.contents.append((HR(), self.step_pile.options()))
         self.step_pile.focus_position = self.current_button_index
 
     def submit(self, btn):


### PR DESCRIPTION
Previously we were setting a separate row for each additional input with
it's own button to press. This was unnecessary and just filled up the
view with additional widgets.

This groups additional input's with multiple input items and associates
a single [ Run ] button to process the inputs.

![image](https://cloud.githubusercontent.com/assets/51892/19534919/c4d57b12-9613-11e6-8f86-593fa0e94bb7.png)

You can test this with pulling this branch and running:

```
conjure-up battlemidget/conjure-up-test-spell
```

Signed-off-by: Adam Stokes <battlemidget@users.noreply.github.com>