### PR TITLE
Proposal: Allow re-use of an existing model in headless mode.

### DIFF
--- a/conjureup/controllers/clouds/tui.py
+++ b/conjureup/controllers/clouds/tui.py
@@ -33,7 +33,8 @@ class CloudsController:
                        "please wait.".format(app.current_model))
             juju.add_model(app.current_model,
                            app.current_controller,
-                           app.current_cloud)
+                           app.current_cloud,
+                           allow_exists=True)
             return controllers.use('deploy').render()
 
         utils.error("Something happened with the controller or model, "

--- a/conjureup/juju.py
+++ b/conjureup/juju.py
@@ -756,15 +756,16 @@ def get_model(controller, name):
         "Unable to find model: {}".format(name))
 
 
-def add_model(name, controller, cloud):
+def add_model(name, controller, cloud, allow_exists=False):
     """ Adds a model to current controller
 
     Arguments:
     controller: controller to add model in
+    allow_exists: re-use an existing model, if one exists.
     """
     sh = run('juju add-model {} -c {} {}'.format(name, controller, cloud),
              shell=True, stdout=DEVNULL, stderr=PIPE)
-    if sh.returncode > 0:
+    if sh.returncode > 0 and not allow_exists:
         raise Exception(
             "Unable to create model: {}".format(sh.stderr.decode('utf8')))
     # the CLI has to connect to the model at least once to populate the model

--- a/conjureup/juju.py
+++ b/conjureup/juju.py
@@ -763,9 +763,12 @@ def add_model(name, controller, cloud, allow_exists=False):
     controller: controller to add model in
     allow_exists: re-use an existing model, if one exists.
     """
+    if allow_exists and model_available():
+        return
+
     sh = run('juju add-model {} -c {} {}'.format(name, controller, cloud),
              shell=True, stdout=DEVNULL, stderr=PIPE)
-    if sh.returncode > 0 and not allow_exists:
+    if sh.returncode > 0:
         raise Exception(
             "Unable to create model: {}".format(sh.stderr.decode('utf8')))
     # the CLI has to connect to the model at least once to populate the model

--- a/test/test_controllers_clouds_tui.py
+++ b/test/test_controllers_clouds_tui.py
@@ -96,7 +96,8 @@ class CloudsTUIFinishTestCase(unittest.TestCase):
         self.mock_app.current_cloud = 'cloud'
         self.controller.finish()
         self.mock_juju.assert_has_calls([
-            call.add_model(ANY, 'testcontroller', 'cloud')])
+            call.add_model(ANY, 'testcontroller', 'cloud',
+                           allow_exists=True)])
 
     def test_finish_no_controller(self):
         "clouds.finish without existing controller"


### PR DESCRIPTION
This make it possible for tools like matrix, which manage their own
models, to call conjure-up. In turn, that allows people to test bundles
that require resources in an automated fashion.

Addressed my comment on https://github.com/conjure-up/conjure-up/issues/753

@battlemidget @johnsca Feel free to reject if this is too sneaky, but this is the simplest way of unblocking me moving forward with making matrix call out to conjure-up. :-)