### PR TITLE
Fixes #747

### DIFF
--- a/conjureup/app.py
+++ b/conjureup/app.py
@@ -262,6 +262,8 @@ def main():
     spell_name = spell
     app.endpoint_type = detect_endpoint(opts.spell)
 
+    app.env = os.environ.copy()
+
     if app.endpoint_type == EndpointType.LOCAL_SEARCH:
         spells = utils.find_spells_matching(opts.spell)
 
@@ -317,9 +319,7 @@ def main():
         download(remote, app.config['spell-dir'], True)
         utils.set_spell_metadata()
 
-    app.env = os.environ.copy()
     app.env['CONJURE_UP_CACHEDIR'] = app.argv.cache_dir
-    app.env['CONJURE_UP_SPELL'] = spell_name
 
     if app.argv.show_env:
         if not app.argv.cloud:

--- a/conjureup/utils.py
+++ b/conjureup/utils.py
@@ -345,7 +345,6 @@ def setup_metadata_controller():
 
 def set_chosen_spell(spell_name, spell_dir):
     track_event("Spell Choice", spell_name, "")
-    app.env = os.environ.copy()
     app.env['CONJURE_UP_SPELL'] = spell_name
     app.config.update({'spell-dir': spell_dir,
                        'spell': spell_name})


### PR DESCRIPTION
We were setting app.env = os.environ.copy() in 2 spots. This fixes copying the
env in a single location.

Signed-off-by: Adam Stokes <battlemidget@users.noreply.github.com>