### PR TITLE
Ensure that bundle placement directives are always used and shown in UI

### DIFF
--- a/conjureup/controllers/deploy/gui.py
+++ b/conjureup/controllers/deploy/gui.py
@@ -122,7 +122,6 @@ class DeployController:
 
     def sync_assignments(self):
         bundle = app.metadata_controller.bundle
-        midx = 0
         for bundle_application in bundle.services:
             deployargs = bundle_application.as_deployargs()
             spec_list = deployargs.get('placement', [])

--- a/conjureup/controllers/deploy/gui.py
+++ b/conjureup/controllers/deploy/gui.py
@@ -25,6 +25,14 @@ class DeployController:
         self.deployed_juju_machines = {}
         self.maas_machine_map = {}
 
+        # If no machines are specified, add a machine for each app:
+        bundle = app.metadata_controller.bundle
+
+        if len(bundle.machines) == 0:
+            self.generate_juju_machines()
+        else:
+            self.sync_assignments()
+
     def _handle_exception(self, tag, exc):
         track_exception(exc.args[0])
         app.ui.show_exception_message(exc)
@@ -86,14 +94,6 @@ class DeployController:
         app.ui.set_body(cv)
 
     def do_architecture(self, application, sender):
-        # If no machines are specified, add a machine for each app:
-        bundle = app.metadata_controller.bundle
-
-        if len(bundle.machines) == 0:
-            self.generate_juju_machines()
-        else:
-            self.sync_assignments()
-
         av = AppArchitectureView(application,
                                  self)
         app.ui.set_header(av.header)

--- a/conjureup/controllers/deploy/gui.py
+++ b/conjureup/controllers/deploy/gui.py
@@ -24,7 +24,9 @@ class DeployController:
         self.assignments = defaultdict(list)
         self.deployed_juju_machines = {}
         self.maas_machine_map = {}
+        self.sync_with_bundle()
 
+    def sync_with_bundle(self):
         # If no machines are specified, add a machine for each app:
         bundle = app.metadata_controller.bundle
 

--- a/conjureup/log.py
+++ b/conjureup/log.py
@@ -22,6 +22,9 @@ class _log:
     def exception(self, msg):
         self.logger.exception("{}: {}".format(self.app, msg))
 
+    def warning(self, msg):
+        self.logger.warning("{}: {}".format(self.app, msg))
+
 
 def setup_logging(app, logfile, debug=False):
     try:

--- a/test/test_controllers_deploy_gui.py
+++ b/test/test_controllers_deploy_gui.py
@@ -14,7 +14,8 @@ from conjureup.controllers.deploy.gui import DeployController
 class DeployGUIRenderTestCase(unittest.TestCase):
 
     def setUp(self):
-        self.controller = DeployController()
+        with patch.object(DeployController, 'sync_with_bundle'):
+            self.controller = DeployController()
 
         self.utils_patcher = patch(
             'conjureup.controllers.deploy.gui.utils')
@@ -73,7 +74,8 @@ class DeployGUIRenderTestCase(unittest.TestCase):
 class DeployGUIFinishTestCase(unittest.TestCase):
 
     def setUp(self):
-        self.controller = DeployController()
+        with patch.object(DeployController, 'sync_with_bundle'):
+            self.controller = DeployController()
 
         self.controllers_patcher = patch(
             'conjureup.controllers.deploy.gui.controllers')


### PR DESCRIPTION
Fixes #553 

Since #514, bundles that came with placement directives were only partially shown in the ui and the placement directives were ignored when deploying.
The bundle's machines and their constraints were used but the directives in the individual applications were ignored.

Test this by deploying openstack-base or kubernetes-core onto MAAS and note that without this branch they use one machine per service. With the branch they use 4 and 2 machines respectively, and many services are on lxds.