### PR TITLE
get_machines should return None when loading

### DIFF
--- a/conjureup/maas.py
+++ b/conjureup/maas.py
@@ -120,7 +120,7 @@ class MaasClient:
         """
         cval = self.get_cached('machines')
         if cval is None:
-            return []
+            return cval
         return [MaasMachine(d) for d in cval]
 
     def tag_new(self, tag):

--- a/conjureup/ui/widgets/machine_widget.py
+++ b/conjureup/ui/widgets/machine_widget.py
@@ -81,7 +81,10 @@ class MachineWidget(WidgetWrap):
         Assumes that machine exists - machines going away is handled
         in machineslist.update().
         """
-        self.machine = next((m for m in app.maas.client.get_machines()
+        machines = app.maas.client.get_machines()
+        if machines is None:
+            return
+        self.machine = next((m for m in machines
                              if m.instance_id == self.machine.instance_id),
                             None)
 

--- a/conjureup/ui/widgets/machines_list.py
+++ b/conjureup/ui/widgets/machines_list.py
@@ -130,6 +130,7 @@ class MachinesList(WidgetWrap):
                      self.machine_pile.options())
                 self.machine_pile.contents.append(p)
             return
+
         if self.loading:
             self.loading = False
             self.machine_pile.contents = self.machine_pile.contents[:-1]


### PR DESCRIPTION
re-enables the "Loading" text in machines_list.

Signed-off-by: Michael McCracken <mike.mccracken@canonical.com>