### PR TITLE
Adds optional ability to use an existing spell dir

### DIFF
--- a/conjureup/app.py
+++ b/conjureup/app.py
@@ -219,7 +219,10 @@ def main():
     spells_dir = app.argv.spells_dir
 
     app.config['spells-dir'] = spells_dir
+    spells_index_path = os.path.join(app.config['spells-dir'],
+                                     'spells-index.yaml')
     spells_registry_branch = os.getenv('CONJUREUP_REGISTRY_BRANCH', 'master')
+
     if not app.argv.nosync:
         if not os.path.exists(spells_dir):
             utils.info("No spells found, syncing from registry, please wait.")
@@ -235,15 +238,13 @@ def main():
             app.log.debug(
                 'Could not sync spells from github: {}'.format(e))
     else:
-        if not os.path.exists(spells_dir):
+        if not os.path.exists(spells_index_path):
             utils.error(
                 "You opted to not sync from the spells registry, however, "
                 "we could not find any suitable spells in: "
                 "{}".format(spells_dir))
             sys.exit(1)
 
-    spells_index_path = os.path.join(app.config['spells-dir'],
-                                     'spells-index.yaml')
     with open(spells_index_path) as fp:
         app.spells_index = yaml.safe_load(fp.read())
 

--- a/conjureup/app.py
+++ b/conjureup/app.py
@@ -221,7 +221,7 @@ def main():
     app.config['spells-dir'] = spells_dir
     spells_index_path = os.path.join(app.config['spells-dir'],
                                      'spells-index.yaml')
-    spells_registry_branch = os.getenv('CONJUREUP_REGISTRY_BRANCH', 'master')
+    spells_registry_branch = os.getenv('CONJUREUP_REGISTRY_BRANCH', 'stable')
 
     if not app.argv.nosync:
         if not os.path.exists(spells_dir):

--- a/conjureup/app.py
+++ b/conjureup/app.py
@@ -234,6 +234,13 @@ def main():
 
             app.log.debug(
                 'Could not sync spells from github: {}'.format(e))
+    else:
+        if not os.path.exists(spells_dir):
+            utils.error(
+                "You opted to not sync from the spells registry, however, "
+                "we could not find any suitable spells in: "
+                "{}".format(spells_dir))
+            sys.exit(1)
 
     spells_index_path = os.path.join(app.config['spells-dir'],
                                      'spells-index.yaml')

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -34,12 +34,19 @@ parts:
     stage-packages:
       - bsdtar
       - jq
-  configs:
-    plugin: dump
-    source: https://github.com/conjure-up/conjure-up
-    source-type: git
     filesets:
       etc/conjure-up.conf: [etc/conjure-up.conf]
+    stage:
+      - -README.md
+      - -debian
+  spells:
+    plugin: dump
+    source: https://github.com/conjure-up/spells.git
+    source-type: git
+    organize:
+      "*": spells/
+    stage:
+      - -README.md
   wrappers:
     plugin: dump
     source: snap/

--- a/snap/wrappers/conjure-up
+++ b/snap/wrappers/conjure-up
@@ -11,4 +11,4 @@ export LANGUAGE=${APPLANG%_*}
 # Make sure a lxc certificate is generated within the snap
 lxc finger > /dev/null 2>&1
 
-exec $SNAP/bin/conjure-up -c $SNAP/etc/conjure-up.conf "$@"
+exec $SNAP/bin/conjure-up -c $SNAP/etc/conjure-up.conf --spells-dir $SNAP/spells --nosync "$@"


### PR DESCRIPTION
This is mainly for snaps where we want to include spells inside the snap. This
is optional and is up to however package maintainers wish to handle this.

Signed-off-by: Adam Stokes <battlemidget@users.noreply.github.com>