### PR TITLE
Add message to indicate shutdown

### DIFF
--- a/conjureup/events.py
+++ b/conjureup/events.py
@@ -113,6 +113,8 @@ async def shutdown_watcher():
     app.log.info('Shutting down')
     if app.headless:
         utils.warning('Shutting down')
+    else:
+        app.ui.show_shutdown_message()
 
     try:
         if app.juju.authenticated:

--- a/conjureup/ui/__init__.py
+++ b/conjureup/ui/__init__.py
@@ -2,6 +2,7 @@ from ubuntui.frame import Frame  # noqa
 from ubuntui.views import ErrorView
 from conjureup import async
 from conjureup.app_config import app
+from conjureup.ui.views.shutdown import ShutdownView
 from ubuntui.ev import EventLoop
 import errno
 
@@ -30,3 +31,6 @@ class ConjureUI(Frame):
 
     def show_error_message(self, msg):
         self.frame.body = ErrorView(msg)
+
+    def show_shutdown_message(self):
+        self.frame.body = ShutdownView()

--- a/conjureup/ui/views/shutdown.py
+++ b/conjureup/ui/views/shutdown.py
@@ -1,0 +1,17 @@
+""" A View to inform user that shutdown is in progress.
+"""
+
+from ubuntui.utils import Padding
+from urwid import Filler, LineBox, Pile, Text, WidgetWrap
+
+
+class ShutdownView(WidgetWrap):
+
+    def __init__(self):
+        message = "Conjure-up is shutting down, please wait."
+        box = Padding.center_45(LineBox(Pile([
+            Padding.line_break(""),
+            Text(message, align="center"),
+            Padding.line_break(""),
+        ])))
+        super().__init__(Filler(box, valign="middle"))


### PR DESCRIPTION
In some circumstances, the shutdown process can take a bit of time, due to things like network latency, etc.  We should show the user a message in the GUI so that they realize that the shutdown is in progress.

Resolves #835