### PR TITLE
Improve error handling for sudo in GUI flow

### DIFF
--- a/conjureup/controllers/steps/common.py
+++ b/conjureup/controllers/steps/common.py
@@ -75,16 +75,6 @@ def do_step(step_model, step_widget, message_cb, gui=False):
     Returns:
     Step title and results message
     """
-
-    if utils.is_linux() and step_model.needs_sudo:
-        password = None
-        if step_widget and step_widget.sudo_input:
-            password = step_widget.sudo_input.value
-        if not step_model.can_sudo(password):
-            raise Exception('Sudo failed.  Please check your password '
-                            'and ensure that your sudo timeout is not '
-                            'set to zero.')
-
     # merge the step_widget input data into our step model
     if gui:
         step_widget.clear_button()

--- a/conjureup/ui/widgets/step.py
+++ b/conjureup/ui/widgets/step.py
@@ -85,8 +85,7 @@ class StepWidget(WidgetWrap):
             if len(lines) < 1:
                 return
             result = json.loads(lines[-1])
-            self.output.set_text(('body', "\n    " +
-                                  result['message']))
+            self.output.set_text(('body', result['message']))
 
     def clear_output(self):
         self.output.set_text("")
@@ -94,6 +93,12 @@ class StepWidget(WidgetWrap):
     def set_description(self, description, color='info_minor'):
         self.description.set_text(
             (color, description))
+
+    def set_error(self, msg):
+        self.output.set_text(('error_major', msg))
+
+    def clear_error(self):
+        self.clear_output()
 
     def set_icon_state(self, result_code):
         """ updates status icon
@@ -138,6 +143,13 @@ class StepWidget(WidgetWrap):
         self.step_pile.contents[self.current_button_index] = (
             Text(""), self.step_pile.options())
 
+    def show_button(self):
+        self.step_pile.contents[self.current_button_index] = (
+            Padding.right_20(
+                Color.button_primary(self.button,
+                                     focus_map='button_primary focus')),
+            self.step_pile.options())
+
     def build_widget(self):
         return Pile([
             Columns(
@@ -145,7 +157,8 @@ class StepWidget(WidgetWrap):
                     ('fixed', 3, self.icon),
                     self.description,
                 ], dividechars=1),
-            self.output
+            Padding.line_break(""),
+            Padding.push_4(self.output)
         ]
         )
 
@@ -192,12 +205,11 @@ class StepWidget(WidgetWrap):
                  self.step_pile.options()))
 
         self.button = submit_btn(label="Run", on_press=self.submit)
-        self.step_pile.contents.append(
-            (Padding.right_20(
-                Color.button_primary(self.button,
-                                     focus_map='button_primary focus')),
-             self.step_pile.options()))
+        self.step_pile.contents.append((Padding.line_break(""),
+                                        self.step_pile.options()))
+        self.step_pile.contents.append((Text(""), self.step_pile.options()))
         self.step_pile.contents.append((HR(), self.step_pile.options()))
+        self.show_button()
         self.step_pile.focus_position = self.current_button_index
 
     def submit(self, btn):


### PR DESCRIPTION
Make sudo failure in GUI non-fatal in case password was typed in wrong.

![conjure-up-sudo-error](https://cloud.githubusercontent.com/assets/406082/24302131/f7ac3686-1087-11e7-8927-2bc91cdbb030.png)
