### PR TITLE
Fix issues with deploying some charms

### DIFF
--- a/bundleplacer/charmstore_api.py
+++ b/bundleplacer/charmstore_api.py
@@ -198,7 +198,14 @@ class MetadataController:
             id_no_rev = csid.as_str_without_rev()
             if id_no_rev in self.charm_info:
                 continue
+
             self.charm_info[id_no_rev] = charm_dict
+
+            if csid.series == "":
+                csid.series = self.bundle.series
+                id_no_rev_with_default_series = csid.as_str_without_rev()
+                self.charm_info[id_no_rev_with_default_series] = charm_dict
+
             rd = md.get("Requires", {})
             pd = md.get("Provides", {})
             requires = []

--- a/conjureup/juju.py
+++ b/conjureup/juju.py
@@ -482,6 +482,9 @@ def deploy_service(service, default_series, msg_cb=None, exc_cb=None):
             source_csid = CharmStoreID(service.charm_source)
             if source_csid.series != '':
                 deploy_args['series'] = source_csid.series
+            else:
+                deploy_args['series'] = default_series
+
         app_params = {"applications": [deploy_args]}
 
         app.log.debug("Deploying {}: {}".format(service, app_params))


### PR DESCRIPTION
Issues were due to changes in charmstore API between v4 and v5

Signed-off-by: Michael McCracken <mike.mccracken@canonical.com>