### PR TITLE
Adds redis-server to snap

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -27,8 +27,18 @@ apps:
     command: wrappers/lxc
   lxd:
     command: wrappers/lxd
+  redis-server:
+    command: wrappers/redis.daemon.start
+    daemon: simple
+  redis-cli:
+    command: wrappers/redis-cli
 
 parts:
+  redis:
+    plugin: make
+    source: https://github.com/antirez/redis.git
+    source-tag: 3.2.9
+    make-install-var: PREFIX
   conjure-up:
     source: .
     plugin: python

--- a/snap/wrappers/redis-cli
+++ b/snap/wrappers/redis-cli
@@ -1,0 +1,4 @@
+#!/bin/sh
+set -eu
+
+$SNAP/bin/redis-cli -p 6380 "$@"

--- a/snap/wrappers/redis.daemon.start
+++ b/snap/wrappers/redis.daemon.start
@@ -1,0 +1,5 @@
+#!/bin/sh
+set -eu
+
+## Start redis-server
+$SNAP/bin/redis-server --port 6380 "$@"


### PR DESCRIPTION
Fixes #901

To test:

```
make snap
snap install ./conjure-up* --dangerous --classic
/snap/conjure-up/current/bin/redis-cli
```

It should connect to redis-server on our custom port 6380

Signed-off-by: Adam Stokes <battlemidget@users.noreply.github.com>