### PR TITLE
Fix handling of boolean step inputs

### DIFF
--- a/conjureup/controllers/steps/common.py
+++ b/conjureup/controllers/steps/common.py
@@ -15,9 +15,9 @@ def set_env(inputs):
     for i in inputs:
         env_key = i['key'].upper()
         try:
-            input_key = i['input']
+            input_key = str(i['input'])
         except KeyError:
-            input_key = i.get('default', '')
+            input_key = str(i.get('default', ''))
         app.env[env_key] = input_key
         app.log.debug("Setting environment var: {}={}".format(
             env_key,

--- a/conjureup/controllers/steps/gui.py
+++ b/conjureup/controllers/steps/gui.py
@@ -105,15 +105,18 @@ class StepsController:
         self.n_completed_steps = 0
         for step_meta_path in self.step_metas:
             step_ex_path, ext = path.splitext(step_meta_path)
-            if not path.isfile(step_ex_path) or \
-               not os.access(step_ex_path, os.X_OK):
-                failed_path = step_ex_path.split('/')[-3:]
-                msg = (
+            short_path = '/'.join(step_ex_path.split('/')[-3:])
+            err_msg = None
+            if not path.isfile(step_ex_path):
+                err_msg = (
+                    'Step {} has no implementation'.format(short_path))
+            elif not os.access(step_ex_path, os.X_OK):
+                err_msg = (
                     'Step {} is not executable, make sure it has '
-                    'the executable bit set'.format(
-                        '/'.join(failed_path)))
-                app.log.error(msg)
-                self.__handle_exception('E002', Exception(msg))
+                    'the executable bit set'.format(short_path))
+            if err_msg:
+                app.log.error(err_msg)
+                self.__handle_exception('E002', Exception(err_msg))
                 return
             step_metadata = {}
             with open(step_meta_path) as fp:

--- a/conjureup/controllers/steps/tui.py
+++ b/conjureup/controllers/steps/tui.py
@@ -27,15 +27,18 @@ class StepsController:
     def render(self):
         for step_meta_path in self.step_metas:
             step_ex_path, ext = path.splitext(step_meta_path)
-            if not path.isfile(step_ex_path) or \
-               not os.access(step_ex_path, os.X_OK):
-                failed_path = step_ex_path.split('/')[-3:]
-                msg = (
+            short_path = '/'.join(step_ex_path.split('/')[-3:])
+            err_msg = None
+            if not path.isfile(step_ex_path):
+                err_msg = (
+                    'Step {} has no implementation'.format(short_path))
+            elif not os.access(step_ex_path, os.X_OK):
+                err_msg = (
                     'Step {} is not executable, make sure it has '
-                    'the executable bit set'.format(
-                        '/'.join(failed_path)))
-                app.log.error(msg)
-                utils.error(msg)
+                    'the executable bit set'.format(short_path))
+            if err_msg:
+                app.log.error(err_msg)
+                utils.error(err_msg)
                 sys.exit(1)
             step_metadata = {}
             with open(step_meta_path) as fp:

--- a/conjureup/ui/widgets/step.py
+++ b/conjureup/ui/widgets/step.py
@@ -16,10 +16,10 @@ from ubuntui.widgets.input import (
 
 class StepWidget(WidgetWrap):
     INPUT_TYPES = {
-        'text': StringEditor(),
-        'password': PasswordEditor(),
-        'boolean': YesNo(),
-        'integer': IntegerEditor()
+        'text': StringEditor,
+        'password': PasswordEditor,
+        'boolean': YesNo,
+        'integer': IntegerEditor,
     }
 
     def __init__(self, app, step_model, cb):
@@ -41,14 +41,21 @@ class StepWidget(WidgetWrap):
         self.additional_input = []
         if len(step_model.additional_input) > 0:
             for i in step_model.additional_input:
+                if i['type'] in self.INPUT_TYPES:
+                    widget_inst = self.INPUT_TYPES[i['type']](
+                        default=i.get('default'))
+                else:
+                    self.app.log.error('Invalid input type "{}" in step {}; '
+                                       'should be one of: {}'.format(
+                                           i['type'],
+                                           step_model.title,
+                                           ', '.join(self.INPUT_TYPES.keys())))
+                    widget_inst = None
                 widget = {
                     "label": Text(('body', i['label'])),
                     "key": i['key'],
-                    "input": self.INPUT_TYPES.get(i['type'])
+                    "input": widget_inst,
                 }
-                if 'default' in i:
-                    widget['input'] = StringEditor(default=i['default'])
-
                 self.additional_input.append(widget)
         else:
             widget = {

--- a/ubuntui/widgets/input.py
+++ b/ubuntui/widgets/input.py
@@ -48,8 +48,8 @@ class PasswordEditor(StringEditor):
     """ Password input prompt with masking
     """
 
-    def __init__(self, caption=None, mask="*"):
-        super().__init__(caption, mask=mask)
+    def __init__(self, caption=None, mask="*", default=None):
+        super().__init__(caption, mask=mask, default=default)
 
 
 class RealnameEditor(StringEditor):
@@ -119,14 +119,20 @@ class Selector(WidgetWrap):
     """ Radio selection list of options
     """
 
-    def __init__(self, opts):
+    def __init__(self, opts, default=None):
         """
         :param list opts: list of options to display
         """
         self.opts = opts
         self.group = []
-        self._add_options()
+        self.default = default
+        if self.default is True and 'Yes' in opts:
+            self.default = 'Yes'
+        elif self.default is False and 'No' in opts:
+            self.default = 'No'
         super().__init__(Columns(self._add_options()))
+        if self.default is not None:
+            self.set_default(self.default, True)
 
     def _add_options(self):
         cols = []
@@ -167,6 +173,6 @@ class YesNo(Selector):
     """ Yes/No selector
     """
 
-    def __init__(self):
+    def __init__(self, default=None):
         opts = ['Yes', 'No']
-        super().__init__(opts)
+        super().__init__(opts, default)


### PR DESCRIPTION
Fixes #733
Fixes #734
Fixes #735

Main issue for bools was that the values passed through `app.env` must be strings.

Fixed default handling for all input types (including `TypeError` for booleans, unmasked passwords, and missing fields with no defaults).

I also improved the error message in case a step had a yaml definition but no implementation.