### PR TITLE
Fix "invalid file" error when reading spell bundle

### DIFF
--- a/conjureup/utils.py
+++ b/conjureup/utils.py
@@ -308,7 +308,7 @@ def setup_metadata_controller():
 
     if bundle_filename.exists():
         # Load bundle data early so we can merge any additional charm options
-        bundle_data = yaml.load(slurp(bundle_filename))
+        bundle_data = yaml.load(bundle_filename.read_text())
     else:
         bundle_name = app.config['metadata'].get('bundle-name', None)
         if bundle_name is None:


### PR DESCRIPTION
pathlib isn't 100% integrated with some of the builtins yet, so you have to either str() it or use the OO methods it provides.

Fixes this:

```
Traceback (most recent call last):
  File "/home/johnsca/juju/conjure-up/conjure-dev/bin/conjure-up", line 11, in <module>
    load_entry_point('conjure-up', 'console_scripts', 'conjure-up')()
  File "/home/johnsca/juju/conjure-up/conjureup/app.py", line 367, in main
    EventLoop.run()
  File "/home/johnsca/juju/conjure-up/ubuntui/ev.py", line 82, in run
    cls.loop.run()
  File "/home/johnsca/juju/conjure-up/conjure-dev/lib/python3.5/site-packages/urwid/main_loop.py", line 278, in run
    self._run()
  File "/home/johnsca/juju/conjure-up/conjure-dev/lib/python3.5/site-packages/urwid/main_loop.py", line 376, in _run
    self.event_loop.run()
  File "/home/johnsca/juju/conjure-up/conjure-dev/lib/python3.5/site-packages/urwid/main_loop.py", line 1328, in run
    raise self._exc_info[0](self._exc_info[1]).with_traceback(self._exc_info[2])
  File "/usr/lib/python3.5/asyncio/events.py", line 125, in _run
    self._callback(*self._args)
  File "/home/johnsca/juju/conjure-up/conjure-dev/lib/python3.5/site-packages/urwid/raw_display.py", line 393, in <lambda>
    event_loop, callback, self.get_available_raw_input())
  File "/home/johnsca/juju/conjure-up/conjure-dev/lib/python3.5/site-packages/urwid/raw_display.py", line 493, in parse_input
    callback(processed, processed_codes)
  File "/home/johnsca/juju/conjure-up/conjure-dev/lib/python3.5/site-packages/urwid/main_loop.py", line 403, in _update
    self.process_input(keys)
  File "/home/johnsca/juju/conjure-up/conjure-dev/lib/python3.5/site-packages/urwid/main_loop.py", line 503, in process_input
    k = self._topmost_widget.keypress(self.screen_size, k)
  File "/home/johnsca/juju/conjure-up/conjure-dev/lib/python3.5/site-packages/urwid/wimp.py", line 643, in keypress
    return self._current_widget.keypress(size, key)
  File "/home/johnsca/juju/conjure-up/conjure-dev/lib/python3.5/site-packages/urwid/container.py", line 1128, in keypress
    return self.body.keypress( (maxcol, remaining), key )
  File "/home/johnsca/juju/conjure-up/conjureup/ui/views/spellpicker.py", line 44, in keypress
    rv = super().keypress(size, key)
  File "/home/johnsca/juju/conjure-up/conjure-dev/lib/python3.5/site-packages/urwid/container.py", line 1128, in keypress
    return self.body.keypress( (maxcol, remaining), key )
  File "/home/johnsca/juju/conjure-up/conjure-dev/lib/python3.5/site-packages/urwid/decoration.py", line 621, in keypress
    return self._original_widget.keypress(maxvals, key)
  File "/home/johnsca/juju/conjure-up/conjure-dev/lib/python3.5/site-packages/urwid/decoration.py", line 836, in keypress
    return self._original_widget.keypress((maxcol,), key)
  File "/home/johnsca/juju/conjure-up/conjure-dev/lib/python3.5/site-packages/urwid/container.py", line 1587, in keypress
    key = self.focus.keypress(tsize, key)
  File "/home/johnsca/juju/conjure-up/conjure-dev/lib/python3.5/site-packages/urwid/wimp.py", line 535, in keypress
    self._emit('click')
  File "/home/johnsca/juju/conjure-up/conjure-dev/lib/python3.5/site-packages/urwid/widget.py", line 463, in _emit
    signals.emit_signal(self, name, self, *args)
  File "/home/johnsca/juju/conjure-up/conjure-dev/lib/python3.5/site-packages/urwid/signals.py", line 264, in emit
    result |= self._call_callback(callback, user_arg, user_args, args)
  File "/home/johnsca/juju/conjure-up/conjure-dev/lib/python3.5/site-packages/urwid/signals.py", line 294, in _call_callback
    return bool(callback(*args_to_pass))
  File "/home/johnsca/juju/conjure-up/conjureup/ui/views/spellpicker.py", line 128, in submit
    self.cb(result['key'])
  File "/home/johnsca/juju/conjure-up/conjureup/controllers/spellpicker/gui.py", line 24, in finish
    utils.setup_metadata_controller()
  File "/home/johnsca/juju/conjure-up/conjureup/utils.py", line 311, in setup_metadata_controller
    bundle_data = yaml.load(slurp(bundle_filename))
  File "/home/johnsca/juju/conjure-up/conjureup/utils.py", line 285, in slurp
    with open(path) as f:
TypeError: invalid file: PosixPath('/home/johnsca/.cache/conjure-up/ghost/bundle.yaml')
```