### PR TITLE
Feature/910 enable redis state server

### DIFF
--- a/conjureup/app.py
+++ b/conjureup/app.py
@@ -11,6 +11,7 @@ import subprocess
 import sys
 import textwrap
 import uuid
+import redis
 
 import yaml
 from prettytable import PrettyTable
@@ -80,6 +81,9 @@ def parse_options(argv):
                         help='The MAAS node hostname to deploy to. Useful '
                         'for using lower end hardware as the Juju admin '
                         'controller.', metavar='<host>.maas')
+    parser.add_argument('--redis-port', dest='redis_port',
+                        help='Redis port to connect to',
+                        default=6379)
     parser.add_argument(
         '--version', action='version', version='%(prog)s {}'.format(VERSION))
     parser.add_argument('--notrack', action='store_true',
@@ -200,6 +204,9 @@ def main():
         os.makedirs(opts.cache_dir)
 
     # Application Config
+    app.state = redis.StrictRedis(host='localhost',
+                                  port=opts.redis_port,
+                                  db=0)
     app.env = os.environ.copy()
     app.config = {'metadata': None}
     app.argv = opts

--- a/conjureup/app.py
+++ b/conjureup/app.py
@@ -11,8 +11,8 @@ import subprocess
 import sys
 import textwrap
 import uuid
-import redis
 
+import redis
 import yaml
 from prettytable import PrettyTable
 from termcolor import colored

--- a/conjureup/app_config.py
+++ b/conjureup/app_config.py
@@ -101,5 +101,8 @@ app = SimpleNamespace(
     # Reference to asyncio loop so that it can be accessed from other threads
     loop=None,
 
+    # Redis State storage endpoint
+    state=None,
+
     # exit code for conjure-up to terminate with
     exit_code=0)

--- a/conjureup/controllers/bootstrap/common.py
+++ b/conjureup/controllers/bootstrap/common.py
@@ -48,7 +48,7 @@ class BaseBootstrapController:
         app.env['JUJU_MODEL'] = app.current_model
 
         step = StepModel({},
-                         path='00_post-bootstrap',
+                         filename='00_post-bootstrap',
                          name='post-bootstrap')
         await utils.run_step(step,
                              self.msg_cb,
@@ -67,7 +67,7 @@ class BaseBootstrapController:
         app.env['CONJURE_UP_SPELLSDIR'] = app.argv.spells_dir
 
         step = StepModel({},
-                         path='00_pre-bootstrap',
+                         filename='00_pre-bootstrap',
                          name='pre-bootstrap')
         await utils.run_step(step,
                              self.msg_cb)

--- a/conjureup/controllers/bootstrap/common.py
+++ b/conjureup/controllers/bootstrap/common.py
@@ -2,6 +2,7 @@ from pathlib import Path
 
 from conjureup import controllers, events, juju, utils
 from conjureup.app_config import app
+from conjureup.models.step import StepModel
 from conjureup.telemetry import track_event
 
 
@@ -46,8 +47,10 @@ class BaseBootstrapController:
         app.env['JUJU_CONTROLLER'] = app.current_controller
         app.env['JUJU_MODEL'] = app.current_model
 
-        await utils.run_step('00_post-bootstrap',
-                             'post-bootstrap',
+        step = StepModel({},
+                         path='00_post-bootstrap',
+                         name='post-bootstrap')
+        await utils.run_step(step,
                              self.msg_cb,
                              'Juju Post-Bootstrap')
         events.Bootstrapped.set()
@@ -63,8 +66,10 @@ class BaseBootstrapController:
         app.env['JUJU_MODEL'] = app.current_model
         app.env['CONJURE_UP_SPELLSDIR'] = app.argv.spells_dir
 
-        await utils.run_step('00_pre-bootstrap',
-                             'pre-bootstrap',
+        step = StepModel({},
+                         path='00_pre-bootstrap',
+                         name='pre-bootstrap')
+        await utils.run_step(step,
                              self.msg_cb)
 
     def emit(self, msg):

--- a/conjureup/controllers/deploy/common.py
+++ b/conjureup/controllers/deploy/common.py
@@ -4,6 +4,7 @@ from datetime import datetime
 from conjureup import events, utils
 from conjureup.app_config import app
 from conjureup.bundlewriter import BundleWriter
+from conjureup.models.step import StepModel
 
 
 def write_bundle(assignments):
@@ -27,7 +28,9 @@ async def pre_deploy(msg_cb):
     app.env['JUJU_MODEL'] = app.current_model
     app.env['CONJURE_UP_SPELLSDIR'] = app.argv.spells_dir
 
-    await utils.run_step('00_pre-deploy',
-                         'pre-deploy',
+    step = StepModel({},
+                     path='00_pre-deploy',
+                     name='pre-deploy')
+    await utils.run_step(step,
                          msg_cb)
     events.PreDeployComplete.set()

--- a/conjureup/controllers/deploy/common.py
+++ b/conjureup/controllers/deploy/common.py
@@ -29,7 +29,7 @@ async def pre_deploy(msg_cb):
     app.env['CONJURE_UP_SPELLSDIR'] = app.argv.spells_dir
 
     step = StepModel({},
-                     path='00_pre-deploy',
+                     filename='00_pre-deploy',
                      name='pre-deploy')
     await utils.run_step(step,
                          msg_cb)

--- a/conjureup/controllers/deploystatus/common.py
+++ b/conjureup/controllers/deploystatus/common.py
@@ -2,6 +2,7 @@ import asyncio
 
 from conjureup import events, utils
 from conjureup.app_config import app
+from conjureup.models.step import StepModel
 
 
 async def wait_for_applications(msg_cb):
@@ -14,8 +15,10 @@ async def wait_for_applications(msg_cb):
     # https://bugs.launchpad.net/juju-wait/+bug/1680963
     for i in range(3):
         try:
-            await utils.run_step('00_deploy-done',
-                                 'deployment watcher',
+            step = StepModel({},
+                             path='00_deploy-done',
+                             name='Deployment Watcher')
+            await utils.run_step(step,
                                  msg_cb)
             break
         except Exception as e:

--- a/conjureup/controllers/deploystatus/common.py
+++ b/conjureup/controllers/deploystatus/common.py
@@ -16,7 +16,7 @@ async def wait_for_applications(msg_cb):
     for i in range(3):
         try:
             step = StepModel({},
-                             path='00_deploy-done',
+                             filename='00_deploy-done',
                              name='Deployment Watcher')
             await utils.run_step(step,
                                  msg_cb)

--- a/conjureup/controllers/steps/common.py
+++ b/conjureup/controllers/steps/common.py
@@ -89,4 +89,8 @@ async def do_step(step_model, msg_cb):
     # Set environment variables so they can be accessed from the step scripts
     set_env(step_model.additional_input)
 
-    return await utils.run_step(step_model.name, step_model.title, msg_cb)
+    # Set result to be written to
+    app.env['RESULT'] = "conjure-up.{}.{}".format(app.config['spell'],
+                                                  step_model.result_key)
+
+    return await utils.run_step(step_model, msg_cb)

--- a/conjureup/controllers/steps/common.py
+++ b/conjureup/controllers/steps/common.py
@@ -89,8 +89,4 @@ async def do_step(step_model, msg_cb):
     # Set environment variables so they can be accessed from the step scripts
     set_env(step_model.additional_input)
 
-    # Set result to be written to
-    app.env['RESULT'] = "conjure-up.{}.{}".format(app.config['spell'],
-                                                  step_model.result_key)
-
     return await utils.run_step(step_model, msg_cb)

--- a/conjureup/models/step.py
+++ b/conjureup/models/step.py
@@ -35,4 +35,4 @@ class StepModel:
         return "<t: {} d: {} v: {} p:>".format(self.title,
                                                self.description,
                                                self.viewable,
-                                               self.path)
+                                               self.filename)

--- a/conjureup/models/step.py
+++ b/conjureup/models/step.py
@@ -5,15 +5,14 @@ from conjureup.app_config import app
 
 class StepModel:
 
-    def __init__(self, step, path, name):
+    def __init__(self, step, filename, name):
         self.title = step.get('title', '')
         self.description = step.get('description', '')
         self.result = ''
         self.viewable = step.get('viewable', False)
         self.needs_sudo = step.get('sudo', False)
-        self.result_key = step.get('result-key', None)
         self.additional_input = step.get('additional-input', [])
-        self.path = path
+        self.filename = filename
         self.name = name
 
     def __getattr__(self, attr):

--- a/conjureup/models/step.py
+++ b/conjureup/models/step.py
@@ -11,6 +11,7 @@ class StepModel:
         self.result = ''
         self.viewable = step.get('viewable', False)
         self.needs_sudo = step.get('sudo', False)
+        self.result_key = step.get('result-key', None)
         self.additional_input = step.get('additional-input', [])
         self.path = path
         self.name = name

--- a/conjureup/ui/widgets/step.py
+++ b/conjureup/ui/widgets/step.py
@@ -78,9 +78,9 @@ class StepWidget(WidgetWrap):
     def update(self):
         if not self.show_output:
             return
-        if not os.path.exists(self.model.path + ".out"):
+        if not os.path.exists(self.model.filename + ".out"):
             return
-        with open(self.model.path + ".out") as outf:
+        with open(self.model.filename + ".out") as outf:
             lines = outf.readlines()
             if len(lines) < 1:
                 return

--- a/conjureup/utils.py
+++ b/conjureup/utils.py
@@ -108,7 +108,12 @@ def run_attach(cmd, output_cb=None):
 
 
 async def run_step(step, msg_cb, event_name=None):
-    step_path = Path(app.config['spell-dir']) / 'steps' / step.path
+    # Define STEP_NAME for use in determining where to store
+    # our step results,
+    #  redis-cli set "conjure-up.$SPELL_NAME.$STEP_NAME.result" "val"
+    app.env['CONJURE_UP_STEP'] = step.filename
+
+    step_path = Path(app.config['spell-dir']) / 'steps' / step.filename
 
     if not step_path.is_file():
         return
@@ -144,8 +149,9 @@ async def run_step(step, msg_cb, event_name=None):
             if event_name is not None:
                 track_event(event_name, "Done", "")
 
-    result = app.state.get("conjure-up.{}.{}".format(app.config['spell'],
-                                                     step.result_key))
+    result = app.state.get(
+        "conjure-up.{}.{}.result".format(app.config['spell'],
+                                         step.filename))
     return result.decode('utf8')
 
 

--- a/conjureup/utils.py
+++ b/conjureup/utils.py
@@ -107,26 +107,25 @@ def run_attach(cmd, output_cb=None):
                                          subproc.returncode))
 
 
-async def run_step(step_file, step_title, msg_cb, event_name=None):
-    step_path = Path(app.config['spell-dir']) / 'steps' / step_file
+async def run_step(step, msg_cb, event_name=None):
+    step_path = Path(app.config['spell-dir']) / 'steps' / step.path
 
     if not step_path.is_file():
         return
 
     step_path = str(step_path)
 
-    msg = "Running step: {}.".format(step_title)
+    msg = "Running step: {}.".format(step.name)
     app.log.info(msg)
     msg_cb(msg)
     if event_name is not None:
         track_event(event_name, "Started", "")
 
     if not os.access(step_path, os.X_OK):
-        raise Exception("Step {} not executable".format(step_title))
+        raise Exception("Step {} not executable".format(step.title))
 
     app.log.debug("Executing script: {}".format(step_path))
 
-    result = None
     async with aiofiles.open(step_path + ".out", 'w') as outf:
         async with aiofiles.open(step_path + ".err", 'w') as errf:
             proc = await asyncio.create_subprocess_exec(step_path,
@@ -136,19 +135,18 @@ async def run_step(step_file, step_title, msg_cb, event_name=None):
             async with aiofiles.open(step_path + '.out', 'r') as f:
                 while proc.returncode is None:
                     async for line in f:
-                        if line.startswith('result:'):
-                            result = line
-                        msg = line
                         msg_cb(line)
                     await asyncio.sleep(0.01)
 
             if proc.returncode != 0:
-                raise Exception("Failure in step {}".format(step_file))
+                raise Exception("Failure in step {}".format(step.path))
 
             if event_name is not None:
                 track_event(event_name, "Done", "")
 
-    return result if result else msg
+    result = app.state.get("conjure-up.{}.{}".format(app.config['spell'],
+                                                     step.result_key))
+    return result.decode('utf8')
 
 
 def can_sudo(password=None):

--- a/conjureup/utils.py
+++ b/conjureup/utils.py
@@ -144,7 +144,7 @@ async def run_step(step, msg_cb, event_name=None):
                     await asyncio.sleep(0.01)
 
             if proc.returncode != 0:
-                raise Exception("Failure in step {}".format(step.path))
+                raise Exception("Failure in step {}".format(step.filename))
 
             if event_name is not None:
                 track_event(event_name, "Done", "")

--- a/snap/wrappers/conjure-up
+++ b/snap/wrappers/conjure-up
@@ -16,4 +16,4 @@ export LXD_DIR=${SNAP_COMMON}/lxd/
 # Make sure we access our python and juju binaries first
 export PATH=$SNAP/bin:$SNAP/usr/bin:/snap/bin:$PATH
 
-exec "$SNAP/bin/conjure-up" --spells-dir "$SNAP/spells" --nosync "$@"
+exec "$SNAP/bin/conjure-up" --spells-dir "$SNAP/spells" --nosync --redis-port 6380 "$@"


### PR DESCRIPTION
This utilizes our StepModel in all run_step invocations. Also makes use of a special environment key 
https://github.com/conjure-up/conjure-up/wiki/Spell-Step-Specification#storing-step-results

You can test this by:

```
sudo apt install redis-server
make dev
. conjure-dev/bin/activate
conjure-up ~/local-path-to-spells/ghost
```

The ghost spell's step to set a url would look something like (step-01_set_url)

```
#!/bin/bash

set -eu

. $CONJURE_UP_SPELLSDIR/sdk/common.sh

juju config -m $JUJU_CONTROLLER:$JUJU_MODEL ghost url="$BLOGURL"

setResult "Visit your Ghost application at $BLOGURL"
exit 0
```

Fixes #910 
Fixes #168 