### PR TITLE
Always store constraint values as ints, MiB units

### DIFF
--- a/conjureup/juju.py
+++ b/conjureup/juju.py
@@ -322,7 +322,9 @@ def get_cloud(name):
 
 
 def constraints_to_dict(constraints):
-    """Parses a constraint string into a dict"""
+    """Parses a constraint string into a dict. Does not do unit
+    conversion. Expects root-disk, mem and cores to be int values, and
+    root-disk and mem should be in megabytes."""
     new_constraints = {}
     if not isinstance(constraints, str):
         app.log.debug(
@@ -337,6 +339,11 @@ def constraints_to_dict(constraints):
             constraint, value = c.split('=')
             if constraint in ['tags', 'spaces']:
                 value = value.split(',')
+            elif constraint in ['root-disk', 'mem', 'cores']:
+                value = int(value)
+            else:
+                raise Exception(
+                    "Unsupported constraint: {}".format(constraint))
             new_constraints[constraint] = value
         except ValueError as e:
             app.log.debug("Skipping constraint: {} ({})".format(c, e))

--- a/conjureup/units.py
+++ b/conjureup/units.py
@@ -15,11 +15,11 @@ def _human_to(s, md):
     if len(s) == 0:
         raise Exception("unexpected empty string")
 
-    suffix = s[-1]
+    suffix = s[-1].upper()
     if suffix.isalpha():
-        return float(s[:-1]) * md[suffix]
+        return int(float(s[:-1]) * md[suffix])
     else:
-        return float(s)
+        return int(s)
 
 
 def mb_to_human(num):
@@ -36,10 +36,10 @@ def gb_to_human(num):
 
 def _to_human(num, suffixes):
     if num == 0:
-        return '0 B'
+        return '0B'
 
     i = 0
     while num >= 1024 and i < len(suffixes) - 1:
         num /= 1024
         i += 1
-    return "{:.2f} {}".format(num, suffixes[i])
+    return "{:d}{}".format(num, suffixes[i])


### PR DESCRIPTION
Fixes #654

Internally store constraint values as integers and only using megabytes,
to match juju api expectations. Translate to and from gigabytes in the
UI (juju_machine_widget.py)

Signed-off-by: Michael McCracken <mike.mccracken@canonical.com>