### PR TITLE
Fix headless deploy blocking indefinitely

### DIFF
--- a/conjureup/controllers/deploy/tui.py
+++ b/conjureup/controllers/deploy/tui.py
@@ -1,7 +1,7 @@
 import asyncio
 from operator import attrgetter
 
-from conjureup import controllers, juju, utils
+from conjureup import controllers, events, juju, utils
 from conjureup.app_config import app
 
 from . import common
@@ -32,6 +32,7 @@ class DeployController:
             tasks.append(juju.set_relations(service,
                                             msg_cb=utils.info))
         await asyncio.gather(*tasks)
+        events.DeploymentComplete.set()
         controllers.use('deploystatus').render()
 
 

--- a/test/test_controllers_deploy_tui.py
+++ b/test/test_controllers_deploy_tui.py
@@ -80,6 +80,8 @@ class DeployTUIDoDeployTestCase(unittest.TestCase):
             'conjureup.controllers.deploy.tui.app')
         self.mock_app = self.app_patcher.start()
         self.mock_app.ui = MagicMock(name="app.ui")
+        self.events_app_patcher = patch('conjureup.events.app', self.mock_app)
+        self.events_app_patcher.start()
         self.juju_patcher = patch(
             'conjureup.controllers.deploy.tui.juju')
         self.mock_juju = self.juju_patcher.start()
@@ -95,6 +97,7 @@ class DeployTUIDoDeployTestCase(unittest.TestCase):
         self.common_patcher.stop()
         self.render_patcher.stop()
         self.app_patcher.stop()
+        self.events_app_patcher.stop()
         self.juju_patcher.stop()
 
     def test_do_deploy(self):


### PR DESCRIPTION
The change to fix duplicate machines changed the event that `deploystatus` was awaiting, which exposed an existing bug that the `deploy/tui.py` controller wasn't setting `events.DeploymentComplete`