### PR TITLE
Fix add_machines failure in headless

### DIFF
--- a/conjureup/controllers/deploy/gui.py
+++ b/conjureup/controllers/deploy/gui.py
@@ -209,12 +209,11 @@ class DeployController:
             await events.MAASConnected.wait()
         app_placements = self.get_all_assignments(application)
         juju_machines = app.metadata_controller.bundle.machines
-        machines = []
+        machines = {}
         for virt_machine_id, _ in app_placements:
             if virt_machine_id in self.deployed_juju_machines:
                 continue
             machine_attrs = {
-                'virt_machine_id': virt_machine_id,
                 'series': application.csid.series,
             }
             if cloud_type == 'maas':
@@ -222,7 +221,7 @@ class DeployController:
                     await self.get_maas_constraints(virt_machine_id)
             else:
                 machine_attrs.update(juju_machines[virt_machine_id])
-            machines.append(machine_attrs)
+            machines[virt_machine_id] = machine_attrs
 
         return await juju.add_machines([application], machines,
                                        msg_cb=app.ui.set_footer)

--- a/conjureup/controllers/deploy/tui.py
+++ b/conjureup/controllers/deploy/tui.py
@@ -19,7 +19,7 @@ class DeployController:
                               key=attrgetter('service_name'))
 
         await common.pre_deploy(msg_cb=utils.info)
-        await juju.add_machines([a.service_name for a in applications],
+        await juju.add_machines(applications,
                                 machines,
                                 msg_cb=utils.info)
         tasks = []

--- a/conjureup/events.py
+++ b/conjureup/events.py
@@ -87,7 +87,7 @@ def handle_exception(loop, context):
         return  # already reporting an error
     Error.set()
     exc = context['exception']
-    track_exception(exc.args[0])
+    track_exception(str(exc))
 
     # not sure of a cleaner way to log the exception instance
     try:

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -6,3 +6,4 @@ nose
 tox
 q
 ipython
+ipdb


### PR DESCRIPTION
Resolve a discrepancy in how `add_machines` was called between GUI and headless.

Fixes #829