### PR TITLE
Fixes #795 shorten model name to max 28 characters

### DIFF
--- a/conjureup/controllers/clouds/tui.py
+++ b/conjureup/controllers/clouds/tui.py
@@ -13,9 +13,7 @@ class CloudsController:
         if app.argv.model:
             app.current_model = app.argv.model
         else:
-            app.current_model = "conjure-up-{}-{}".format(
-                app.env['CONJURE_UP_SPELL'],
-                utils.gen_hash())
+            app.current_model = utils.gen_model()
 
         if not app.argv.controller:
             app.current_controller = "conjure-up-{}-{}".format(

--- a/conjureup/controllers/controllerpicker/gui.py
+++ b/conjureup/controllers/controllerpicker/gui.py
@@ -27,9 +27,7 @@ class ControllerPicker:
             return controllers.use('jaaslogin').render()
 
         app.current_controller = controller
-        app.current_model = "conjure-up-{}-{}".format(
-            app.env['CONJURE_UP_SPELL'],
-            utils.gen_hash())
+        app.current_model = utils.gen_model()
 
         try:
             c_info = juju.get_controller_info(app.current_controller)

--- a/conjureup/controllers/newcloud/gui.py
+++ b/conjureup/controllers/newcloud/gui.py
@@ -168,9 +168,7 @@ class NewCloudController:
                 utils.gen_hash())
 
         if app.current_model is None:
-            app.current_model = "conjure-up-{}-{}".format(
-                app.env['CONJURE_UP_SPELL'],
-                utils.gen_hash())
+            app.current_model = utils.gen_model()
 
         # LXD is a special case as we want to make sure a bridge
         # is configured. If not we'll bring up a new view to allow

--- a/conjureup/utils.py
+++ b/conjureup/utils.py
@@ -423,6 +423,13 @@ def gen_hash():
     return str(uuid.uuid4()).split('-')[0][:3]
 
 
+def gen_model():
+    """ generates a unique model name
+    """
+    name = "conjure-{}".format(app.env['CONJURE_UP_SPELL'])
+    return "{}-{}".format(name[:24], gen_hash())
+
+
 def is_darwin():
     """ Checks if host platform is macOS
     """


### PR DESCRIPTION
This is to avoid the situation with Azure where juju tacks on a UUID to the end
of the generated model to map to a resource group.

Signed-off-by: Adam Stokes <battlemidget@users.noreply.github.com>