### PR TITLE
Fixes #583

### DIFF
--- a/conjureup/app.py
+++ b/conjureup/app.py
@@ -319,6 +319,7 @@ def main():
     else:
         app.ui = ConjureUI()
         EventLoop.build_loop(app.ui, STYLES,
-                             unhandled_input=unhandled_input)
+                             unhandled_input=unhandled_input,
+                             handle_mouse=False)
         EventLoop.set_alarm_in(0.05, _start)
         EventLoop.run()


### PR DESCRIPTION
We don't heavily test the use of a mouse within the conjure-up terminal UI.
Disable this feature to limit any unexpected results when a mouse click is
registered inside the app.

Signed-off-by: Adam Stokes <battlemidget@users.noreply.github.com>