### PR TITLE
Make sure lxd profile is correct for our bridges

### DIFF
--- a/test/test_controllers_lxdsetup_gui.py
+++ b/test/test_controllers_lxdsetup_gui.py
@@ -48,6 +48,7 @@ class LXDSetupGUIRenderTestCase(unittest.TestCase):
         self.controller = LXDSetupController()
         self.controller.next_screen = MagicMock()
         self.controller.setup = MagicMock()
+        self.controller.set_default_profile = MagicMock()
 
     def tearDown(self):
         self.utils_patcher.stop()
@@ -107,6 +108,7 @@ class LXDSetupGUIFinishTestCase(unittest.TestCase):
 
         self.controller = LXDSetupController()
         self.controller.flag_file = MagicMock()
+        self.controller.set_default_profile = MagicMock()
 
     def tearDown(self):
         self.controllers_patcher.stop()


### PR DESCRIPTION
Our internal lxd instance should only contain the bridge information for our
conjureup0 and conjureup1 network bridges to be used by conjure-up during
localhost deployments. In some cases the default profile was getting written
with lxdbr0 as it's parent bridge which causes issues as the certificates would
not match between bootstraps.

Fixes #921

Signed-off-by: Adam Stokes <battlemidget@users.noreply.github.com>