### PR TITLE
bson python library no longer needed

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,6 @@ requests_unixsocket
 ws4py==0.3.4
 nose
 tox
-bson
 termcolor
 petname
 progressbar2


### PR DESCRIPTION
We included this when we were pulling a seperate maasclient. Since writing a
small api client inside conjure-up this is no longer needed.

Signed-off-by: Adam Stokes <battlemidget@users.noreply.github.com>