### PR TITLE
Fixes #540

### DIFF
--- a/conjureup/maas.py
+++ b/conjureup/maas.py
@@ -434,7 +434,8 @@ def satisfies(machine, constraints):
             'cpu_cores': 'cpu_count',
             'cores': 'cpu_count',
             'cpu-cores': 'cpu_count',
-            'root-disk': 'storage'}
+            'root-disk': 'storage',
+            'tags': 'tag_names'}
 
     cons_checks = []
 
@@ -454,6 +455,11 @@ def satisfies(machine, constraints):
             if mval == '*':
                 continue
             if _arch_clean(mval) != _arch_clean(v):
+                cons_checks.append(k)
+
+        elif k == 'tags':
+            mval = machine.machine[kmap[k]]
+            if set(mval) != set(v):
                 cons_checks.append(k)
         else:
             if kmap[k] == 'storage':

--- a/conjureup/ui/views/app_architecture_view.py
+++ b/conjureup/ui/views/app_architecture_view.py
@@ -258,6 +258,7 @@ class AppArchitectureView(WidgetWrap):
                 self.controller.add_assignment(self.application,
                                                juju_machine_id, atype)
 
+        self.controller.clear_machine_pins()
         for j_m_id, m in self.shadow_pins.items():
             self.controller.set_machine_pin(j_m_id, m)
 


### PR DESCRIPTION
Fixes issue where re-pinning a machine caused a crash. (Fixes #540.)

Also fixes a problem later where removing a pin did not persist after apply.
Now correctly clears pins in commit before replaying shadow pins.

Signed-off-by: Michael McCracken <mike.mccracken@canonical.com>