### PR TITLE
Bundle centric placement

### DIFF
--- a/conjureup/controllers/deploy/gui.py
+++ b/conjureup/controllers/deploy/gui.py
@@ -1,13 +1,17 @@
 import json
 import os
+from collections import defaultdict
 from functools import partial
 from operator import attrgetter
 from subprocess import PIPE
+
+from bundleplacer.assignmenttype import atype_to_label
 
 from conjureup import async, controllers, juju, utils
 from conjureup.api.models import model_info
 from conjureup.app_config import app
 from conjureup.telemetry import track_event, track_exception, track_screen
+from conjureup.ui.views.app_architecture_view import AppArchitectureView
 from conjureup.ui.views.applicationconfigure import ApplicationConfigureView
 from conjureup.ui.views.applicationlist import ApplicationListView
 from ubuntui.ev import EventLoop
@@ -17,6 +21,8 @@ class DeployController:
 
     def __init__(self):
         self.applications = []
+        self.placements = defaultdict(list)
+        self.machine_id_map = {}
 
     def _handle_exception(self, tag, exc):
         track_exception(exc.args[0])
@@ -78,10 +84,82 @@ class DeployController:
         app.ui.set_header("Configure {}".format(application.service_name))
         app.ui.set_body(cv)
 
-    def handle_configure_done(self):
+    def do_placement(self, application, sender):
+        av = AppArchitectureView(application,
+                                 self)
+        app.ui.set_header("Architecture")
+        app.ui.set_body(av)
+
+    def add_placement(self, application, machine, atype):
+        self.placements[machine].append((application, atype))
+
+    def remove_placement(self, application, machine):
+        np = []
+        np = [(app, at) for app, at in self.placements[machine]
+              if app != application]
+        self.placements[machine] = np
+
+    def get_placements(self, application, machine):
+        return [(app, at) for app, at in self.placements[machine]
+                if app == application]
+
+    def get_all_placements(self, application):
+
+        app_placements = []
+        for machine, alist in self.placements.items():
+            for a, at in alist:
+                if a == application:
+                    app_placements.append((machine, at))
+        return app_placements
+
+    def clear_placements(self, application):
+        np = defaultdict(list)
+        for m, al in self.placements.items():
+            al = [(app, at) for app, at in al if app != application]
+            np[m] = al
+        self.placements = np
+
+    def handle_sub_view_done(self):
         app.ui.set_header(self.list_header)
         self.list_view.update()
         app.ui.set_body(self.list_view)
+
+    def ensure_machines(self, application, done_cb):
+        """add machines if required to fulfill placement directives
+
+        Only useful for maas clouds. others will have no placements
+        and this will be a noop.
+        """
+
+        # TODO: call tag_names if we haven't yet
+
+        new_machine_list = []
+        pending_machines = []
+        placements = self.get_all_placements(application)
+        for machine, _ in placements:
+            if machine not in self.machine_id_map:
+                pending_machines.append(machine)
+                machine_tag = machine.instance_id.split('/')[-2]
+                cons = "tags={}".format(machine_tag)
+                machine_attrs = {'series': application.csid.series,
+                                 'constraints': cons}
+                new_machine_list.append(machine_attrs)
+                f = juju.add_machines([machine_attrs])
+                result = f.result()
+                # TODO here update machine placement map
+                self.machine_id_map[machine] = 4747
+        done_cb()
+
+    def translate_machine_ids(self, application):
+        new_placements = []
+        for machine, at in self.get_all_placements(application):
+            label = atype_to_label(at)
+            plabel = ""
+            if label != "":
+                plabel += "{}".format(label)
+            plabel += str(self.machine_id_map[machine])
+            new_placements.append(plabel)
+        application.placement_spec = new_placements
 
     def do_deploy(self, application, msg_cb):
         "launches deploy in background for application"
@@ -91,18 +169,27 @@ class DeployController:
             msg_cb(*args)
             app.ui.set_footer(*args)
 
-        juju.deploy_service(application,
-                            app.metadata_controller.series,
-                            msg_cb=msg_both,
-                            exc_cb=partial(self._handle_exception, "ED"))
+        def _do_deploy():
+            self.translate_machine_ids(application)
+            juju.deploy_service(application,
+                                app.metadata_controller.series,
+                                msg_cb=msg_both,
+                                exc_cb=partial(self._handle_exception, "ED"))
+
+        self.ensure_machines(application, _do_deploy)
 
     def do_deploy_remaining(self):
         "deploys all un-deployed applications"
-        for application in self.undeployed_applications:
+        def _do_deploy(application):
+            self.translate_machine_ids(application)
             juju.deploy_service(application,
                                 app.metadata_controller.series,
                                 app.ui.set_footer,
                                 partial(self._handle_exception, "ED"))
+
+        for application in self.undeployed_applications:
+            self.ensure_machines(application,
+                                 partial(_do_deploy, application))
 
     def finish(self):
         juju.set_relations(self.applications,
@@ -124,6 +211,7 @@ class DeployController:
         except Exception as e:
             return self._handle_exception('E003', e)
 
+        #  TODO - maybe don't do this here for MAAS?
         juju.add_machines(
             list(app.metadata_controller.bundle.machines.values()),
             exc_cb=partial(self._handle_exception, "ED"))

--- a/conjureup/controllers/deploy/gui.py
+++ b/conjureup/controllers/deploy/gui.py
@@ -149,7 +149,7 @@ class DeployController:
         self.list_view.update()
         app.ui.set_body(self.list_view)
 
-    def set_machine_pin(self, juju_machine_id, maas_machine_id):
+    def set_machine_pin(self, juju_machine_id, maas_machine):
         """store the mapping between a juju machine and maas machine.
 
 
@@ -159,13 +159,14 @@ class DeployController:
         """
         bundle = app.metadata_controller.bundle
         juju_machine = bundle.machines[juju_machine_id]
-        tagstr = "tags={}".format(maas_machine_id)
+        tag = maas_machine.instance_id.split('/')[-2]
+        tagstr = "tags={}".format(tag)
         if 'constraints' in juju_machine:
             juju_machine['constraints'] += "," + tagstr
         else:
             juju_machine['constraints'] = tagstr
 
-        self.maas_machine_map[juju_machine_id] = maas_machine_id
+        self.maas_machine_map[juju_machine_id] = maas_machine
 
     def apply_assignments(self, application):
         new_assignments = []

--- a/conjureup/controllers/deploy/gui.py
+++ b/conjureup/controllers/deploy/gui.py
@@ -91,9 +91,6 @@ class DeployController:
         app.ui.set_body(cv)
 
     def do_architecture(self, application, sender):
-
-        # TODO - do we really always want to do this?
-
         # If no machines are specified, add a machine for each app:
         bundle = app.metadata_controller.bundle
         if len(bundle.machines) == 0:
@@ -133,7 +130,6 @@ class DeployController:
                 if app == application]
 
     def get_all_assignments(self, application):
-
         app_assignments = []
         for juju_machine_id, alist in self.assignments.items():
             for a, at in alist:
@@ -155,6 +151,7 @@ class DeployController:
 
     def set_machine_pin(self, juju_machine_id, maas_machine_id):
         """store the mapping between a juju machine and maas machine.
+
 
         Also ensure that the juju machine has constraints that
         uniquely id the maas machine
@@ -224,11 +221,6 @@ class DeployController:
             future.add_done_callback(self._pre_deploy_done)
         except Exception as e:
             return self._handle_exception('E003', e)
-
-        #  TODO - maybe don't do this here for MAAS?
-        # juju.add_machines(
-        #     list(app.metadata_controller.bundle.machines.values()),
-        #     exc_cb=partial(self._handle_exception, "ED"))
 
         self.applications = sorted(app.metadata_controller.bundle.services,
                                    key=attrgetter('service_name'))

--- a/conjureup/controllers/deploy/gui.py
+++ b/conjureup/controllers/deploy/gui.py
@@ -5,14 +5,13 @@ from functools import partial
 from operator import attrgetter
 from subprocess import PIPE
 
-from bundleplacer.assignmenttype import atype_to_label, AssignmentType
-
+from bundleplacer.assignmenttype import AssignmentType, atype_to_label
 from conjureup import async, controllers, juju, utils
 from conjureup.api.models import model_info
 from conjureup.app_config import app
+from conjureup.juju import get_controller_info
 from conjureup.maas import setup_maas
 from conjureup.telemetry import track_event, track_exception, track_screen
-from conjureup.juju import get_controller_info
 from conjureup.ui.views.app_architecture_view import AppArchitectureView
 from conjureup.ui.views.applicationconfigure import ApplicationConfigureView
 from conjureup.ui.views.applicationlist import ApplicationListView

--- a/conjureup/controllers/deploy/gui.py
+++ b/conjureup/controllers/deploy/gui.py
@@ -110,7 +110,8 @@ class DeployController:
         """
         bundle = app.metadata_controller.bundle
         midx = 0
-        for bundle_application in bundle.services:
+        for bundle_application in sorted(bundle.services,
+                                         key=attrgetter('service_name')):
             for n in range(bundle_application.num_units):
                 bundle.add_machine(dict(series=bundle.series),
                                    str(midx))

--- a/conjureup/controllers/newcloud/common.py
+++ b/conjureup/controllers/newcloud/common.py
@@ -75,21 +75,3 @@ def save_creds(cloud, credentials):
     with open(cred_path, 'w') as cred_f:
         cred_f.write(yaml.safe_dump(existing_creds,
                                     default_flow_style=False))
-
-
-def parse_maas_apikey(api_key):
-    """ Parses the api key and splitting it up accordingly
-
-    Arguments:
-    api_key: colon seperated maas apikey
-
-    Returns:
-    Tuple containing (consumer_secret, token_key, token_secret)
-    """
-    try:
-        consumer_secret, token_key, token_secret = api_key.split(':')
-    except Exception as e:
-        raise Exception(
-            "Problem parsing MAAS apikey, please verify it was "
-            "entered correctly: {}".format(e))
-    return consumer_secret, token_key, token_secret

--- a/conjureup/controllers/newcloud/gui.py
+++ b/conjureup/controllers/newcloud/gui.py
@@ -134,16 +134,7 @@ class NewCloudController:
         if self.cloud == 'maas':
             self.cloud = '{}/{}'.format(self.cloud,
                                         credentials['@maas-server'].value)
-            # Store the MAAS information for the api client
-            maas_api_key = common.parse_maas_apikey(
-                credentials['maas-oauth'].value)
-            app.maas.client = MaasClient(
-                server_address=credentials['@maas-server'].value,
-                consumer_key=maas_api_key[0],
-                token_key=maas_api_key[1],
-                token_secret=maas_api_key[2])
-        track_event("Credentials", "Added", "")
-
+        utils.pollinate(app.session_id, 'CA')
         self.__do_bootstrap(credential=credentials_key)
 
     def render(self, cloud):

--- a/conjureup/controllers/newcloud/gui.py
+++ b/conjureup/controllers/newcloud/gui.py
@@ -9,7 +9,6 @@ import petname
 from conjureup import async, controllers, juju, utils
 from conjureup.api.models import model_info
 from conjureup.app_config import app
-
 from conjureup.models.provider import Schema
 from conjureup.telemetry import track_event, track_exception, track_screen
 from conjureup.ui.views.newcloud import NewCloudView

--- a/conjureup/controllers/newcloud/gui.py
+++ b/conjureup/controllers/newcloud/gui.py
@@ -9,7 +9,7 @@ import petname
 from conjureup import async, controllers, juju, utils
 from conjureup.api.models import model_info
 from conjureup.app_config import app
-from conjureup.maas import MaasClient
+
 from conjureup.models.provider import Schema
 from conjureup.telemetry import track_event, track_exception, track_screen
 from conjureup.ui.views.newcloud import NewCloudView

--- a/conjureup/juju.py
+++ b/conjureup/juju.py
@@ -49,6 +49,17 @@ def read_config(name):
     return yaml.safe_load(open(abs_path))
 
 
+def get_bootstrap_config(controller_name):
+    bootstrap_config = read_config("bootstrap-config")
+    if 'controllers' not in bootstrap_config:
+        raise Exception("Could not read Juju's bootstrap-config.yaml")
+    cd = bootstrap_config['controllers'].get(controller_name, None)
+    if cd is None:
+        raise Exception("'{}' not found in Juju's "
+                        "bootstrap-config.yaml".format(controller_name))
+    return cd
+
+
 def get_current_controller():
     """ Grabs the current default controller
     """

--- a/conjureup/juju.py
+++ b/conjureup/juju.py
@@ -304,8 +304,10 @@ def constraints_to_dict(constraints):
                         if c != ""]
     for c in list_constraints:
         try:
-            constraint, constraint_value = c.split('=')
-            new_constraints[constraint] = constraint_value
+            constraint, value = c.split('=')
+            if constraint in ['tags', 'spaces']:
+                value = value.split(',')
+            new_constraints[constraint] = value
         except ValueError as e:
             app.log.debug("Skipping constraint: {} ({})".format(c, e))
     return new_constraints

--- a/conjureup/maas.py
+++ b/conjureup/maas.py
@@ -3,10 +3,18 @@
 
 import requests
 from requests_oauthlib import OAuth1
+from enum import Enum
+import time
+
+from conjureup.app_config import app
+from conjureup.async import submit
+from conjureup.units import human_to_mb
+from conjureup import juju
 
 
 class MaasClient:
     API_VERSION = '2.0'
+    CACHE = {}
 
     def __init__(self, server_address, consumer_key,
                  token_key, token_secret):
@@ -77,79 +85,319 @@ class MaasClient:
                                headers={'Accept': 'application/json'},
                                auth=self.oauth)
 
+    # Higher level API
+    def _get_machines_async(self):
+        r = self.get("/machines/")
+        if r.status_code != 200:
+            raise Exception("Error in MAAS API")
+        return [MaasMachine(d) for d in r.json()]
 
-class vocab(dict):
-    __slots__ = ()
+    def _update_machine_cache(self, future):
+        val = future.result()
+        self.CACHE['machines'] = (val, time.time())
 
-    def __getattr__(self, k):
-        try:
-            return self[k]
-        except KeyError:
-            return AttributeError(k)
+    def get_machines(self):
+        """cached API call, refreshes in background every 5 sec
 
-    def label(self, value):
-        for k, v in self.items():
-            if v == value:
-                return k
+        returns None on the first call so you know it's just loading
+        instead of an actual empty list of machines.
 
+        """
+        now = time.time()
+        c_val, c_ts = self.CACHE.get('machines', (None, now))
+        if c_val is None or now - c_ts > 5:
+            f = submit(self._get_machines_async,
+                       lambda _: None)
+            f.add_done_callback(self._update_machine_cache)
 
-MAAS_STATES = vocab(
-    DECLARED=0,
-    COMMISSIONING=1,
-    FAILED_TESTS=2,
-    MISSING=3,
-    READY=4,
-    RESERVED=5,
-    ALLOCATED=6,
-    RETIRED=7)
+        return c_val
 
 
-class Machine(dict):
+class MaasMachineStatus(Enum):
+    """Symbolic names for maas API status numbers.
 
-    __slots__ = ()
+    -1, UNKNOWN is never returned by maas API. It's used here to
+    denote a MaasMachine object that wasn't created from a Maas API
+    return.
+    """
+    UNKNOWN = -1
+    NEW = 0
+    COMMISSIONING = 1
+    FAILED_COMMISSIONING = 2
+    MISSING = 3
+    READY = 4
+    RESERVED = 5
+    # as of maas 1.7, state #s 6, and 9-15 are mapped
+    # onto 6 by the view that services the nodes/
+    # url. so we will only ever see '6' for any of
+    # these, until sometime in the future.
+    DEPLOYED = 6
+    RETIRED = 7
+    BROKEN = 8
+    DEPLOYING = 9  # see DEPLOYED
+    MAAS_1_7_ALLOCATED = 10  # the actual "ALLOCATED" state. see DEPLOYED
+    FAILED_DEPLOYMENT = 11  # see DEPLOYED.
+    RELEASING = 12
+    FAILED_RELEASING = 13
+    DISK_ERASING = 14
+    FAILED_DISK_ERASING = 15
+    ALLOCATED = 6  # for backward compatibility with internal uses
+
+    def __str__(self):
+        return self.name.lower()
+
+
+class MaasMachine:
+    """ Single maas machine """
+
+    def __init__(self, machine):
+        self.machine = machine
+
+    def __eq__(self, other):
+        return self.hostname == other.hostname
+
+    def __hash__(self):
+        return hash(self.hostname)
 
     @property
     def hostname(self):
-        return self['hostname']
+        """ Query hostname reported by MaaS
 
-    @property
-    def arch(self):
-        return self['architecture']
+        :returns: hostname
+        :rtype: str
+        """
+        return self.machine.get('hostname', '')
 
     @property
     def status(self):
-        return self['status']
+        """ Status of machine state
+
+        :returns: status enum
+        :rtype: MaasMachineStatus
+        """
+        return MaasMachineStatus(self.machine.get('status',
+                                                  MaasMachineStatus.UNKNOWN))
+
+    @property
+    def zone(self):
+        """ Zone information
+
+        :returns: zone information
+        :rtype: dict
+        """
+        return self.machine.get('zone', {})
 
     @property
     def cpu_cores(self):
-        return self['cpu_count']
+        """ Returns number of cpu-cores
+
+        :returns: number of cpus
+        :rtype: str
+        """
+        return self.machine.get('cpu_count', '0')
+
+    @property
+    def storage(self):
+        """ Return storage
+
+        :returns: storage size
+        :rtype: str
+        """
+        try:
+            _storage_in_gb = float(self.machine.get('storage')) / 1024
+        except ValueError:
+            return "N/A"
+        return "{size:.1f} G".format(size=_storage_in_gb)
+
+    @property
+    def arch(self):
+        """ Return architecture
+
+        :returns: architecture type
+        :rtype: str
+        """
+        return self.machine.get('architecture')
 
     @property
     def mem(self):
-        """ Size Memory in mb"""
-        return self['memory']
+        """ Return memory
+
+        :returns: memory size
+        :rtype: str
+        """
+        try:
+            _mem = float(self.machine.get('memory'))
+        except ValueError:
+            return "N/A"
+        if _mem > 1024:
+            _mem = _mem / 1024
+            return "{:.1f} G".format(_mem)
+        else:
+            return "{:.1f} M".format(_mem)
 
     @property
-    def disk(self):
-        """ Size root disk in gb"""
-        return self['storage']
+    def power_type(self):
+        """ Machine power type
+
+        :returns: machines power type
+        :rtype: str
+        """
+        return self.machine.get('power_type', 'None')
+
+    @property
+    def instance_id(self):
+        """ Returns instance-id of a machine
+
+        :returns: instance-id of machine
+        :rtype: str
+        """
+        return self.machine.get('resource_uri', '')
 
     @property
     def system_id(self):
-        return self['system_id']
+        """ Returns system id of a maas machine
 
-    @property
-    def tags(self):
-        return self.get('tags', [])
+        :returns: system id of machine
+        :rtype: str
+        """
+        return self.machine.get('system_id', '')
 
     @property
     def ip_addresses(self):
-        return self['ip_addresses']
+        """ Ip addresses for machine
+
+        :returns: ip addresses
+        :rtype: list
+        """
+        return self.machine.get('ip_addresses', [])
 
     @property
-    def mac_addresses(self):
-        return [m['mac_address'] for m in self.get('macaddress_set', [])]
+    def macaddress_set(self):
+        """ Macaddress set of maas machine
+
+        :returns: list of dict(mac_address, resource_uri)
+        :rtype: list
+        """
+        return self.machine.get('macaddress_set', [])
 
     @property
-    def status_label(self):
-        return MAAS_STATES.label(self.status)
+    def tag_names(self):
+        """ Tag names for machine
+
+        :returns: tags associated with machine
+        :rtype: list
+        """
+        return self.machine.get('tag_names', [])
+
+    @property
+    def tag(self):
+        """ Machine tag
+
+        :returns: tag defined
+        :rtype: str
+        """
+        return self.machine.get('tag', '')
+
+    @property
+    def owner(self):
+        """ Machine owner
+
+        :returns: owner
+        :rtype: str
+        """
+        return self.machine.get('owner', 'root')
+
+    def __repr__(self):
+        return "<MaasMachine({dns_name},{mem}," \
+            "{storage},{cpus})>".format(dns_name=self.hostname,
+                                        mem=self.mem,
+                                        storage=self.storage,
+                                        cpus=self.cpu_cores)
+
+    def __str__(self):
+        return repr(self)
+
+    def filter_label(self):
+        d = dict(dns_name=self.hostname,
+                 arch=self.arch,
+                 tag=self.tag,
+                 mem=self.mem,
+                 storage=self.storage,
+                 cpus=self.cpu_cores)
+        return ("hostname:{dns_name} tag:{tag} mem:{mem} arch:{arch}"
+                "storage:{storage} cores:{cpus}").format(**d)
+
+
+def setup_maas():
+    try:
+        maascreds = juju.get_credentials()['maas'][app.current_controller]
+    except KeyError:
+        raise Exception("Could not get credentials for "
+                        "maas controller {}".format(app.current_controller))
+
+    bc = juju.get_bootstrap_config(app.current_controller)
+    endpoint = bc.get('endpoint', None)
+    if endpoint is None:
+        raise Exception("Couldn't find endpoint for controller".format(
+            app.current_controller))
+
+    api_key = maascreds['maas-oauth']
+    try:
+        consumer_key, token_key, token_secret = api_key.split(':')
+    except:
+        raise Exception("Could not parse MAAS API Key '{}'".format(api_key))
+
+    app.maas.client = MaasClient(server_address=endpoint,
+                                 consumer_key=consumer_key,
+                                 token_key=token_key,
+                                 token_secret=token_secret)
+
+
+def satisfies(machine, constraints):
+    """Evaluates whether a MAAS machine's hardware matches constraints.
+
+    If constraints is None or an empty dict, then any machine will be
+    evaluated as satisfying the constraints.
+
+    .. note::
+
+        That if a machine has '*' as a value, that value satisfies
+        any constraint.
+
+    If successful the return will be (True, [])
+
+    :rtype: tuple
+    :returns: (bool, [list-of-failed constraint keys])
+
+    """
+    kmap = dict(mem='memory',
+                arch='architecture',
+                storage='storage',
+                cpu_cores='cpu_count')
+    kmap['root-disk'] = 'storage'
+
+    cons_checks = []
+
+    if constraints is None:
+        return (True, [])
+
+    for k, v in constraints.items():
+        if k == 'arch':
+            mval = machine.machine[kmap[k]]
+            if mval != '*' and mval != v:
+                cons_checks.append(k)
+        else:
+            mval = machine.machine[kmap[k]]
+
+            if mval == '*':
+                # '*' always satisfies.
+                continue
+
+            if not str(v).isdecimal():
+                v = human_to_mb(v)
+
+            if mval < v:
+                cons_checks.append(k)
+
+    rval = (len(cons_checks) == 0), cons_checks
+    return rval

--- a/conjureup/maas.py
+++ b/conjureup/maas.py
@@ -1,16 +1,17 @@
 """ simple maas client
 """
 
+import time
+from enum import Enum
 from functools import partial
+
 import requests
 from requests_oauthlib import OAuth1
-from enum import Enum
-import time
 
+from conjureup import juju
 from conjureup.app_config import app
 from conjureup.async import submit
 from conjureup.units import human_to_mb
-from conjureup import juju
 
 
 class MaasClient:

--- a/conjureup/maas.py
+++ b/conjureup/maas.py
@@ -112,6 +112,46 @@ class MaasClient:
 
         return c_val
 
+    def tag_new(self, tag):
+        """ Create tag if it doesn't exist.
+
+        :param tag: Tag name
+        :returns: Success/Fail boolean
+        """
+        tags = {tagmd['name'] for tagmd in self.tags}
+        if tag not in tags:
+            res = self.post('/tags/', dict(op='new', name=tag))
+            return res.ok
+        return False
+
+    def tag_machine(self, tag, system_id):
+        """ Tag the machine with the specified tag.
+
+        :param tag: Tag name
+        :type tag: str
+        :param system_id: ID of node
+        :type system_id: str
+        :returns: Success or Fail
+        :rtype: bool
+        """
+
+        res = self.post('/tags/%s/' % (tag,),
+                        dict(op='update_nodes',
+                             add=system_id))
+        if res.ok:
+            return True
+        return False
+
+    def assign_id_tags(self, nodes):
+        """ Tag each managed node with its unique system id
+        """
+        for machine in nodes:
+            system_id = machine['system_id']
+            if 'tag_names' not in machine['tag_names'] or \
+               system_id not in machine['tag_names']:
+                self.tag_new(system_id)
+                self.tag_machine(system_id, system_id)
+
 
 class MaasMachineStatus(Enum):
     """Symbolic names for maas API status numbers.

--- a/conjureup/ui/views/app_architecture_view.py
+++ b/conjureup/ui/views/app_architecture_view.py
@@ -1,0 +1,132 @@
+""" Application Architecture / Machine Placement View
+
+"""
+import logging
+
+import q
+from urwid import Columns, Filler, Frame, Pile, Text, WidgetWrap
+
+from conjureup.ui.widgets.machines_list import MachinesList
+
+from ubuntui.ev import EventLoop
+from ubuntui.utils import Color, Padding
+from ubuntui.widgets.buttons import menu_btn
+from ubuntui.widgets.hr import HR
+
+log = logging.getLogger('conjure')
+
+
+class AppArchitectureView(WidgetWrap):
+
+    def __init__(self, application, controller):
+        self.controller = controller
+        self.application = application
+        self._assignments = []
+
+        self.alarm = None
+        self.widgets = self.build_widgets()
+        self.description_w = Text("")
+        self.buttons_selected = False
+        self.frame = Frame(body=self.build_widgets(),
+                           footer=self.build_footer())
+        super().__init__(self.frame)
+        self.update()
+
+    def selectable(self):
+        return True
+
+    def keypress(self, size, key):
+        # handle keypress first, then get new focus widget
+        rv = super().keypress(size, key)
+        if key in ['tab', 'shift tab']:
+            self._swap_focus()
+        return rv
+
+    def _swap_focus(self):
+        if not self.buttons_selected:
+            self.buttons_selected = True
+            self.frame.focus_position = 'footer'
+            self.buttons.focus_position = 3
+        else:
+            self.buttons_selected = False
+            self.frame.focus_position = 'body'
+
+    def build_widgets(self):
+        ws = [Text("Choose where to place {} unit{} of {}".format(
+            self.application.num_units,
+            "" if self.application.num_units == 1 else "s",
+            self.application.service_name))]
+
+        self.machines_list = MachinesList(self.application,
+                                          self.do_select,
+                                          self.do_unselect,
+                                          self.controller,
+                                          show_only_ready=True,
+                                          show_filter_box=True)
+        ws.append(self.machines_list)
+
+        self.pile = Pile(ws)
+        return Padding.center_90(Filler(self.pile, valign="top"))
+
+    def build_footer(self):
+        cancel = menu_btn(on_press=self.do_cancel,
+                          label="\n  BACK\n")
+        self.apply_button = menu_btn(on_press=self.do_commit,
+                                     label="\n APPLY\n")
+        self.buttons = Columns([
+            ('fixed', 2, Text("")),
+            ('fixed', 13, Color.menu_button(
+                cancel,
+                focus_map='button_primary focus')),
+            Text(""),
+            ('fixed', 20, Color.menu_button(
+                self.apply_button,
+                focus_map='button_primary focus')),
+            ('fixed', 2, Text(""))
+        ])
+
+        footer = Pile([
+            HR(top=0),
+            Padding.center_90(self.description_w),
+            Padding.line_break(""),
+            Color.frame_footer(Pile([
+                Padding.line_break(""),
+                self.buttons]))
+        ])
+
+        return footer
+
+    def update_now(self, *args):
+        if len(self._assignments) == self.application.num_units:
+            self.machines_list.all_assigned = True
+        else:
+            self.machines_list.all_assigned = False
+        self.machines_list.update()
+
+    def update(self, *args):
+        self.update_now()
+        self.alarm = EventLoop.set_alarm_in(1, self.update)
+
+    def do_select(self, machine, assignment_type):
+        self._assignments.append((machine,
+                                  assignment_type))
+        self.update_now()
+
+    def do_unselect(self, machine):
+        self._assignments = [(m, a) for (m, a) in self._assignments
+                             if m != machine]
+        self.update_now()
+
+    def do_cancel(self, sender):
+        self.controller.handle_sub_view_done()
+        if self.alarm:
+            EventLoop.remove_alarm(self.alarm)
+
+    def do_commit(self, sender):
+        self.controller.clear_placements(self.application)
+        for machine, atype in self._assignments:
+            self.controller.add_placement(self.application, machine, atype)
+
+        self.controller.handle_sub_view_done()
+        if self.alarm:
+            EventLoop.remove_alarm(self.alarm)

--- a/conjureup/ui/views/app_architecture_view.py
+++ b/conjureup/ui/views/app_architecture_view.py
@@ -59,6 +59,10 @@ class AppArchitectureView(WidgetWrap):
     def selectable(self):
         return True
 
+    def __repr__(self):
+        return "App Architecture View for {}".format(
+            self.application.service_name)
+
     def keypress(self, size, key):
         # handle keypress first, then get new focus widget
         rv = super().keypress(size, key)
@@ -184,6 +188,12 @@ class AppArchitectureView(WidgetWrap):
         return self.shadow_pins.get(juju_machine_id, None)
 
     get_pin = get_shadow_pin
+
+    def get_pin_for_maas_machine(self, maas_machine):
+        for j_id, m in self.shadow_pins.items():
+            if m == maas_machine:
+                return j_id
+        return None
 
     def show_pin_chooser(self, juju_machine_id):
         app.ui.set_header("Pin Machine {}".format(juju_machine_id))

--- a/conjureup/ui/views/app_architecture_view.py
+++ b/conjureup/ui/views/app_architecture_view.py
@@ -1,4 +1,3 @@
-import q
 """ Application Architecture View
 
 """
@@ -83,16 +82,17 @@ class AppArchitectureView(WidgetWrap):
             self.application.service_name))]
 
         controller_is_maas = self.controller.cloud_type == 'maas'
-        self.machines_list = JujuMachinesList(self.application,
-                                              self._machines,
-                                              self.do_assign,
-                                              self.do_unassign,
-                                              self.add_machine,
-                                              self.remove_machine,
-                                              self,
-                                              show_filter_box=True,
-                                              show_pins=controller_is_maas)
-        ws.append(self.machines_list)
+        self.juju_machines_list = JujuMachinesList(
+            self.application,
+            self._machines,
+            self.do_assign,
+            self.do_unassign,
+            self.add_machine,
+            self.remove_machine,
+            self,
+            show_filter_box=True,
+            show_pins=controller_is_maas)
+        ws.append(self.juju_machines_list)
 
         self.pile = Pile(ws)
         return Padding.center_90(Filler(self.pile, valign="top"))

--- a/conjureup/ui/views/app_architecture_view.py
+++ b/conjureup/ui/views/app_architecture_view.py
@@ -2,15 +2,14 @@
 
 """
 import copy
-from collections import defaultdict
 import logging
+from collections import defaultdict
 
 from urwid import Columns, Filler, Frame, Pile, Text, WidgetWrap
 
 from conjureup.app_config import app
-from conjureup.ui.widgets.juju_machines_list import JujuMachinesList
 from conjureup.ui.views.machine_pin_view import MachinePinView
-
+from conjureup.ui.widgets.juju_machines_list import JujuMachinesList
 from ubuntui.ev import EventLoop
 from ubuntui.utils import Color, Padding
 from ubuntui.widgets.buttons import menu_btn

--- a/conjureup/ui/views/app_architecture_view.py
+++ b/conjureup/ui/views/app_architecture_view.py
@@ -130,11 +130,12 @@ class AppArchitectureView(WidgetWrap):
             self.machine_pin_view.update()
             return
 
-        if len(self.shadow_assignments) == self.application.num_units:
-            self.machines_list.all_assigned = True
+        n_assigned = len(self.get_all_shadow_assignments(self.application))
+        if n_assigned == self.application.num_units:
+            self.juju_machines_list.all_assigned = True
         else:
-            self.machines_list.all_assigned = False
-        self.machines_list.update()
+            self.juju_machines_list.all_assigned = False
+        self.juju_machines_list.update()
 
     def update(self, *args):
         self.update_now()
@@ -164,6 +165,13 @@ class AppArchitectureView(WidgetWrap):
 
     def get_shadow_assignments(self, application, juju_machine_id):
         return self.shadow_assignments[juju_machine_id]
+
+    def get_all_shadow_assignments(self, application):
+        all_assignments = []
+        for j_m_id, al in self.shadow_assignments.items():
+            all_assignments += al
+        return [(a, at) for (a, at)
+                in all_assignments if a == application]
 
     def add_machine(self):
         md = dict(series=app.metadata_controller.bundle.series)

--- a/conjureup/ui/views/app_architecture_view.py
+++ b/conjureup/ui/views/app_architecture_view.py
@@ -1,12 +1,16 @@
-""" Application Architecture / Machine Placement View
+import q
+""" Application Architecture View
 
 """
+import copy
+from collections import defaultdict
 import logging
 
-import q
 from urwid import Columns, Filler, Frame, Pile, Text, WidgetWrap
 
-from conjureup.ui.widgets.machines_list import MachinesList
+from conjureup.app_config import app
+from conjureup.ui.widgets.juju_machines_list import JujuMachinesList
+from conjureup.ui.views.machine_pin_view import MachinePinView
 
 from ubuntui.ev import EventLoop
 from ubuntui.utils import Color, Padding
@@ -19,9 +23,30 @@ log = logging.getLogger('conjure')
 class AppArchitectureView(WidgetWrap):
 
     def __init__(self, application, controller):
+        """
+        application: a Service instance representing a juju application
+
+        controller: a DeployGUIController instance
+        """
         self.controller = controller
         self.application = application
-        self._assignments = []
+
+        self.header = "Architecture"
+        # Shadow means temporary to the view, they are committed to
+        # the controller if the user chooses OK
+
+        # {machine_id : [(app, assignmenttype) ...]
+        self.shadow_assignments = defaultdict(list)
+        for machine_id, al in self.controller.assignments.items():
+            for (a, at) in al:
+                if a == self.application:
+                    self.shadow_assignments[machine_id].append((a, at))
+
+        # {juju_machine_id : maas machine id}
+        self.shadow_pins = copy.copy(controller.maas_machine_map)
+        self.machine_pin_view = None
+
+        self._machines = app.metadata_controller.bundle.machines.copy()
 
         self.alarm = None
         self.widgets = self.build_widgets()
@@ -57,12 +82,16 @@ class AppArchitectureView(WidgetWrap):
             "" if self.application.num_units == 1 else "s",
             self.application.service_name))]
 
-        self.machines_list = MachinesList(self.application,
-                                          self.do_select,
-                                          self.do_unselect,
-                                          self.controller,
-                                          show_only_ready=True,
-                                          show_filter_box=True)
+        controller_is_maas = self.controller.cloud_type == 'maas'
+        self.machines_list = JujuMachinesList(self.application,
+                                              self._machines,
+                                              self.do_assign,
+                                              self.do_unassign,
+                                              self.add_machine,
+                                              self.remove_machine,
+                                              self,
+                                              show_filter_box=True,
+                                              show_pins=controller_is_maas)
         ws.append(self.machines_list)
 
         self.pile = Pile(ws)
@@ -97,7 +126,11 @@ class AppArchitectureView(WidgetWrap):
         return footer
 
     def update_now(self, *args):
-        if len(self._assignments) == self.application.num_units:
+        if self.machine_pin_view:
+            self.machine_pin_view.update()
+            return
+
+        if len(self.shadow_assignments) == self.application.num_units:
             self.machines_list.all_assigned = True
         else:
             self.machines_list.all_assigned = False
@@ -107,15 +140,63 @@ class AppArchitectureView(WidgetWrap):
         self.update_now()
         self.alarm = EventLoop.set_alarm_in(1, self.update)
 
-    def do_select(self, machine, assignment_type):
-        self._assignments.append((machine,
-                                  assignment_type))
+    def do_assign(self, juju_machine_id, assignment_type):
+        self.shadow_assignments[juju_machine_id].append((self.application,
+                                                         assignment_type))
         self.update_now()
 
-    def do_unselect(self, machine):
-        self._assignments = [(m, a) for (m, a) in self._assignments
-                             if m != machine]
+    def do_unassign(self, juju_machine_id):
+        self.shadow_assignments[juju_machine_id] = [
+            (a, at) for (a, at)
+            in self.shadow_assignments[juju_machine_id]
+            if a != self.application]
         self.update_now()
+
+    def get_all_assignments(self, juju_machine_id):
+        """merge committed assignments of other apps with shadow assignments
+        of this app
+        return list of tuples [(application, assignmenttype)]
+        """
+        all_assignments = [(a, at) for (a, at)
+                           in self.controller.assignments[juju_machine_id]
+                           if a != self.application]
+        return all_assignments + self.shadow_assignments[juju_machine_id]
+
+    def get_shadow_assignments(self, application, juju_machine_id):
+        return self.shadow_assignments[juju_machine_id]
+
+    def add_machine(self):
+        md = dict(series=app.metadata_controller.bundle.series)
+        self._machines[str(len(self._machines))] = md
+
+    def remove_machine(self):
+        raise Exception("TODO")
+
+    def get_shadow_pin(self, juju_machine_id):
+        return self.shadow_pins.get(juju_machine_id, None)
+
+    get_pin = get_shadow_pin
+
+    def show_pin_chooser(self, juju_machine_id):
+        app.ui.set_header("Pin Machine {}".format(juju_machine_id))
+        self.machine_pin_view = MachinePinView(
+            juju_machine_id, self.application, self)
+        self.update_now()
+        app.ui.set_body(self.machine_pin_view)
+
+    def handle_sub_view_done(self):
+        app.ui.set_header(self.header)
+        self.machine_pin_view = None
+        self.update_now()
+        app.ui.set_body(self)
+
+    def set_pin(self, juju_machine_id, maas_machine):
+        self.shadow_pins[juju_machine_id] = maas_machine
+
+    def unset_pin(self, maas_machine):
+        self.shadow_pins = {j_m_id: m for j_m_id, m in
+                            self.shadow_pins.items()
+                            if m != maas_machine}
 
     def do_cancel(self, sender):
         self.controller.handle_sub_view_done()
@@ -123,9 +204,18 @@ class AppArchitectureView(WidgetWrap):
             EventLoop.remove_alarm(self.alarm)
 
     def do_commit(self, sender):
-        self.controller.clear_placements(self.application)
-        for machine, atype in self._assignments:
-            self.controller.add_placement(self.application, machine, atype)
+        """Commit changes to shadow assignments, constraints, and pins"""
+        app.metadata_controller.bundle.machines = self._machines
+
+        self.controller.clear_assignments(self.application)
+        for juju_machine_id, al in self.shadow_assignments.items():
+            for application, atype in al:
+                assert application == self.application
+                self.controller.add_assignment(self.application,
+                                               juju_machine_id, atype)
+
+        for j_m_id, m in self.shadow_pins.items():
+            self.controller.set_machine_pin(j_m_id, m)
 
         self.controller.handle_sub_view_done()
         if self.alarm:

--- a/conjureup/ui/views/applicationconfigure.py
+++ b/conjureup/ui/views/applicationconfigure.py
@@ -204,8 +204,8 @@ class ApplicationConfigureView(WidgetWrap):
         self.application.num_units = scale
 
     def do_cancel(self, sender):
-        self.controller.handle_configure_done()
+        self.controller.handle_sub_view_done()
 
     def do_commit(self, sender):
         self.application.options = self.options_copy
-        self.controller.handle_configure_done()
+        self.controller.handle_sub_view_done()

--- a/conjureup/ui/views/applicationlist.py
+++ b/conjureup/ui/views/applicationlist.py
@@ -7,6 +7,8 @@ from functools import partial
 from urwid import Columns, Filler, Frame, Pile, Text, WidgetWrap
 
 from conjureup.app_config import app
+from conjureup.juju import get_controller_info
+from conjureup.maas import setup_maas
 from conjureup.utils import get_options_whitelist
 from ubuntui.ev import EventLoop
 from ubuntui.utils import Color, Padding
@@ -64,12 +66,25 @@ class ApplicationWidget(WidgetWrap):
                                     self.application)),
                 focus_map='button_secondary focus'))
 
+        c_info = get_controller_info(app.current_controller)
+        cloud_type = c_info['details']['cloud']
+
+        if cloud_type == 'maas'and self.application.num_units > 0:
+            arch_button = (20, Color.button_secondary(
+                PlainButton("Architecture",
+                            partial(self.controller.do_placement,
+                                    self.application)),
+                focus_map='button_secondary focus'))
+            cws.insert(4, arch_button)
+
+            setup_maas()
+
         self.columns = Columns(cws, dividechars=1)
         return self.columns
 
     def remove_buttons(self):
         self._selectable = False
-        self.columns.contents = self.columns.contents[:-2]
+        self.columns.contents = self.columns.contents[:-3]
         self.columns.contents.append((Text(""),
                                       self.columns.options()))
 

--- a/conjureup/ui/views/applicationlist.py
+++ b/conjureup/ui/views/applicationlist.py
@@ -7,8 +7,6 @@ from functools import partial
 from urwid import Columns, Filler, Frame, Pile, Text, WidgetWrap
 
 from conjureup.app_config import app
-from conjureup.juju import get_controller_info
-from conjureup.maas import setup_maas
 from conjureup.utils import get_options_whitelist
 from ubuntui.ev import EventLoop
 from ubuntui.utils import Color, Padding
@@ -66,18 +64,13 @@ class ApplicationWidget(WidgetWrap):
                                     self.application)),
                 focus_map='button_secondary focus'))
 
-        c_info = get_controller_info(app.current_controller)
-        cloud_type = c_info['details']['cloud']
-
-        if cloud_type == 'maas'and self.application.num_units > 0:
+        if self.application.num_units > 0:
             arch_button = (20, Color.button_secondary(
                 PlainButton("Architecture",
-                            partial(self.controller.do_placement,
+                            partial(self.controller.do_architecture,
                                     self.application)),
                 focus_map='button_secondary focus'))
             cws.insert(4, arch_button)
-
-            setup_maas()
 
         self.columns = Columns(cws, dividechars=1)
         return self.columns

--- a/conjureup/ui/views/machine_pin_view.py
+++ b/conjureup/ui/views/machine_pin_view.py
@@ -1,0 +1,118 @@
+""" Application Architecture / Machine Placement View
+
+"""
+import logging
+
+import q
+from urwid import Columns, Filler, Frame, Pile, Text, WidgetWrap
+
+from conjureup.app_config import app
+from conjureup.ui.widgets.machines_list import MachinesList
+
+from ubuntui.utils import Color, Padding
+from ubuntui.widgets.buttons import menu_btn
+from ubuntui.widgets.hr import HR
+
+log = logging.getLogger('conjure')
+
+
+class MachinePinView(WidgetWrap):
+
+    def __init__(self, juju_machine_id, application, controller):
+        """
+        juju_machine_id: a numeric machine id for a juju machine
+
+        application: an application currently being configured
+
+        controller: an object that provides get_pin, set_pin,
+        unset_pin and commit_machine_pin()
+        """
+        self.juju_machine_id = juju_machine_id
+        self.application = application
+        self.controller = controller
+
+        self.buttons_selected = False
+
+        self.frame = Frame(body=self.build_widgets(),
+                           footer=self.build_footer())
+        super().__init__(self.frame)
+        self.update()
+
+    def selectable(self):
+        return True
+
+    def keypress(self, size, key):
+        rv = super().keypress(size, key)
+        if key in ['tab', 'shift tab']:
+            self._swap_focus()
+        return rv
+
+    def _swap_focus(self):
+        if not self.buttons_selected:
+            self.buttons_selected = True
+            self.frame.focus_position = 'footer'
+            self.buttons.focus_position = 3
+        else:
+            self.buttons_selected = False
+            self.frame.focus_position = 'body'
+
+    def __repr__(self):
+        return "MachinePinView"
+
+    def build_widgets(self):
+        self.machines_list = MachinesList(
+            select_cb=self.select_machine,
+            unselect_cb=self.unselect_machine,
+            context_string=str(self.juju_machine_id),
+            show_hardware=True,
+            show_only_ready=True,
+            show_filter_box=True
+        )
+        header = Text("Choose a MAAS machine to pin to Juju Machine {}".format(
+            self.juju_machine_id))
+        self.pile = Pile([header,
+                          self.machines_list])
+        return Padding.center_90(Filler(self.pile,
+                                        valign="top"))
+
+    def build_footer(self):
+        cancel = menu_btn(on_press=self.do_cancel,
+                          label="\n  BACK\n")
+        self.apply_button = menu_btn(on_press=self.do_done,
+                                     label="\n DONE\n")
+        self.buttons = Columns([
+            ('fixed', 2, Text("")),
+            ('fixed', 13, Color.menu_button(
+                cancel,
+                focus_map='button_primary focus')),
+            Text(""),
+            ('fixed', 20, Color.menu_button(
+                self.apply_button,
+                focus_map='button_primary focus')),
+            ('fixed', 2, Text(""))
+        ])
+
+        footer = Pile([
+            HR(top=0),
+            Padding.line_break(""),
+            Color.frame_footer(Pile([
+                Padding.line_break(""),
+                self.buttons]))
+        ])
+
+        return footer
+
+    def update(self):
+        self.machines_list.update()
+
+    def select_machine(self, maas_machine):
+        self.controller.set_pin(self.juju_machine_id, maas_machine)
+
+    def unselect_machine(self, maas_machine):
+        self.controller.unset_pin(maas_machine)
+
+    def do_cancel(self, sender):
+        self.controller.handle_sub_view_done()
+
+    def do_done(self, sender):
+        self.controller.handle_sub_view_done()

--- a/conjureup/ui/views/machine_pin_view.py
+++ b/conjureup/ui/views/machine_pin_view.py
@@ -3,10 +3,8 @@
 """
 import logging
 
-import q
 from urwid import Columns, Filler, Frame, Pile, Text, WidgetWrap
 
-from conjureup.app_config import app
 from conjureup.ui.widgets.machines_list import MachinesList
 
 from ubuntui.utils import Color, Padding

--- a/conjureup/ui/views/machine_pin_view.py
+++ b/conjureup/ui/views/machine_pin_view.py
@@ -61,7 +61,8 @@ class MachinePinView(WidgetWrap):
         self.machines_list = MachinesList(
             select_cb=self.select_machine,
             unselect_cb=self.unselect_machine,
-            context_string=str(self.juju_machine_id),
+            target_info=str(self.juju_machine_id),
+            current_pin_cb=self.controller.get_pin_for_maas_machine,
             show_hardware=True,
             show_only_ready=True,
             show_filter_box=True

--- a/conjureup/ui/views/machine_pin_view.py
+++ b/conjureup/ui/views/machine_pin_view.py
@@ -6,7 +6,6 @@ import logging
 from urwid import Columns, Filler, Frame, Pile, Text, WidgetWrap
 
 from conjureup.ui.widgets.machines_list import MachinesList
-
 from ubuntui.utils import Color, Padding
 from ubuntui.widgets.buttons import menu_btn
 from ubuntui.widgets.hr import HR

--- a/conjureup/ui/widgets/filter_box.py
+++ b/conjureup/ui/widgets/filter_box.py
@@ -1,0 +1,55 @@
+# Copyright 2014 Canonical, Ltd.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import logging
+
+from urwid import (
+    AttrMap,
+    Columns,
+    Edit,
+    Pile,
+    Text,
+    WidgetWrap,
+    connect_signal
+)
+
+log = logging.getLogger('bundleplacer')
+
+
+class FilterBox(WidgetWrap):
+
+    def __init__(self, edit_changed_cb, label="", info_text=""):
+        self.label = Text(label)
+        self.info_text = Text(info_text)
+        self.editbox = Edit(caption=('text', "Filter: "))
+        connect_signal(self.editbox, 'change',
+                       edit_changed_cb)
+
+        w = Pile([Columns([AttrMap(self.editbox,
+                                   'filter', 'filter_focus')])
+                  # self.info_text  # -- WORKAROUND for issue #194
+                  ])
+        super().__init__(w)
+
+    def set_info(self, n_showing, n_total):
+        m = ["Filter ", ('label', "({} of {} shown): ".format(n_showing,
+                                                              n_total))]
+        self.editbox.set_caption(m)
+        if False:   # WORKAROUND for issue #194
+            t = ''
+        else:
+            t = ('label',
+                 "  Filter on hostname or hardware info like 'cores:4'")
+        self.info_text.set_text(t)

--- a/conjureup/ui/widgets/juju_machine_widget.py
+++ b/conjureup/ui/widgets/juju_machine_widget.py
@@ -1,0 +1,259 @@
+import q
+# Copyright 2016 Canonical, Ltd.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+from collections import defaultdict
+import logging
+
+from urwid import (AttrMap, Columns, connect_signal, Divider, Edit,
+                   Pile, Text, WidgetWrap)
+
+from bundleplacer.assignmenttype import AssignmentType, atype_to_label
+
+from conjureup import juju
+from ubuntui.widgets.buttons import PlainButton, MenuSelectButton
+
+
+log = logging.getLogger('bundleplacer')
+
+
+class JujuMachineWidget(WidgetWrap):
+
+    """A widget displaying a machine and action buttons.
+
+    juju_machine_id = juju id of the machine
+
+    md = the machine dict
+
+    application - the current application for which machines are being shown
+
+    assign_cb - a function that takes a machine and assignmenttype to
+    perform the button action
+
+    unassign_cb - a function that takes a machine and removes
+    assignments for the machine
+
+    controller - a controller object that provides show_pin_chooser
+
+    show_assignments - display info about which charms are assigned
+    and what assignment type (LXC, KVM, etc) they have.
+
+    show_pin - show whether a machine has been pinned to a maas machine.
+
+    """
+
+    def __init__(self, juju_machine_id, md, application, assign_cb, unassign_cb,
+                 controller, show_assignments=True, show_pin=False):
+        self.juju_machine_id = juju_machine_id
+        self.md = md
+        self.application = application
+        self.is_selected = False
+        self.assign_cb = assign_cb
+        self.unassign_cb = unassign_cb
+        self.controller = controller
+        self.show_assignments = show_assignments
+        self.show_pin = show_pin
+        self.all_assigned = False
+
+        w = self.build_widgets()
+        super().__init__(w)
+        self.update()
+
+    def selectable(self):
+        return True
+
+    def __repr__(self):
+        return "jujumachinewidget #" + str(self.juju_machine_id)
+
+    def build_widgets(self):
+
+        self.action_button_cols = Columns([])
+        self.action_buttons = []
+        self.build_unselected_widgets()
+        self.pile = Pile([self.unselected_columns])
+        return self.pile
+
+    def build_unselected_widgets(self):
+        cdict = juju.constraints_to_dict(self.md.get('constraints', ''))
+
+        self.juju_machine_id_button = MenuSelectButton(
+            '{:20s}'.format(self.juju_machine_id), self.show_pin_chooser)
+        self.cores_field = Edit('', cdict.get('cores', ''))
+        connect_signal(self.cores_field, 'change', self.handle_cores_changed)
+        self.mem_field = Edit('', cdict.get('mem', ''))
+        connect_signal(self.mem_field, 'change', self.handle_mem_changed)
+        self.disk_field = Edit('', cdict.get('root-disk', ''))
+        connect_signal(self.disk_field, 'change', self.handle_disk_changed)
+
+        cols = [self.juju_machine_id_button, self.cores_field,
+                self.mem_field, self.disk_field, Text("placeholder")]
+        self.unselected_columns = Columns(cols)
+        self.update_assignments()
+        return self.unselected_columns
+
+    def update_assignments(self):
+        assignments = []
+
+        mps = self.controller.get_all_assignments(self.juju_machine_id)
+        if len(mps) > 0:
+            if self.show_assignments:
+                ad = defaultdict(list)
+                for application, atype in mps:
+                    ad[atype].append(application)
+                astr = " ".join(["{}{}".format(
+                    atype_to_label([atype])[0],
+                    ",".join([application.service_name
+                              for application in al]))
+                                 for atype, al in ad.items()])
+                assignments.append(astr)
+        else:
+            if self.show_assignments:
+                assignments.append("-")
+
+        if any([application == self.application for application, _ in mps]):
+            action = self.do_remove
+            label = "Remove"
+        else:
+            action = self.do_select
+            label = "Select"
+
+        self.select_button = PlainButton(label, action)
+
+        cols = [Text(s) for s in assignments]
+
+        current_assignments = [a for a, _ in mps if a == self.application]
+        if self.all_assigned and len(current_assignments) == 0:
+            cols.append(Text(""))
+        else:
+            cols += [AttrMap(self.select_button, 'text',
+                             'button_secondary focus')]
+        opts = self.unselected_columns.options()
+        self.unselected_columns.contents[4:] = [(w, opts) for w in cols]
+
+    def update(self):
+        self.update_action_buttons()
+
+        if self.is_selected:
+            self.update_selected()
+        else:
+            self.update_unselected()
+
+    def update_selected(self):
+        cn = self.application.service_name
+        msg = Text("  Add {} to machine #{}:".format(cn,
+                                                     self.juju_machine_id))
+        self.pile.contents = [(msg, self.pile.options()),
+                              (self.action_button_cols,
+                               self.pile.options()),
+                              (Divider(), self.pile.options())]
+
+    def update_unselected(self):
+        if self.show_pin:
+            pinned_machine = self.controller.get_pin(self.juju_machine_id)
+
+            if pinned_machine:
+                pin_label = "({})".format(pinned_machine.hostname)
+            else:
+                pin_label = ""
+            self.juju_machine_id_button.set_label('{:20s} {}'.format(
+                self.juju_machine_id, pin_label))
+        else:
+            self.juju_machine_id_button.set_label('{:20s}'.format(
+                self.juju_machine_id))
+
+        self.pile.contents = [(self.unselected_columns, self.pile.options()),
+                              (Divider(), self.pile.options())]
+        self.update_assignments()
+
+    def update_action_buttons(self):
+
+        all_actions = [(AssignmentType.BareMetal,
+                        'Add as Bare Metal',
+                        self.select_baremetal),
+                       (AssignmentType.LXD,
+                        'Add as LXD',
+                        self.select_lxd),
+                       (AssignmentType.KVM,
+                        'Add as KVM',
+                        self.select_kvm)]
+
+        sc = self.application
+        if sc:
+            allowed_set = set(sc.allowed_assignment_types)
+            allowed_types = set([atype for atype, _, _ in all_actions])
+            allowed_types = allowed_types.intersection(allowed_set)
+        else:
+            allowed_types = set()
+
+        # + 1 for the cancel button:
+        if len(self.action_buttons) == len(allowed_types) + 1:
+            return
+
+        self.action_buttons = [AttrMap(PlainButton(label,
+                                                   on_press=func),
+                                       'button_secondary',
+                                       'button_secondary focus')
+                               for atype, label, func in all_actions
+                               if atype in allowed_types]
+        self.action_buttons.append(
+            AttrMap(PlainButton("Cancel",
+                                on_press=self.do_cancel),
+                    'button_secondary',
+                    'button_secondary focus'))
+
+        opts = self.action_button_cols.options()
+        self.action_button_cols.contents = [(b, opts) for b in
+                                            self.action_buttons]
+
+    def do_select(self, sender):
+        self.is_selected = True
+        self.update()
+        self.pile.focus_position = 1
+        self.action_button_cols.focus_position = 0
+
+    def do_remove(self, sender):
+        self.unassign_cb(self.juju_machine_id)
+
+    def do_cancel(self, sender):
+        self.is_selected = False
+        self.update()
+        self.pile.focus_position = 0
+
+    def _do_select_assignment(self, atype):
+        self.assign_cb(self.juju_machine_id, atype)
+        self.pile.focus_position = 0
+        self.is_selected = False
+        self.update()
+
+    def select_baremetal(self, sender):
+        self._do_select_assignment(AssignmentType.BareMetal)
+
+    def select_lxd(self, sender):
+        self._do_select_assignment(AssignmentType.LXD)
+
+    def select_kvm(self, sender):
+        self._do_select_assignment(AssignmentType.KVM)
+
+    def handle_cores_changed(self, sender, val):
+        q.q(val)
+
+    def handle_mem_changed(self, sender, val):
+        q.q(val)
+
+    def handle_disk_changed(self, sender, val):
+        q.q(val)
+
+    def show_pin_chooser(self, sender):
+        self.controller.show_pin_chooser(self.juju_machine_id)

--- a/conjureup/ui/widgets/juju_machine_widget.py
+++ b/conjureup/ui/widgets/juju_machine_widget.py
@@ -13,17 +13,23 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-from collections import defaultdict
 import logging
+from collections import defaultdict
 
-from urwid import (AttrMap, Columns, connect_signal, Divider, Edit,
-                   Pile, Text, WidgetWrap)
+from urwid import (
+    AttrMap,
+    Columns,
+    Divider,
+    Edit,
+    Pile,
+    Text,
+    WidgetWrap,
+    connect_signal
+)
 
 from bundleplacer.assignmenttype import AssignmentType, atype_to_label
-
 from conjureup import juju
-from ubuntui.widgets.buttons import PlainButton, MenuSelectButton
-
+from ubuntui.widgets.buttons import MenuSelectButton, PlainButton
 
 log = logging.getLogger('bundleplacer')
 
@@ -122,7 +128,7 @@ class JujuMachineWidget(WidgetWrap):
                     atype_to_label([atype])[0],
                     ",".join([application.service_name
                               for application in al]))
-                                 for atype, al in ad.items()])
+                    for atype, al in ad.items()])
                 assignments.append(astr)
         else:
             if self.show_assignments:

--- a/conjureup/ui/widgets/juju_machine_widget.py
+++ b/conjureup/ui/widgets/juju_machine_widget.py
@@ -50,12 +50,13 @@ class JujuMachineWidget(WidgetWrap):
     show_assignments - display info about which charms are assigned
     and what assignment type (LXC, KVM, etc) they have.
 
-    show_pin - show whether a machine has been pinned to a maas machine.
+    show_pin - show button to pin juju machine to a maas machine
 
     """
 
-    def __init__(self, juju_machine_id, md, application, assign_cb, unassign_cb,
-                 controller, show_assignments=True, show_pin=False):
+    def __init__(self, juju_machine_id, md, application, assign_cb,
+                 unassign_cb, controller, show_assignments=True,
+                 show_pin=False):
         self.juju_machine_id = juju_machine_id
         self.md = md
         self.application = application
@@ -90,6 +91,8 @@ class JujuMachineWidget(WidgetWrap):
 
         self.juju_machine_id_button = MenuSelectButton(
             '{:20s}'.format(self.juju_machine_id), self.show_pin_chooser)
+        self.juju_machine_id_label = Text(
+            "{:20s}".format(self.juju_machine_id))
         self.cores_field = Edit('', cdict.get('cores', ''))
         connect_signal(self.cores_field, 'change', self.handle_cores_changed)
         self.mem_field = Edit('', cdict.get('mem', ''))
@@ -97,7 +100,11 @@ class JujuMachineWidget(WidgetWrap):
         self.disk_field = Edit('', cdict.get('root-disk', ''))
         connect_signal(self.disk_field, 'change', self.handle_disk_changed)
 
-        cols = [self.juju_machine_id_button, self.cores_field,
+        if self.show_pin:
+            machine_id_w = self.juju_machine_id_button
+        else:
+            machine_id_w = self.juju_machine_id_label
+        cols = [machine_id_w, self.cores_field,
                 self.mem_field, self.disk_field, Text("placeholder")]
         self.unselected_columns = Columns(cols)
         self.update_assignments()
@@ -170,7 +177,7 @@ class JujuMachineWidget(WidgetWrap):
             self.juju_machine_id_button.set_label('{:20s} {}'.format(
                 self.juju_machine_id, pin_label))
         else:
-            self.juju_machine_id_button.set_label('{:20s}'.format(
+            self.juju_machine_id_label.set_text('{:20s}'.format(
                 self.juju_machine_id))
 
         self.pile.contents = [(self.unselected_columns, self.pile.options()),

--- a/conjureup/ui/widgets/juju_machine_widget.py
+++ b/conjureup/ui/widgets/juju_machine_widget.py
@@ -1,4 +1,3 @@
-import q
 # Copyright 2016 Canonical, Ltd.
 #
 # This program is free software: you can redistribute it and/or modify
@@ -254,13 +253,13 @@ class JujuMachineWidget(WidgetWrap):
         self._do_select_assignment(AssignmentType.KVM)
 
     def handle_cores_changed(self, sender, val):
-        q.q(val)
+        raise Exception("TODO")
 
     def handle_mem_changed(self, sender, val):
-        q.q(val)
+        raise Exception("TODO")
 
     def handle_disk_changed(self, sender, val):
-        q.q(val)
+        raise Exception("TODO")
 
     def show_pin_chooser(self, sender):
         self.controller.show_pin_chooser(self.juju_machine_id)

--- a/conjureup/ui/widgets/juju_machines_list.py
+++ b/conjureup/ui/widgets/juju_machines_list.py
@@ -13,8 +13,8 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses>.
 
-from operator import attrgetter
 import logging
+from operator import attrgetter
 
 from urwid import AttrMap, Columns, Divider, Pile, Text, WidgetWrap
 

--- a/conjureup/ui/widgets/juju_machines_list.py
+++ b/conjureup/ui/widgets/juju_machines_list.py
@@ -1,0 +1,213 @@
+import q
+# Copyright 2016 Canonical, Ltd.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses>.
+
+from operator import attrgetter
+import logging
+
+from urwid import AttrMap, Columns, Divider, Pile, Text, WidgetWrap
+
+from conjureup.ui.widgets.filter_box import FilterBox
+from conjureup.ui.widgets.juju_machine_widget import JujuMachineWidget
+from ubuntui.widgets.buttons import PlainButton
+
+log = logging.getLogger('bundleplacer')
+
+
+class JujuMachinesList(WidgetWrap):
+
+    """A list of machines in a juju bundle, with configurable action
+    buttons for each machine.
+
+    application - an application
+
+    machines - list of machine info dicts
+
+    assign_cb - a function that takes a machine and assignmenttype to
+    perform the button action
+
+    unassign_cb - a function that takes a machine and clears assignments
+
+    controller - a controller object that provides get_placements and get_pin.
+
+    show_constraints - bool, whether or not to show the constraints
+    for each of the machines
+
+    title_widgets - A list of widgets to be used in place of the default
+    title.
+
+    show_assignments - bool, whether or not to show the assignments
+    for each of the machines.
+
+    show_filter_box - bool, show text box to filter listed machines
+
+    """
+
+    def __init__(self, application, machines, assign_cb, unassign_cb,
+                 add_machine_cb, remove_machine_cb,
+                 controller,
+                 show_constraints=True,
+                 title_widgets=None, show_assignments=True,
+                 show_filter_box=False,
+                 show_pins=False):
+        self.application = application
+        self.machines = machines
+        self.assign_cb = assign_cb
+        self.unassign_cb = unassign_cb
+        self.add_machine_cb = add_machine_cb
+        self.remove_machine_cb = remove_machine_cb
+        self.controller = controller
+        self.machine_widgets = []
+        self.show_assignments = show_assignments
+        self.show_filter_box = show_filter_box
+        self.show_pins = show_pins
+        self.filter_string = ""
+        w = self.build_widgets(title_widgets)
+        self.update()
+        super().__init__(w)
+
+    def __repr__(self):
+        return "machineslist"
+
+    def selectable(self):
+        # overridden to ensure that we can arrow through the buttons
+        # shouldn't be necessary according to documented behavior of
+        # Pile & Columns, but discovered via trial & error.
+        return True
+
+    def build_widgets(self, title_widgets):
+        if title_widgets is None:
+            title_widgets = [Text("Machines", align='center')]
+
+        self.filter_edit_box = FilterBox(self.handle_filter_change)
+
+        header_widgets = title_widgets + [Divider()]
+
+        if self.show_filter_box:
+            header_widgets += [self.filter_edit_box, Divider()]
+        labels = ["ID", "Cores", "Memory", "Storage"]
+        if self.show_assignments:
+            labels += ["Assignments", ""]
+        else:
+            labels += [""]
+
+        header_label_col = Columns([Text(m) for m in labels])
+        header_widgets.append(header_label_col)
+        self.header_padding = len(header_widgets)
+        self.add_new_button = AttrMap(
+            PlainButton("Add New Machine",
+                        on_press=self.do_add_machine),
+            'button_secondary',
+            'button_secondary focus')
+
+        self.machine_pile = Pile(header_widgets + self.machine_widgets +
+                                 [self.add_new_button])
+        return self.machine_pile
+
+    def do_add_machine(self, sender):
+        self.add_machine_cb()
+        self.update()
+
+    def remove_machine(self, sender):
+        self.remove_machine_cb()
+        raise Exception("TODO")
+
+    def handle_filter_change(self, edit_button, userdata):
+        self.filter_string = userdata
+        self.update()
+
+    def find_machine_widget(self, midx):
+        return next((mw for mw in self.machine_widgets if
+                     mw.juju_machine_id == midx), None)
+
+    def update(self):
+
+        # don't need this?
+        # for mw in self.machine_widgets:
+        #     machine = next((m for m in machines if
+        #                     mw.machine.instance_id == m.instance_id), None)
+        #     if machine is None:
+        #         self.remove_machine_widget(mw.machine)
+
+        for midx, md in sorted(self.machines.items()):
+            # filter_label = m.filter_label()
+            # if self.filter_string != "" and \
+            #    self.filter_string not in filter_label:
+            #     self.remove_machine_widget(m)
+            #     continue
+
+            mw = self.find_machine_widget(midx)
+            if mw is None:
+                mw = self.add_machine_widget(midx, md)
+            mw.update()
+
+        n = len(self.machine_widgets)
+        self.filter_edit_box.set_info(n, n)
+
+        self.sort_machine_widgets()
+
+    def add_machine_widget(self, midx, md):
+        mw = JujuMachineWidget(midx, md,
+                               self.application,
+                               self.assign_cb,
+                               self.unassign_cb,
+                               self.controller,
+                               self.show_assignments,
+                               self.show_pins)
+        self.machine_widgets.append(mw)
+        options = self.machine_pile.options()
+        self.machine_pile.contents.insert(
+            len(self.machine_pile.contents) - 1,
+            (mw, options))
+
+        return mw
+
+    def remove_machine_widget(self, midx, md):
+        mw = self.find_machine_widget(midx)
+        if mw is None:
+            return
+
+        self.machine_widgets.remove(mw)
+        mw_idx = 0
+        for w, opts in self.machine_pile.contents:
+            if w == mw:
+                break
+            mw_idx += 1
+
+        c = self.machine_pile.contents[:mw_idx] + \
+            self.machine_pile.contents[mw_idx + 1:]
+        self.machine_pile.contents = c
+
+    def sort_machine_widgets(self):
+
+        self.machine_widgets.sort(key=attrgetter('juju_machine_id'))
+
+        def wrappedkeyfunc(t):
+            mw, options = t
+            if isinstance(mw, JujuMachineWidget):
+                return "B{}".format(mw.juju_machine_id)
+            if mw in [self.add_new_button]:
+                return 'C'
+            return 'A'
+
+        self.machine_pile.contents.sort(key=wrappedkeyfunc)
+
+    def focus_prev_or_top(self):
+        self.update()
+        try:
+            if self.machine_pile.focus_position <= self.header_padding:
+                self.machine_pile.focus_position = self.header_padding
+        except IndexError:
+            log.debug("index error in machines_list focus_top")

--- a/conjureup/ui/widgets/juju_machines_list.py
+++ b/conjureup/ui/widgets/juju_machines_list.py
@@ -122,7 +122,7 @@ class JujuMachinesList(WidgetWrap):
 
     def remove_machine(self, sender):
         self.remove_machine_cb()
-        raise Exception("TODO")
+        self.update()
 
     def handle_filter_change(self, edit_button, userdata):
         self.filter_string = userdata
@@ -134,19 +134,13 @@ class JujuMachinesList(WidgetWrap):
 
     def update(self):
 
-        # don't need this?
-        # for mw in self.machine_widgets:
-        #     machine = next((m for m in machines if
-        #                     mw.machine.instance_id == m.instance_id), None)
-        #     if machine is None:
-        #         self.remove_machine_widget(mw.machine)
-
         for midx, md in sorted(self.machines.items()):
-            # filter_label = m.filter_label()
-            # if self.filter_string != "" and \
-            #    self.filter_string not in filter_label:
-            #     self.remove_machine_widget(m)
-            #     continue
+            allvalues = ["{}={}".format(k, v) for k, v in md.items()]
+            filter_label = midx + " " + " ".join(allvalues)
+            if self.filter_string != "" and \
+               self.filter_string not in filter_label:
+                self.remove_machine_widget(midx)
+                continue
 
             mw = self.find_machine_widget(midx)
             if mw is None:
@@ -174,7 +168,7 @@ class JujuMachinesList(WidgetWrap):
 
         return mw
 
-    def remove_machine_widget(self, midx, md):
+    def remove_machine_widget(self, midx):
         mw = self.find_machine_widget(midx)
         if mw is None:
             return

--- a/conjureup/ui/widgets/juju_machines_list.py
+++ b/conjureup/ui/widgets/juju_machines_list.py
@@ -70,6 +70,7 @@ class JujuMachinesList(WidgetWrap):
         self.controller = controller
         self.machine_widgets = []
         self.show_assignments = show_assignments
+        self.all_assigned = False
         self.show_filter_box = show_filter_box
         self.show_pins = show_pins
         self.filter_string = ""
@@ -144,6 +145,7 @@ class JujuMachinesList(WidgetWrap):
             mw = self.find_machine_widget(midx)
             if mw is None:
                 mw = self.add_machine_widget(midx, md)
+            mw.all_assigned = self.all_assigned
             mw.update()
 
         n = len(self.machine_widgets)

--- a/conjureup/ui/widgets/juju_machines_list.py
+++ b/conjureup/ui/widgets/juju_machines_list.py
@@ -1,4 +1,3 @@
-import q
 # Copyright 2016 Canonical, Ltd.
 #
 # This program is free software: you can redistribute it and/or modify

--- a/conjureup/ui/widgets/machine_widget.py
+++ b/conjureup/ui/widgets/machine_widget.py
@@ -1,0 +1,213 @@
+# Copyright 2016 Canonical, Ltd.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+from collections import defaultdict
+import logging
+
+from urwid import AttrMap, Columns, Divider, Pile, Text, WidgetWrap
+
+from bundleplacer.assignmenttype import AssignmentType, atype_to_label
+from conjureup.app_config import app
+from ubuntui.widgets.buttons import MenuSelectButton, PlainButton
+
+log = logging.getLogger('bundleplacer')
+
+
+class MachineWidget(WidgetWrap):
+
+    """A widget displaying a machine and action buttons.
+
+    machine - the machine to display
+
+    application - the current application for which machines are being shown
+
+    select_cb - a function that takes a machine and assignmenttype to
+    perform the button action
+
+    unselect_cb - a function that takes a machine and removes
+    assignments for the machine
+
+    show_assignments - display info about which charms are assigned
+    and what assignment type (LXC, KVM, etc) they have.
+
+    """
+
+    def __init__(self, machine, application, select_cb, unselect_cb,
+                 controller, show_assignments=True):
+        self.machine = machine
+        self.application = application
+        self.is_selected = False
+        self.select_cb = select_cb
+        self.unselect_cb = unselect_cb
+        self.controller = controller
+        self.show_assignments = show_assignments
+        self.all_assigned = False
+
+        w = self.build_widgets()
+        super().__init__(w)
+        self.update()
+
+    def selectable(self):
+        return True
+
+    def build_widgets(self):
+
+        self.action_button_cols = Columns([])
+        self.action_buttons = []
+
+        self.pile = Pile([self.get_toprow()])
+        return self.pile
+
+    def update_machine(self):
+        """Refresh with potentially updated machine info from controller.
+        Assumes that machine exists - machines going away is handled
+        in machineslist.update().
+        """
+        self.machine = next((m for m in app.maas.client.get_machines()
+                             if m.instance_id == self.machine.instance_id),
+                            None)
+
+    def __repr__(self):
+        return "widget for " + str(self.machine)
+
+    def get_toprow(self):
+        m = self.machine
+        l = ['{:20s}'.format(m.hostname),
+             '{:3d}'.format(m.cpu_cores),
+             '{:6s}'.format(m.mem),
+             '{:10s}'.format(m.storage)]
+
+        mps = self.controller.get_placements(self.application, m)
+        if len(mps) > 0:
+            if self.show_assignments:
+                ad = defaultdict(list)
+                for application, atype in mps:
+                    ad[atype].append(application)
+                astr = " ".join(["{}{}".format(atype_to_label(atype),
+                                               ",".join([a.service_name
+                                                         for a in al]))
+                                 for atype, al in ad.items()])
+                l.append(astr)
+            action = self.do_remove
+            label = "Remove"
+        else:
+            if self.show_assignments:
+                l.append("-")
+            action = self.do_select
+            label = "Select"
+
+        select_button = MenuSelectButton(label, action)
+        cols = [Text(m) for m in l]
+
+        current_assignments = [a for a, _ in mps if a == self.application]
+        if self.all_assigned and len(current_assignments) == 0:
+            cols.append(Text(""))
+        else:
+            cols += [AttrMap(select_button, 'text',
+                             'button_secondary focus')]
+        return Columns(cols)
+
+    def update(self):
+        self.update_machine()
+        self.update_action_buttons()
+
+        if self.is_selected:
+            self.update_selected()
+        else:
+            self.update_unselected()
+
+    def update_selected(self):
+        cn = self.application.service_name
+        msg = Text("  Add {} to {}:".format(cn,
+                                            self.machine.hostname))
+        self.pile.contents = [(msg, self.pile.options()),
+                              (self.action_button_cols,
+                               self.pile.options()),
+                              (Divider(), self.pile.options())]
+
+    def update_unselected(self):
+        self.pile.contents = [(self.get_toprow(), self.pile.options()),
+                              (Divider(), self.pile.options())]
+
+    def update_action_buttons(self):
+
+        all_actions = [(AssignmentType.BareMetal,
+                        'Add as Bare Metal',
+                        self.select_baremetal),
+                       (AssignmentType.LXD,
+                        'Add as LXD',
+                        self.select_lxd),
+                       (AssignmentType.KVM,
+                        'Add as KVM',
+                        self.select_kvm)]
+
+        sc = self.application
+        if sc:
+            allowed_set = set(sc.allowed_assignment_types)
+            allowed_types = set([atype for atype, _, _ in all_actions])
+            allowed_types = allowed_types.intersection(allowed_set)
+        else:
+            allowed_types = set()
+
+        # + 1 for the cancel button:
+        if len(self.action_buttons) == len(allowed_types) + 1:
+            return
+
+        self.action_buttons = [AttrMap(PlainButton(label,
+                                                   on_press=func),
+                                       'button_secondary',
+                                       'button_secondary focus')
+                               for atype, label, func in all_actions
+                               if atype in allowed_types]
+        self.action_buttons.append(
+            AttrMap(PlainButton("Cancel",
+                                on_press=self.do_cancel),
+                    'button_secondary',
+                    'button_secondary focus'))
+
+        opts = self.action_button_cols.options()
+        self.action_button_cols.contents = [(b, opts) for b in
+                                            self.action_buttons]
+
+    def do_select(self, sender):
+        self.is_selected = True
+        self.update()
+        self.pile.focus_position = 1
+        self.action_button_cols.focus_position = 0
+
+    def do_remove(self, sender):
+        self.controller.remove_placement(self.application, self.machine)
+        self.unselect_cb(self.machine)
+
+    def do_cancel(self, sender):
+        self.is_selected = False
+        self.update()
+        self.pile.focus_position = 0
+
+    def _do_select_assignment(self, atype):
+        self.controller.add_placement(self.application, self.machine, atype)
+        self.select_cb(self.machine, atype)
+        self.pile.focus_position = 0
+        self.is_selected = False
+        self.update()
+
+    def select_baremetal(self, sender):
+        self._do_select_assignment(AssignmentType.BareMetal)
+
+    def select_lxd(self, sender):
+        self._do_select_assignment(AssignmentType.LXD)
+
+    def select_kvm(self, sender):
+        self._do_select_assignment(AssignmentType.KVM)

--- a/conjureup/ui/widgets/machine_widget.py
+++ b/conjureup/ui/widgets/machine_widget.py
@@ -13,12 +13,10 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-from collections import defaultdict
 import logging
 
-from urwid import AttrMap, Columns, Divider, Pile, Text, WidgetWrap
+from urwid import AttrMap, Columns, Text, WidgetWrap
 
-from bundleplacer.assignmenttype import AssignmentType, atype_to_label
 from conjureup.app_config import app
 from ubuntui.widgets.buttons import PlainButton
 

--- a/conjureup/ui/widgets/machine_widget.py
+++ b/conjureup/ui/widgets/machine_widget.py
@@ -20,55 +20,64 @@ from urwid import AttrMap, Columns, Divider, Pile, Text, WidgetWrap
 
 from bundleplacer.assignmenttype import AssignmentType, atype_to_label
 from conjureup.app_config import app
-from ubuntui.widgets.buttons import MenuSelectButton, PlainButton
+from ubuntui.widgets.buttons import PlainButton
 
 log = logging.getLogger('bundleplacer')
 
 
 class MachineWidget(WidgetWrap):
 
-    """A widget displaying a machine and action buttons.
+    """A widget displaying a machine and one action button.
 
     machine - the machine to display
 
-    application - the current application for which machines are being shown
+    select_cb - a function that takes a machine to select
 
-    select_cb - a function that takes a machine and assignmenttype to
-    perform the button action
+    unselect_cb - a function that takes a machine to un-select
 
-    unselect_cb - a function that takes a machine and removes
-    assignments for the machine
-
-    show_assignments - display info about which charms are assigned
-    and what assignment type (LXC, KVM, etc) they have.
+    context_string - a string to show in the label for context
 
     """
 
-    def __init__(self, machine, application, select_cb, unselect_cb,
-                 controller, show_assignments=True):
+    def __init__(self, machine, select_cb, unselect_cb,
+                 context_string):
         self.machine = machine
-        self.application = application
         self.is_selected = False
         self.select_cb = select_cb
         self.unselect_cb = unselect_cb
-        self.controller = controller
-        self.show_assignments = show_assignments
-        self.all_assigned = False
+        self.context_string = context_string
+        self.can_select = True
 
         w = self.build_widgets()
         super().__init__(w)
-        self.update()
 
     def selectable(self):
         return True
 
     def build_widgets(self):
+        m = self.machine
+        l = ['{:20s}'.format(m.hostname),
+             '{:3d}'.format(m.cpu_cores),
+             '{:6s}'.format(m.mem),
+             '{:10s}'.format(m.storage)]
 
-        self.action_button_cols = Columns([])
-        self.action_buttons = []
+        self.select_button_label = "Pin {} to {}".format(m.hostname,
+                                                         self.context_string)
+        self.unselect_button_label = "Un-pin {} from {}".format(
+            m.hostname, self.context_string)
 
-        self.pile = Pile([self.get_toprow()])
-        return self.pile
+        self.select_button = PlainButton(self.select_button_label,
+                                         self.handle_button)
+        cols = [Text(m) for m in l]
+
+        if self.can_select:
+            cols += [AttrMap(self.select_button, 'text',
+                             'button_secondary focus')]
+        else:
+            cols.append(Text(""))
+
+        self.columns = Columns(cols)
+        return self.columns
 
     def update_machine(self):
         """Refresh with potentially updated machine info from controller.
@@ -82,132 +91,26 @@ class MachineWidget(WidgetWrap):
     def __repr__(self):
         return "widget for " + str(self.machine)
 
-    def get_toprow(self):
-        m = self.machine
-        l = ['{:20s}'.format(m.hostname),
-             '{:3d}'.format(m.cpu_cores),
-             '{:6s}'.format(m.mem),
-             '{:10s}'.format(m.storage)]
-
-        mps = self.controller.get_placements(self.application, m)
-        if len(mps) > 0:
-            if self.show_assignments:
-                ad = defaultdict(list)
-                for application, atype in mps:
-                    ad[atype].append(application)
-                astr = " ".join(["{}{}".format(atype_to_label(atype),
-                                               ",".join([a.service_name
-                                                         for a in al]))
-                                 for atype, al in ad.items()])
-                l.append(astr)
-            action = self.do_remove
-            label = "Remove"
-        else:
-            if self.show_assignments:
-                l.append("-")
-            action = self.do_select
-            label = "Select"
-
-        select_button = MenuSelectButton(label, action)
-        cols = [Text(m) for m in l]
-
-        current_assignments = [a for a, _ in mps if a == self.application]
-        if self.all_assigned and len(current_assignments) == 0:
-            cols.append(Text(""))
-        else:
-            cols += [AttrMap(select_button, 'text',
-                             'button_secondary focus')]
-        return Columns(cols)
-
     def update(self):
         self.update_machine()
-        self.update_action_buttons()
-
         if self.is_selected:
-            self.update_selected()
+            self.select_button.set_label(self.unselect_button_label)
         else:
-            self.update_unselected()
+            self.select_button.set_label(self.select_button_label)
 
-    def update_selected(self):
-        cn = self.application.service_name
-        msg = Text("  Add {} to {}:".format(cn,
-                                            self.machine.hostname))
-        self.pile.contents = [(msg, self.pile.options()),
-                              (self.action_button_cols,
-                               self.pile.options()),
-                              (Divider(), self.pile.options())]
-
-    def update_unselected(self):
-        self.pile.contents = [(self.get_toprow(), self.pile.options()),
-                              (Divider(), self.pile.options())]
-
-    def update_action_buttons(self):
-
-        all_actions = [(AssignmentType.BareMetal,
-                        'Add as Bare Metal',
-                        self.select_baremetal),
-                       (AssignmentType.LXD,
-                        'Add as LXD',
-                        self.select_lxd),
-                       (AssignmentType.KVM,
-                        'Add as KVM',
-                        self.select_kvm)]
-
-        sc = self.application
-        if sc:
-            allowed_set = set(sc.allowed_assignment_types)
-            allowed_types = set([atype for atype, _, _ in all_actions])
-            allowed_types = allowed_types.intersection(allowed_set)
+        opts = self.columns.options()
+        if self.can_select:
+            self.columns.contents[-1] = (self.select_button,
+                                         opts)
         else:
-            allowed_types = set()
+            self.columns.contents[-1] = (Text(""), opts)
 
-        # + 1 for the cancel button:
-        if len(self.action_buttons) == len(allowed_types) + 1:
-            return
+    def handle_button(self, sender):
+        if self.is_selected:
+            self.is_selected = False
+            self.unselect_cb(self.machine)
+        else:
+            self.is_selected = True
+            self.select_cb(self.machine)
 
-        self.action_buttons = [AttrMap(PlainButton(label,
-                                                   on_press=func),
-                                       'button_secondary',
-                                       'button_secondary focus')
-                               for atype, label, func in all_actions
-                               if atype in allowed_types]
-        self.action_buttons.append(
-            AttrMap(PlainButton("Cancel",
-                                on_press=self.do_cancel),
-                    'button_secondary',
-                    'button_secondary focus'))
-
-        opts = self.action_button_cols.options()
-        self.action_button_cols.contents = [(b, opts) for b in
-                                            self.action_buttons]
-
-    def do_select(self, sender):
-        self.is_selected = True
         self.update()
-        self.pile.focus_position = 1
-        self.action_button_cols.focus_position = 0
-
-    def do_remove(self, sender):
-        self.controller.remove_placement(self.application, self.machine)
-        self.unselect_cb(self.machine)
-
-    def do_cancel(self, sender):
-        self.is_selected = False
-        self.update()
-        self.pile.focus_position = 0
-
-    def _do_select_assignment(self, atype):
-        self.controller.add_placement(self.application, self.machine, atype)
-        self.select_cb(self.machine, atype)
-        self.pile.focus_position = 0
-        self.is_selected = False
-        self.update()
-
-    def select_baremetal(self, sender):
-        self._do_select_assignment(AssignmentType.BareMetal)
-
-    def select_lxd(self, sender):
-        self._do_select_assignment(AssignmentType.LXD)
-
-    def select_kvm(self, sender):
-        self._do_select_assignment(AssignmentType.KVM)

--- a/conjureup/ui/widgets/machines_list.py
+++ b/conjureup/ui/widgets/machines_list.py
@@ -1,0 +1,239 @@
+# Copyright 2015 Canonical, Ltd.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses>.
+
+import logging
+
+from urwid import Columns, Divider, Pile, Text, WidgetWrap
+
+from conjureup.maas import MaasMachineStatus, satisfies
+from conjureup.app_config import app
+from conjureup.ui.widgets.filter_box import FilterBox
+from conjureup.ui.widgets.machine_widget import MachineWidget
+
+log = logging.getLogger('bundleplacer')
+
+
+class MachinesList(WidgetWrap):
+
+    """A list of machines with configurable action buttons for each
+    machine.
+
+    application - an application
+
+    select_cb - a function that takes a machine and assignmenttype to
+    perform the button action
+
+    unselect_cb - a function that takes a machine and clears assignments
+
+    controller - deploy/gui controller
+
+    constraints - a dict of constraints to filter the machines list.
+    only machines matching all the constraints will be shown.
+
+    show_hardware - bool, whether or not to show the hardware details
+    for each of the machines
+
+    title_widgets - A Text Widget to be used in place of the default
+    title.
+
+    show_assignments - bool, whether or not to show the assignments
+    for each of the machines.
+
+    show_only_ready - bool, only show machines with a ready state.
+
+    show_filter_box - bool, show text box to filter listed machines
+
+    """
+
+    def __init__(self, application, select_cb, unselect_cb,
+                 controller,
+                 constraints=None, show_hardware=False,
+                 title_widgets=None, show_assignments=True,
+                 show_only_ready=False,
+                 show_filter_box=False):
+        self.application = application
+        self.select_cb = select_cb
+        self.unselect_cb = unselect_cb
+        self.controller = controller
+        self.all_assigned = False
+        self.machine_widgets = []
+        if constraints is None:
+            self.constraints = {}
+        else:
+            self.constraints = constraints
+        self.show_hardware = show_hardware
+        self.show_assignments = show_assignments
+        self.show_only_ready = show_only_ready
+        self.show_filter_box = show_filter_box
+        self.filter_string = ""
+        self.loading = False
+        w = self.build_widgets(title_widgets)
+        self.update()
+        super().__init__(w)
+
+    def __repr__(self):
+        return "machineslist"
+
+    def selectable(self):
+        # overridden to ensure that we can arrow through the buttons
+        # shouldn't be necessary according to documented behavior of
+        # Pile & Columns, but discovered via trial & error.
+        return True
+
+    def build_widgets(self, title_widgets):
+        if title_widgets is None:
+            if len(self.constraints) > 0:
+                cstr = " matching constraints"
+            else:
+                cstr = ""
+
+            title_widgets = [Text("Machines" + cstr, align='center')]
+
+        self.filter_edit_box = FilterBox(self.handle_filter_change)
+
+        header_widgets = title_widgets + [Divider()]
+
+        if self.show_filter_box:
+            header_widgets += [self.filter_edit_box, Divider()]
+        labels = ["FQDN", "Cores", "Memory", "Storage"]
+        if self.show_assignments:
+            labels += ["Assignments", ""]
+        else:
+            labels += [""]
+        header_label_col = Columns([Text(m) for m in labels])
+        header_widgets.append(header_label_col)
+        self.header_padding = len(header_widgets)
+        self.machine_pile = Pile(header_widgets + self.machine_widgets)
+        return self.machine_pile
+
+    def handle_filter_change(self, edit_button, userdata):
+        self.filter_string = userdata
+        self.update()
+
+    def find_machine_widget(self, m):
+        return next((mw for mw in self.machine_widgets if
+                     mw.machine.instance_id == m.instance_id), None)
+
+    def update(self):
+        machines = app.maas.client.get_machines()
+        if machines is None:
+            if not self.loading:
+                self.loading = True
+                p = (Text("\n\nLoading...", align='center'),
+                     self.machine_pile.options())
+                self.machine_pile.contents.append(p)
+            return
+        if self.loading:
+            self.loading = False
+            self.machine_pile.contents = self.machine_pile.contents[:-1]
+
+        if self.show_only_ready:
+            machines = [m for m in machines
+                        if m.status == MaasMachineStatus.READY]
+        for mw in self.machine_widgets:
+            machine = next((m for m in machines if
+                            mw.machine.instance_id == m.instance_id), None)
+            if machine is None:
+                self.remove_machine(mw.machine)
+
+        n_satisfying_machines = len(machines)
+
+        def get_placement_filter_label(d):
+            s = ""
+            for atype, al in d.items():
+                s += " ".join(["{} {}".format(cc.service_name,
+                                              cc.display_name)
+                               for cc in al])
+            return s
+
+        for m in machines:
+            if not satisfies(m, self.constraints)[0]:
+                self.remove_machine(m)
+                n_satisfying_machines -= 1
+                continue
+
+            filter_label = m.filter_label()
+            if self.filter_string != "" and \
+               self.filter_string not in filter_label:
+                self.remove_machine(m)
+                continue
+
+            mw = self.find_machine_widget(m)
+            if mw is None:
+                mw = self.add_machine_widget(m)
+            mw.all_assigned = self.all_assigned
+            mw.update()
+
+        self.filter_edit_box.set_info(len(self.machine_widgets),
+                                      n_satisfying_machines)
+
+        self.sort_machine_widgets()
+
+    def add_machine_widget(self, machine):
+        mw = MachineWidget(machine,
+                           self.application,
+                           self.select_cb,
+                           self.unselect_cb,
+                           self.controller,
+                           self.show_assignments)
+        self.machine_widgets.append(mw)
+        options = self.machine_pile.options()
+        self.machine_pile.contents.append((mw, options))
+
+        return mw
+
+    def remove_machine(self, machine):
+        mw = self.find_machine_widget(machine)
+        if mw is None:
+            return
+
+        self.machine_widgets.remove(mw)
+        mw_idx = 0
+        for w, opts in self.machine_pile.contents:
+            if w == mw:
+                break
+            mw_idx += 1
+
+        c = self.machine_pile.contents[:mw_idx] + \
+            self.machine_pile.contents[mw_idx + 1:]
+        self.machine_pile.contents = c
+
+    def sort_machine_widgets(self):
+        def keyfunc(mw):
+            m = mw.machine
+            hwinfo = " ".join(map(str, [m.arch, m.cpu_cores, m.mem,
+                                        m.storage]))
+            if str(mw.machine.status) == 'ready':
+                skey = 'A'
+            else:
+                skey = str(mw.machine.status)
+            return skey + mw.machine.hostname + hwinfo
+        self.machine_widgets.sort(key=keyfunc)
+
+        def wrappedkeyfunc(t):
+            mw, options = t
+            if not isinstance(mw, MachineWidget):
+                return 'A'
+            return keyfunc(mw)
+
+        self.machine_pile.contents.sort(key=wrappedkeyfunc)
+
+    def focus_prev_or_top(self):
+        self.update()
+        try:
+            if self.machine_pile.focus_position <= self.header_padding:
+                self.machine_pile.focus_position = self.header_padding
+        except IndexError:
+            log.debug("index error in machines_list focus_top")

--- a/conjureup/ui/widgets/machines_list.py
+++ b/conjureup/ui/widgets/machines_list.py
@@ -35,7 +35,12 @@ class MachinesList(WidgetWrap):
 
     unselect_cb - a function that takes a machine and clears assignments
 
-    context_string - a string that describes what you're picking a machine for
+    target_info - a string that describes what you're picking a machine for
+
+    current_pin_cb - a function that takes a machine and returns
+    None if the machine is not currently selected, or returns a
+    context value to show the user about the current selection (like a
+    juju machine ID that represents the current pin)
 
     constraints - a dict of constraints to filter the machines list.
     only machines matching all the constraints will be shown.
@@ -52,13 +57,16 @@ class MachinesList(WidgetWrap):
 
     """
 
-    def __init__(self, select_cb, unselect_cb, context_string,
+    def __init__(self, select_cb, unselect_cb, target_info,
+                 current_pin_cb,
                  constraints=None, show_hardware=False,
                  title_widgets=None, show_only_ready=False,
                  show_filter_box=False):
         self.select_cb = select_cb
         self.unselect_cb = unselect_cb
-        self.context_string = context_string
+        self.target_info = target_info
+        self.current_pin_cb = current_pin_cb
+
         self.n_selected = 0
         self.machine_widgets = []
         if constraints is None:
@@ -160,10 +168,7 @@ class MachinesList(WidgetWrap):
             mw = self.find_machine_widget(m)
             if mw is None:
                 mw = self.add_machine_widget(m)
-            if not mw.is_selected and self.n_selected > 0:
-                mw.can_select = False
-            else:
-                mw.can_select = True
+
             mw.update()
 
         self.filter_edit_box.set_info(len(self.machine_widgets),
@@ -175,7 +180,8 @@ class MachinesList(WidgetWrap):
         mw = MachineWidget(machine,
                            self.handle_select,
                            self.handle_unselect,
-                           self.context_string)
+                           self.target_info,
+                           self.current_pin_cb)
 
         self.machine_widgets.append(mw)
         options = self.machine_pile.options()

--- a/conjureup/ui/widgets/machines_list.py
+++ b/conjureup/ui/widgets/machines_list.py
@@ -17,8 +17,8 @@ import logging
 
 from urwid import Columns, Divider, Pile, Text, WidgetWrap
 
-from conjureup.maas import MaasMachineStatus, satisfies
 from conjureup.app_config import app
+from conjureup.maas import MaasMachineStatus, satisfies
 from conjureup.ui.widgets.filter_box import FilterBox
 from conjureup.ui.widgets.machine_widget import MachineWidget
 

--- a/conjureup/units.py
+++ b/conjureup/units.py
@@ -1,0 +1,27 @@
+
+def human_to_mb(s):
+    """Translates human-readable strings like '10G' to numeric
+    megabytes"""
+
+    if len(s) == 0:
+        raise Exception("unexpected empty string")
+
+    md = dict(M=1, G=1024, T=1024 * 1024, P=1024 * 1024 * 1024)
+    suffix = s[-1]
+    if suffix.isalpha():
+        return float(s[:-1]) * md[suffix]
+    else:
+        return float(s)
+
+
+def mb_to_human(num):
+    """Translates float number of bytes into human readable strings."""
+    suffixes = ['M', 'G', 'T', 'P']
+    if num == 0:
+        return '0 B'
+
+    i = 0
+    while num >= 1024 and i < len(suffixes) - 1:
+        num /= 1024
+        i += 1
+    return "{:.2f} {}".format(num, suffixes[i])

--- a/test/test_controllers_deploy_gui.py
+++ b/test/test_controllers_deploy_gui.py
@@ -14,6 +14,13 @@ from conjureup.controllers.deploy.gui import DeployController
 class DeployGUIRenderTestCase(unittest.TestCase):
 
     def setUp(self):
+
+        self.get_c_info_patcher = patch(
+            'conjureup.controllers.deploy.gui.get_controller_info')
+        self.mock_get_controller_info = self.get_c_info_patcher.start()
+        self.mock_get_controller_info.return_value = dict(
+            details=dict(cloud='testcloud'))
+
         self.controller = DeployController()
 
         self.utils_patcher = patch(
@@ -43,6 +50,7 @@ class DeployGUIRenderTestCase(unittest.TestCase):
         mock_app = self.app_patcher.start()
         mock_app.ui = MagicMock(name="app.ui")
         mock_app.metadata_controller.bundle = self.mock_bundle
+        mock_app.current_controller = 'testcontroller'
 
         self.juju_patcher = patch(
             'conjureup.controllers.deploy.gui.juju')
@@ -60,6 +68,7 @@ class DeployGUIRenderTestCase(unittest.TestCase):
         self.view_patcher.stop()
         self.app_patcher.stop()
         self.juju_patcher.stop()
+        self.get_c_info_patcher.stop()
         self.track_screen_patcher.stop()
 
     def test_queue_predeploy_once(self):
@@ -68,18 +77,17 @@ class DeployGUIRenderTestCase(unittest.TestCase):
         self.mock_submit.assert_has_calls([self.predeploy_call],
                                           any_order=True)
 
-    def test_call_add_machines_once_only(self):
-        "Call add_machines once"
-        self.controller.render()
-        self.mock_submit.assert_has_calls([self.predeploy_call],
-                                          any_order=True)
-        self.mock_juju.add_machines.assert_called_once_with(
-            [sentinel.machine_1], exc_cb=ANY)
-
 
 class DeployGUIFinishTestCase(unittest.TestCase):
 
     def setUp(self):
+
+        self.get_c_info_patcher = patch(
+            'conjureup.controllers.deploy.gui.get_controller_info')
+        self.mock_get_controller_info = self.get_c_info_patcher.start()
+        self.mock_get_controller_info.return_value = dict(
+            details=dict(cloud='testcloud'))
+
         self.controller = DeployController()
 
         self.controllers_patcher = patch(
@@ -108,6 +116,7 @@ class DeployGUIFinishTestCase(unittest.TestCase):
         self.juju_patcher.stop()
         self.render_patcher.stop()
         self.app_patcher.stop()
+        self.get_c_info_patcher.stop()
 
     def test_show_bootstrap_wait(self):
         "Go to bootstrap wait controller if bootstrap pending"


### PR DESCRIPTION
Add "Architecture" button to each app in applications list.
Opens a screen allowing you to place any of the num_units of the app onto a juju machine. also lets you create new juju machines and edit their constraints (NOTE: constraints broken in this branch)

On MAAS controllers, also lets you 'pin' a maas machine to any of the juju machines to ensure that you get a specific placement if you can't get what you want with constraints.