### PR TITLE
fix use without access to google analytics

### DIFF
--- a/conjureup/telemetry.py
+++ b/conjureup/telemetry.py
@@ -1,5 +1,6 @@
 
 import requests
+from functools import partial
 
 from conjureup import __version__ as VERSION
 from conjureup.app_config import app
@@ -16,7 +17,8 @@ def track_screen(screen_name):
                 t="screenview")
     if 'spell' in app.config:
         args['cd1'] = app.config['spell']
-    submit(_post_track(args), lambda _: None,
+
+    submit(partial(_post_track, args), lambda _: None,
            queue_name=TELEMETRY_ASYNC_QUEUE)
 
 
@@ -30,7 +32,7 @@ def track_event(category, action, label):
                 t='event')
     if 'spell' in app.config:
         args['cd1'] = app.config['spell']
-    submit(_post_track(args), lambda _: None,
+    submit(partial(_post_track, args), lambda _: None,
            queue_name=TELEMETRY_ASYNC_QUEUE)
 
 
@@ -44,7 +46,7 @@ def track_exception(description, is_fatal=True):
                 exf=exf)
     if 'spell' in app.config:
         args['cd1'] = app.config['spell']
-    submit(_post_track(args), lambda _: None,
+    submit(partial(_post_track, args), lambda _: None,
            queue_name=TELEMETRY_ASYNC_QUEUE)
 
 

--- a/conjureup/telemetry.py
+++ b/conjureup/telemetry.py
@@ -1,6 +1,7 @@
 
-import requests
 from functools import partial
+
+import requests
 
 from conjureup import __version__ as VERSION
 from conjureup.app_config import app


### PR DESCRIPTION
use partial to delay eval until actually called in separate thread.
d'oh, of course this was the original intent

Fixes #554.

Signed-off-by: Michael McCracken <mike.mccracken@canonical.com>