### PR TITLE
Better error dialog handling, especially for bootstrap failures

### DIFF
--- a/conjureup/app_config.py
+++ b/conjureup/app_config.py
@@ -85,4 +85,8 @@ app = SimpleNamespace(
     headless=False,
 
     # Remote endpoint type (An enum, see download.py)
-    endpoint_type=None)
+    endpoint_type=None,
+
+    # Flag so we only show the initial cause even if future async
+    # events also raise cascading errors
+    showing_error=False)

--- a/conjureup/async.py
+++ b/conjureup/async.py
@@ -42,7 +42,7 @@ def submit(func, exc_callback, queue_name="DEFAULT"):
             q.q(qstatsf())
     if ShutdownEvent.is_set():
         log.debug("ignoring async.submit due to impending shutdown.")
-        return
+        return None
     f = _queues[queue_name].submit(func)
     if ENABLE_LOG:
         _queueLog[queue_name][func] = ("added", time.time(), None, None, None)

--- a/conjureup/controllers/bootstrapwait/gui.py
+++ b/conjureup/controllers/bootstrapwait/gui.py
@@ -34,7 +34,8 @@ class BootstrapWaitController:
         app.ui.set_header(title="Waiting")
         app.ui.set_body(self.view)
 
-        app.bootstrap.running.add_done_callback(self.finish)
+        if app.bootstrap.running:
+            app.bootstrap.running.add_done_callback(self.finish)
         self.__refresh()
 
 

--- a/conjureup/controllers/deploy/gui.py
+++ b/conjureup/controllers/deploy/gui.py
@@ -354,7 +354,7 @@ class DeployController:
         # screen was already shown. We should bail to avoid
         # overwriting the error screen.
         bf = app.bootstrap.running
-        if bf and bf.exception():
+        if bf and bf.done() and bf.exception():
             return
 
         track_screen("Deploy")

--- a/conjureup/controllers/deploy/gui.py
+++ b/conjureup/controllers/deploy/gui.py
@@ -47,9 +47,11 @@ class DeployController:
             self.sync_assignments()
 
     def _handle_exception(self, tag, exc):
+        if app.showing_error:
+            return
+        app.showing_error = True
         track_exception(exc.args[0])
         app.ui.show_exception_message(exc)
-        self.showing_error = True
         EventLoop.remove_alarms()
 
     def _pre_deploy_exec(self):
@@ -68,27 +70,24 @@ class DeployController:
             msg = "Running pre-deployment tasks."
             app.log.debug(msg)
             app.ui.set_footer(msg)
-            return utils.run(pre_deploy_sh,
-                             shell=True,
-                             stdout=PIPE,
-                             stderr=PIPE,
-                             env=app.env)
+            out = utils.run(pre_deploy_sh,
+                            shell=True,
+                            stdout=PIPE,
+                            stderr=PIPE,
+                            env=app.env)
+            return out.stdout.decode()
         return json.dumps({'message': 'No pre deploy necessary',
                            'returnCode': 0,
                            'isComplete': True})
 
     def _pre_deploy_done(self, future):
-        try:
-            result = json.loads(future.result().stdout.decode())
-        except AttributeError:
-            result = json.loads(future.result())
-        except:
-            return self._handle_exception(
-                'E003',
-                Exception(
-                    "Problem with pre-deploy: \n{}, ".format(
-                        future.result())))
 
+        e = future.exception()
+        if e:
+            self._handle_exception('E003', e)
+            return
+
+        result = json.loads(future.result())
         app.log.debug("pre_deploy_done: {}".format(result))
         if result['returnCode'] > 0:
             track_exception("Pre-deploy error")
@@ -351,12 +350,20 @@ class DeployController:
             return controllers.use('deploystatus').render(f)
 
     def render(self):
+        # If bootstrap fails fast, we may be called after the error
+        # screen was already shown. We should bail to avoid
+        # overwriting the error screen.
+        bf = app.bootstrap.running
+        if bf and bf.exception():
+            return
+
         track_screen("Deploy")
         try:
             future = async.submit(self._pre_deploy_exec,
                                   partial(self._handle_exception, 'E003'),
                                   queue_name=juju.JUJU_ASYNC_QUEUE)
-            future.add_done_callback(self._pre_deploy_done)
+            if future:
+                future.add_done_callback(self._pre_deploy_done)
         except Exception as e:
             return self._handle_exception('E003', e)
 

--- a/conjureup/controllers/deploystatus/gui.py
+++ b/conjureup/controllers/deploystatus/gui.py
@@ -36,7 +36,8 @@ class DeployStatusController:
                                       app.ui.set_footer),
                               self.__handle_exception,
                               queue_name=juju.JUJU_ASYNC_QUEUE)
-        future.add_done_callback(self.finish)
+        if future:
+            future.add_done_callback(self.finish)
 
     def finish(self, future):
         if not future.exception():
@@ -63,8 +64,9 @@ class DeployStatusController:
         )
         app.ui.set_body(self.view)
         self.__refresh()
-        last_deploy_action_future.add_done_callback(
-            self.__wait_for_applications)
+        if last_deploy_action_future:
+            last_deploy_action_future.add_done_callback(
+                self.__wait_for_applications)
 
 
 _controller_class = DeployStatusController

--- a/conjureup/controllers/deploystatus/tui.py
+++ b/conjureup/controllers/deploystatus/tui.py
@@ -31,7 +31,8 @@ class DeployStatusController:
                                       utils.info),
                               self.__handle_exception,
                               queue_name=juju.JUJU_ASYNC_QUEUE)
-        future.add_done_callback(self.finish)
+        if future:
+            future.add_done_callback(self.finish)
 
 
 _controller_class = DeployStatusController

--- a/conjureup/controllers/destroyconfirm/gui.py
+++ b/conjureup/controllers/destroyconfirm/gui.py
@@ -22,8 +22,8 @@ class DestroyConfirm:
         future = juju.destroy_model_async(controller=controller_name,
                                           model=model_name,
                                           exc_cb=self.__handle_exception)
-        future.add_done_callback(
-            self.__handle_destroy_done)
+        if future:
+            future.add_done_callback(self.__handle_destroy_done)
 
     def __handle_destroy_done(self, future):
         if not future.exception():

--- a/conjureup/controllers/steps/gui.py
+++ b/conjureup/controllers/steps/gui.py
@@ -87,7 +87,8 @@ class StepsController:
                                       app.ui.set_footer,
                                       gui=True),
                               partial(self.__handle_exception, 'E002'))
-        future.add_done_callback(self.get_result)
+        if future:
+            future.add_done_callback(self.get_result)
 
     def update(self, *args):
         for w in self.all_step_widgets:

--- a/conjureup/juju.py
+++ b/conjureup/juju.py
@@ -1,7 +1,5 @@
 """ Juju helpers
 """
-import q
-
 import os
 from concurrent import futures
 from functools import partial, wraps

--- a/conjureup/juju.py
+++ b/conjureup/juju.py
@@ -1,5 +1,7 @@
 """ Juju helpers
 """
+import q
+
 import os
 from concurrent import futures
 from functools import partial, wraps

--- a/conjureup/maas.py
+++ b/conjureup/maas.py
@@ -110,7 +110,8 @@ class MaasClient:
         if c_val is None or now - c_ts > 5:
             f = submit(partial(self._get_key_sync, key),
                        lambda _: None)
-            f.add_done_callback(partial(self._update_cache, key))
+            if f:
+                f.add_done_callback(partial(self._update_cache, key))
 
         return c_val
 

--- a/conjureup/ui/__init__.py
+++ b/conjureup/ui/__init__.py
@@ -28,7 +28,7 @@ class ConjureUI(Frame):
         async.shutdown()
         EventLoop.remove_alarms()
         self.frame.body = ErrorView(errmsg)
-        app.log.exception("Showing dialog for exception:")
+        app.log.debug("Showing dialog for exception: {}".format(ex))
 
     def show_error_message(self, msg):
         self.frame.body = ErrorView(msg)

--- a/test/test_controllers_deploy_gui.py
+++ b/test/test_controllers_deploy_gui.py
@@ -45,6 +45,7 @@ class DeployGUIRenderTestCase(unittest.TestCase):
         mock_app.ui = MagicMock(name="app.ui")
         mock_app.metadata_controller.bundle = self.mock_bundle
         mock_app.current_controller = 'testcontroller'
+        mock_app.bootstrap.running.exception.return_value = None
 
         self.juju_patcher = patch(
             'conjureup.controllers.deploy.gui.juju')

--- a/ubuntui/views/error.py
+++ b/ubuntui/views/error.py
@@ -2,7 +2,7 @@
 log output, and where to file a bug.
 """
 
-from urwid import (Pile, Text, Filler, WidgetWrap, Divider)
+from urwid import (ExitMainLoop, Pile, Text, Filler, WidgetWrap, Divider)
 from ubuntui.widgets.buttons import cancel_btn
 from ubuntui.utils import Color, Padding
 import sys
@@ -40,4 +40,4 @@ class ErrorView(WidgetWrap):
         return Pile(buttons)
 
     def cancel(self, button):
-        sys.exit(1)
+        raise ExitMainLoop()


### PR DESCRIPTION
Several issues were causing problems with error handling in bootstrap.

an error message shown by the async code launched by newcloud could get overwritten by deploy.gui.render. 
worse, newcloud was calling deploy.gui.render twice, so there were extra chances for that to happen.

Most of this should be fixed.

Also fixes the spurious SystemExit traceback when the user hits 'OK' to exit in the error dialog.
