### PR TITLE
Drops global config, simplifies registry remote

### DIFF
--- a/conjureup/app.py
+++ b/conjureup/app.py
@@ -51,9 +51,9 @@ def parse_options(argv):
                         'during post deployment actions. This is useful '
                         'for headless installs allowing you to set those '
                         'variables to further customize your deployment.')
-    parser.add_argument('-c', dest='global_config_file',
-                        help='Location of conjure-up.conf',
-                        default='/etc/conjure-up.conf')
+    parser.add_argument('--registry', dest='registry',
+                        help='Spells Registry',
+                        default='https://github.com/conjure-up/spells.git')
     parser.add_argument('--cache-dir', dest='cache_dir',
                         help='Download directory for spells',
                         default=os.path.expanduser("~/.cache/conjure-up"))
@@ -214,19 +214,6 @@ def main():
     app.session_id = os.getenv('CONJURE_TEST_SESSION_ID',
                                str(uuid.uuid4()))
 
-    global_config_filename = app.argv.global_config_file
-    if not os.path.exists(global_config_filename):
-        # fallback to source tree location
-        global_config_filename = os.path.join(os.path.dirname(__file__),
-                                              "../etc/conjure-up.conf")
-        if not os.path.exists(global_config_filename):
-            utils.error("Could not find {}.".format(global_config_filename))
-            sys.exit(1)
-
-    with open(global_config_filename) as fp:
-        global_conf = yaml.safe_load(fp.read())
-        app.global_config = global_conf
-
     spells_dir = app.argv.spells_dir
 
     app.config['spells-dir'] = spells_dir
@@ -239,7 +226,7 @@ def main():
             utils.info("No spells found, syncing from registry, please wait.")
         try:
             download_or_sync_registry(
-                app.global_config['registry']['repo'],
+                app.argv.registry,
                 spells_dir, branch=spells_registry_branch)
         except subprocess.CalledProcessError as e:
             if not os.path.exists(spells_dir):

--- a/conjureup/app_config.py
+++ b/conjureup/app_config.py
@@ -45,9 +45,6 @@ app = SimpleNamespace(
     # Contains metadata and spell name
     config=None,
 
-    # Contains conjure-up global settings
-    global_config=None,
-
     # List of multiple bundles, usually from a charmstore search
     bundles=None,
 

--- a/conjureup/juju.py
+++ b/conjureup/juju.py
@@ -15,7 +15,7 @@ import macumba
 from bundleplacer.charmstore_api import CharmStoreID
 from conjureup import async, consts
 from conjureup.app_config import app
-from conjureup.utils import juju_path, run, is_darwin
+from conjureup.utils import is_darwin, juju_path, run
 from macumba.v2 import JujuClient
 
 JUJU_ASYNC_QUEUE = "juju-async-queue"

--- a/conjureup/utils.py
+++ b/conjureup/utils.py
@@ -296,23 +296,6 @@ def install_user():
     return user
 
 
-def load_global_conf():
-    """ loads global configuration
-
-    Returns:
-    dictionary of config items
-    """
-    global_conf_file = '/etc/conjure-up.conf'
-    if not os.path.exists(global_conf_file):
-        global_conf_file = os.path.join(
-            os.path.dirname(__file__), '..', 'etc', 'conjure-up.conf')
-    try:
-        with open(global_conf_file) as fp:
-            return yaml.safe_load(fp.read())
-    except:
-        return {}
-
-
 def setup_metadata_controller():
     bundle_filename = os.path.join(app.config['spell-dir'], 'bundle.yaml')
     if not os.path.isfile(bundle_filename):

--- a/etc/conjure-up.conf
+++ b/etc/conjure-up.conf
@@ -1,3 +1,0 @@
-registry:
-  # git repository holding spells
-  repo: https://github.com/conjure-up/spells.git

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -27,9 +27,6 @@ parts:
       - bsdtar
       - jq
       - bridge-utils
-    install: |
-      mkdir -p $SNAPCRAFT_PART_INSTALL/etc
-      cp etc/conjure-up.conf $SNAPCRAFT_PART_INSTALL/etc/conjure-up.conf
     stage:
       - -README.md
       - -debian

--- a/snap/wrappers/conjure-up
+++ b/snap/wrappers/conjure-up
@@ -37,5 +37,5 @@ if [[ -f /usr/bin/lxd  && -f /snap/bin/lxd ]]; then
 fi
 
 
-exec $SNAP/bin/conjure-up -c $SNAP/etc/conjure-up.conf \
+exec $SNAP/bin/conjure-up \
      --spells-dir $SNAP/spells --nosync "$@"


### PR DESCRIPTION
Drop the global config in favor of a simplified cli option to specify different
spell registry location.

Signed-off-by: Adam Stokes <battlemidget@users.noreply.github.com>