### PR TITLE
Improve can_sudo check

### DIFF
--- a/conjureup/controllers/steps/common.py
+++ b/conjureup/controllers/steps/common.py
@@ -81,7 +81,9 @@ def do_step(step_model, step_widget, message_cb, gui=False):
         if step_widget and step_widget.sudo_input:
             password = step_widget.sudo_input.value
         if not step_model.can_sudo(password):
-            raise Exception('Sudo failed')
+            raise Exception('Sudo failed.  Please check your password '
+                            'and ensure that your sudo timeout is not '
+                            'set to zero.')
 
     # merge the step_widget input data into our step model
     if gui:

--- a/conjureup/models/step.py
+++ b/conjureup/models/step.py
@@ -39,19 +39,15 @@ class StepModel:
                                                self.path)
 
     def can_sudo(self, password=None):
-        if not password:
-            result = subprocess.run(['sudo', '-nv'],
-                                    stdout=subprocess.DEVNULL,
-                                    stderr=subprocess.DEVNULL)
-            if result.returncode != 0:
-                # Try a second method
-                result = subprocess.run(['sudo', '-n', '/bin/true'],
-                                        stdout=subprocess.DEVNULL,
-                                        stderr=subprocess.DEVNULL)
-        else:
+        if password:
             password = '{}\n'.format(password).encode('utf8')
-            result = subprocess.run(['sudo', '-Sv'],
+            result = subprocess.run(['sudo', '-S', '/bin/true'],
                                     input=password,
                                     stdout=subprocess.DEVNULL,
                                     stderr=subprocess.DEVNULL)
+            if result.returncode != 0:
+                return False
+        result = subprocess.run(['sudo', '-n', '/bin/true'],
+                                stdout=subprocess.DEVNULL,
+                                stderr=subprocess.DEVNULL)
         return result.returncode == 0


### PR DESCRIPTION
We should check immediately after authenticating sudo that we can indeed perform a passwordless sudo.  This will catch early the case where auth caching is disabled by setting timestamp_timeout=0 in sudoers (though it will still fail).

Also, the -v flag does not work when actual passwordless sudo is enabled for a user, so this drops it entirely in favor of executing /bin/true.