### PR TITLE
Snap sysctl increase

### DIFF
--- a/snap/hooks/configure
+++ b/snap/hooks/configure
@@ -13,3 +13,15 @@ iptables -I INPUT -i conjureup0 -p tcp -m tcp --dport 53 -j ACCEPT
 iptables -I INPUT -i conjureup0 -p udp -m udp --dport 53 -j ACCEPT
 iptables -I INPUT -i conjureup0 -p tcp -m tcp --dport 67 -j ACCEPT
 iptables -I INPUT -i conjureup0 -p udp -m udp --dport 67 -j ACCEPT
+
+# TODO: This should be addressed with a sysctl interface once we start
+# moving this application over to a strict confinement. For now though,
+# increase the resources for LXD to utilize.
+#
+# TODO: Snapd should look into supporting tear down hooks for snap
+# remove. File bug at https://launchpad.net/snapd
+sysctl -w net.ipv4.ip_forward=1
+sysctl -w fs.inotify.max_user_instances = 1048576
+sysctl -w fs.inotify.max_queued_events = 1048576
+sysctl -w fs.inotify.max_user_watches = 1048576
+sysctl -w vm.max_map_count = 262144

--- a/snap/hooks/configure
+++ b/snap/hooks/configure
@@ -1,10 +1,8 @@
-#!/bin/sh
+#!/bin/bash
 
 ip link add dev conjureup0 type bridge
 ip addr add 10.99.0.1/24 dev conjureup0
 ip link set dev conjureup0 up
-
-echo 1 > /proc/sys/net/ipv4/ip_forward
 
 iptables -I FORWARD -i conjureup0 -j ACCEPT
 iptables -I FORWARD -o conjureup0 -j ACCEPT
@@ -20,8 +18,12 @@ iptables -I INPUT -i conjureup0 -p udp -m udp --dport 67 -j ACCEPT
 #
 # TODO: Snapd should look into supporting tear down hooks for snap
 # remove. File bug at https://launchpad.net/snapd
-sysctl -w net.ipv4.ip_forward=1
-sysctl -w fs.inotify.max_user_instances = 1048576
-sysctl -w fs.inotify.max_queued_events = 1048576
-sysctl -w fs.inotify.max_user_watches = 1048576
-sysctl -w vm.max_map_count = 262144
+cat<<EOF>/etc/sysctl.d/60-conjure-up.conf
+net.ipv4.ip_forward = 1
+fs.inotify.max_user_instances = 1048576
+fs.inotify.max_queued_events = 1048576
+fs.inotify.max_user_watches = 1048576
+vm.max_map_count = 262144
+EOF
+
+sysctl -p


### PR DESCRIPTION
We need to expand the lxd's capabilities so that some of the more intensive spells have enough resources to complete successfully. This only affects snap installs as the debian based install still requires manually editing of the sysctl. 