### PR TITLE
Expose MAAS endpoint and api_key for use in steps

### DIFF
--- a/conjureup/app_config.py
+++ b/conjureup/app_config.py
@@ -12,7 +12,13 @@ bootstrap = SimpleNamespace(
 
 maas = SimpleNamespace(
     # Client
-    client=None
+    client=None,
+
+    # API key
+    api_key=None,
+
+    # API Endpoint
+    endpoint=None
 )
 
 juju = SimpleNamespace(

--- a/conjureup/controllers/steps/common.py
+++ b/conjureup/controllers/steps/common.py
@@ -74,6 +74,11 @@ def do_step(step_model, step_widget, message_cb, gui=False):
     app.env['JUJU_CONTROLLER'] = app.current_controller
     app.env['JUJU_MODEL'] = app.current_model
 
+    if info['provider-type'] == "maas":
+        # Expose MAAS endpoints and tokens
+        app.env['MAAS_ENDPOINT'] == app.maas.endpoint
+        app.env['MAAS_APIKEY'] == app.maas.api_key
+
     # Set environment variables so they can be accessed from the step scripts
     set_env(step_model.additional_input)
 

--- a/conjureup/maas.py
+++ b/conjureup/maas.py
@@ -405,6 +405,8 @@ def setup_maas():
     except:
         raise Exception("Could not parse MAAS API Key '{}'".format(api_key))
 
+    app.maas.endpoint = endpoint
+    app.maas.api_key = api_key
     app.maas.client = MaasClient(server_address=endpoint,
                                  consumer_key=consumer_key,
                                  token_key=token_key,


### PR DESCRIPTION
This was an addition for LDS but is general enough to apply for other spells
that may require it.

Example use: https://github.com/battlemidget/landscape-spell/blob/master/steps/step-01_register-autopilot

Signed-off-by: Adam Stokes <battlemidget@users.noreply.github.com>