### PR TITLE
remove vestigial old pollinate call

### DIFF
--- a/conjureup/controllers/newcloud/gui.py
+++ b/conjureup/controllers/newcloud/gui.py
@@ -133,7 +133,6 @@ class NewCloudController:
         if self.cloud == 'maas':
             self.cloud = '{}/{}'.format(self.cloud,
                                         credentials['@maas-server'].value)
-        utils.pollinate(app.session_id, 'CA')
         self.__do_bootstrap(credential=credentials_key)
 
     def render(self, cloud):


### PR DESCRIPTION
Note we don't need to replace it with anything new since the new scheme tracks each screen when you render it and you either get the next screen or an error when it's done.

Signed-off-by: Michael McCracken <mike.mccracken@canonical.com>