### PR TITLE
Snappy updates

### DIFF
--- a/conjureup/app.py
+++ b/conjureup/app.py
@@ -306,16 +306,6 @@ def main():
 
         show_env()
 
-    # XXX: This is temporary for snap installs once snap dependencies
-    # can be defined (similar to apt package deps)
-    if not utils.check_deb_installed('lxd-client'):
-        if not utils.is_snap_package_installed('lxd'):
-            utils.warning("This next step utilizes snappy to install LXD "
-                          "and requires you to enter a sudo password. ")
-            utils.run_script('sudo snap install lxd')
-            lxd_dir = os.environ['SNAP_COMMON']
-            app.env['LXD_DIR'] = lxd_dir
-
     if app.argv.cloud:
         if app.endpoint_type in [None, EndpointType.LOCAL_SEARCH]:
             utils.error("Please specify a spell for headless mode.")

--- a/conjureup/log.py
+++ b/conjureup/log.py
@@ -27,24 +27,20 @@ class _log:
 
 
 def setup_logging(app, logfile, debug=False):
-    try:
-        cmdslog = TimedRotatingFileHandler(logfile,
-                                           when='D',
-                                           interval=1,
-                                           backupCount=7)
-    except FileNotFoundError as e:
-        # SNAP: This failing
-        # May need to do something different for snappy
-        cmdslog = logging.FileHandler('deploy-done.log')
+    cmdslog = TimedRotatingFileHandler(logfile,
+                                       when='D',
+                                       interval=1,
+                                       backupCount=7)
 
     if debug:
         env = logging.DEBUG
         cmdslog.setFormatter(logging.Formatter(
-            "%(name)s: [%(levelname)s] %(filename)s:%(lineno)d - %(message)s"))
+            "%(asctime)s %(name)s: [%(levelname)s] "
+            "%(filename)s:%(lineno)d - %(message)s"))
     else:
         env = logging.INFO
         cmdslog.setFormatter(logging.Formatter(
-            "%(name)s: [%(levelname)s] %(message)s"))
+            "%(asctime)s %(name)s: [%(levelname)s] %(message)s"))
 
     cmdslog.setLevel(env)
 

--- a/snap/hooks/configure
+++ b/snap/hooks/configure
@@ -1,8 +1,52 @@
 #!/bin/bash
 
+
+VERSION=$(lxd --version)
+
+# LXD 2.3+ needs lxdbr0 setup via lxc.
+if dpkg --compare-versions "$VERSION" gt "2.2"; then
+    if ! lxc network list | grep -q lxdbr0; then
+        # Configure a known address ranges for lxdbr0.
+        lxc network create lxdbr0 \
+            ipv4.address=10.0.8.1/24 ipv4.nat=true \
+            ipv6.address=none ipv6.nat=false
+    fi
+    lxc network show lxdbr0
+    lxc config show
+else
+    # LXD 2.2 and earlier use debconf to create and configure the network.
+    sudo debconf-communicate << EOF
+set lxd/setup-bridge true
+set lxd/bridge-domain lxd
+set lxd/bridge-name lxdbr0
+set lxd/bridge-ipv4 true
+set lxd/bridge-ipv4-address 10.0.8.1
+set lxd/bridge-ipv4-dhcp-first 10.0.8.2
+set lxd/bridge-ipv4-dhcp-last 10.0.8.254
+set lxd/bridge-ipv4-dhcp-leases 252
+set lxd/bridge-ipv4-netmask 24
+set lxd/bridge-ipv4-nat true
+set lxd/bridge-ipv6 false
+EOF
+
+    sudo rm -rf /etc/default/lxd-bridge
+
+    sudo dpkg-reconfigure lxd --frontend=noninteractive
+
+    # Must run a command for systemd socket activation to start the service
+    lxc config show
+fi
+
+sysctl fs.inotify.max_user_instances=1048576
+sysctl fs.inotify.max_queued_events=1048576
+sysctl fs.inotify.max_user_watches=1048576
+sysctl vm.max_map_count=262144
+
 ip link add dev conjureup0 type bridge
 ip addr add 10.99.0.1/24 dev conjureup0
 ip link set dev conjureup0 up
+
+echo 1 > /proc/sys/net/ipv4/ip_forward
 
 iptables -I FORWARD -i conjureup0 -j ACCEPT
 iptables -I FORWARD -o conjureup0 -j ACCEPT
@@ -11,19 +55,3 @@ iptables -I INPUT -i conjureup0 -p tcp -m tcp --dport 53 -j ACCEPT
 iptables -I INPUT -i conjureup0 -p udp -m udp --dport 53 -j ACCEPT
 iptables -I INPUT -i conjureup0 -p tcp -m tcp --dport 67 -j ACCEPT
 iptables -I INPUT -i conjureup0 -p udp -m udp --dport 67 -j ACCEPT
-
-# TODO: This should be addressed with a sysctl interface once we start
-# moving this application over to a strict confinement. For now though,
-# increase the resources for LXD to utilize.
-#
-# TODO: Snapd should look into supporting tear down hooks for snap
-# remove. File bug at https://launchpad.net/snapd
-cat<<EOF>/etc/sysctl.d/60-conjure-up.conf
-net.ipv4.ip_forward = 1
-fs.inotify.max_user_instances = 1048576
-fs.inotify.max_queued_events = 1048576
-fs.inotify.max_user_watches = 1048576
-vm.max_map_count = 262144
-EOF
-
-sysctl -p

--- a/snap/hooks/configure
+++ b/snap/hooks/configure
@@ -15,7 +15,7 @@ if dpkg --compare-versions "$VERSION" gt "2.2"; then
     lxc config show
 else
     # LXD 2.2 and earlier use debconf to create and configure the network.
-    sudo debconf-communicate << EOF
+    debconf-communicate << EOF
 set lxd/setup-bridge true
 set lxd/bridge-domain lxd
 set lxd/bridge-name lxdbr0
@@ -29,18 +29,22 @@ set lxd/bridge-ipv4-nat true
 set lxd/bridge-ipv6 false
 EOF
 
-    sudo rm -rf /etc/default/lxd-bridge
+    rm -rf /etc/default/lxd-bridge
 
-    sudo dpkg-reconfigure lxd --frontend=noninteractive
+    dpkg-reconfigure lxd --frontend=noninteractive
 
     # Must run a command for systemd socket activation to start the service
     lxc config show
 fi
 
+cat <<EOF>/etc/sysctl.d/60-conjure-up.conf
 sysctl fs.inotify.max_user_instances=1048576
 sysctl fs.inotify.max_queued_events=1048576
 sysctl fs.inotify.max_user_watches=1048576
 sysctl vm.max_map_count=262144
+EOF
+
+sysctl -p/etc/sysctl.d/60-conjure-up.conf
 
 ip link add dev conjureup0 type bridge
 ip addr add 10.99.0.1/24 dev conjureup0

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -12,16 +12,12 @@ apps:
   conjure-up:
     command: conjure-up-wrapper
   juju:
-    command: juju-wrapper
-    aliases:
-      - juju
+    command: bin/juju
   bridge:
     command: bridge.start
     stop-command: bridge.stop
     restart-condition: never
     daemon: oneshot
-  shell:
-    command: bash
 
 parts:
   conjure:
@@ -29,13 +25,15 @@ parts:
     source: .
     requirements: requirements.txt
     stage-packages:
-      - locales
-      - libc-bin
       - bsdtar
-      - coreutils
       - jq
-      - iproute2
-      - iptables
+    stage:
+      - -usr/bin/2to3-3.5
+      - -usr/bin/py3clean
+      - -usr/bin/py3compile
+      - -usr/bin/pydoc3.5
+      - -usr/share/dh-python
+      - -usr/share/python3/py3versions.py
   conjure-configs:
     plugin: dump
     source: .

--- a/snapcraft/script/bridge.start
+++ b/snapcraft/script/bridge.start
@@ -1,11 +1,22 @@
 #!/bin/sh
 
+logger -t "conjure-up/systemd" "[DEBUG] Setting sysctl settings"
+
+sysctl fs.inotify.max_user_instances=1048576
+sysctl fs.inotify.max_queued_events=1048576
+sysctl fs.inotify.max_user_watches=1048576
+sysctl vm.max_map_count=262144
+
+logger -t "conjure-up/systemd" "[DEBUG] Creating conjure-up network bridge"
 ip link add dev conjureup0 type bridge
 ip addr add 10.99.0.1/24 dev conjureup0
 ip link set dev conjureup0 up
 
+sleep 5
+
 echo 1 > /proc/sys/net/ipv4/ip_forward
 
+logger -t "conjure-up/systemd" "[DEBUG] Defining iptables rules"
 iptables -I FORWARD -i conjureup0 -j ACCEPT
 iptables -I FORWARD -o conjureup0 -j ACCEPT
 iptables -t nat -A POSTROUTING -s 10.99.0.1/24 ! -d 10.99.0.1/24 -j MASQUERADE

--- a/snapcraft/script/bridge.start
+++ b/snapcraft/script/bridge.start
@@ -1,12 +1,5 @@
 #!/bin/sh
 
-logger -t "conjure-up/systemd" "[DEBUG] Setting sysctl settings"
-
-sysctl fs.inotify.max_user_instances=1048576
-sysctl fs.inotify.max_queued_events=1048576
-sysctl fs.inotify.max_user_watches=1048576
-sysctl vm.max_map_count=262144
-
 logger -t "conjure-up/systemd" "[DEBUG] Creating conjure-up network bridge"
 ip link add dev conjureup0 type bridge
 ip addr add 10.99.0.1/24 dev conjureup0

--- a/snapcraft/script/bridge.stop
+++ b/snapcraft/script/bridge.stop
@@ -3,6 +3,8 @@
 ip addr flush dev conjureup0
 ip link set dev conjureup0 down
 
+sleep 5
+
 iptables -D FORWARD -i conjureup0 -j ACCEPT
 iptables -D FORWARD -o conjureup0 -j ACCEPT
 

--- a/snapcraft/script/conjure-up-wrapper
+++ b/snapcraft/script/conjure-up-wrapper
@@ -1,21 +1,14 @@
 #!/bin/sh
 
-export HOME=$SNAP_USER_DATA
-
-export I18NPATH=$SNAP/usr/share/i18n
-export LOCPATH=$SNAP_USER_DATA
-
 APPLANG=en_US
 APPENC=UTF-8
 APPLOC="$APPLANG.$APPENC"
-
-# generate a locale so we get properly working charsets and graphics
-if [ ! -e $SNAP_USER_DATA/$APPLOC ]; then
-  localedef --prefix=$SNAP_USER_DATA -f $APPENC -i $APPLANG $SNAP_USER_DATA/$APPLOC
-fi
 
 export LC_ALL=$APPLOC
 export LANG=$APPLOC
 export LANGUAGE=${APPLANG%_*}
 
-$SNAP/bin/conjure-up -c $SNAP/etc/conjure-up.conf --spells-dir $SNAP_USER_COMMON/spells --cache-dir $SNAP_USER_DATA/conjure-up "$@"
+# Make sure a lxc certificate is generated within the snap
+lxc finger
+
+$SNAP/bin/conjure-up -c $SNAP/etc/conjure-up.conf "$@"

--- a/snapcraft/script/juju-wrapper
+++ b/snapcraft/script/juju-wrapper
@@ -1,4 +1,0 @@
-#!/bin/sh
-
-export LXD_DIR=${SNAP_COMMON}/lxd/
-$SNAP/bin/juju "$@"


### PR DESCRIPTION
- improve network and sysctl settings for localhost.
  Sets up a network bridge via systemd along with for
  the current environment so users can deploy to localhost
  immediately.
- pull in lxc/lxd as parts dependencies.
  We utilize the LXD snap part so it is built in the
  same exact way as upstream. This will allow us to
  stabilize conjure-up on a known set of dependency versions
  even across distro series.
- correct proper paths in a snap environment.
  in classic mode this allows us to utilize the filesystem
  as normal and makes the transition to snap much easier.

Signed-off-by: Adam Stokes <battlemidget@users.noreply.github.com>