### PR TITLE
Revert "Make sure lxd profile is correct for our bridges"

### DIFF
--- a/conjureup/controllers/lxdsetup/common.py
+++ b/conjureup/controllers/lxdsetup/common.py
@@ -1,7 +1,5 @@
 import os
-import textwrap
 from pathlib import Path
-from tempfile import NamedTemporaryFile
 
 from conjureup import controllers, utils
 from conjureup.app_config import app
@@ -55,41 +53,6 @@ class BaseLXDSetupController:
 
         self.setup_bridge_network(iface)
         self.setup_unused_bridge_network()
-        self.set_default_profile()
-
-    def set_default_profile(self):
-        """ Sets the default profile with the correct parent network bridges
-        """
-        profile = textwrap.dedent(
-            """
-            config: {}
-            description: Default LXD profile
-            devices:
-              eth0:
-                name: eth0
-                nictype: bridged
-                parent: conjureup1
-                type: nic
-              eth1:
-                name: eth1
-                nictype: bridged
-                parent: conjureup0
-                type: nic
-              root:
-                path: /
-                pool: default
-                type: disk
-            name: default
-            """)
-        with NamedTemporaryFile(mode='w', encoding='utf-8',
-                                delete=False) as tempf:
-            utils.spew(tempf.name, profile)
-            out = utils.run_script(
-                'cat {} |conjure-up.lxc profile edit default'.format(
-                    tempf.name))
-            if out.returncode != 0:
-                raise Exception("Problem setting default profile: {}".format(
-                    out))
 
     def setup_bridge_network(self, iface):
         """ Sets up our main network bridge to be used with Localhost deployments
@@ -107,6 +70,17 @@ class BaseLXDSetupController:
             raise Exception("Failed to create LXD conjureup1 network bridge: "
                             "{}".format(out.stderr.decode()))
 
+        out = utils.run_script(
+            'conjure-up.lxc network attach-profile conjureup1 '
+            'default eth0 eth0')
+
+        if out.returncode != 0:
+            # Skip if device already exists
+            if 'device already exists' not in out.stderr.decode():
+                raise Exception(
+                    "Failed to attach LXD conjureup1 network profile: "
+                    "{}".format(out.stderr.decode()))
+
     def setup_unused_bridge_network(self):
         """ Sets up an unused bridge that can be used with deployments such as
         OpenStack on LXD using NovaLXD.
@@ -121,7 +95,13 @@ class BaseLXDSetupController:
                                'ipv6.address=none '
                                'ipv6.nat=false')
 
+        out = utils.run_script(
+            'conjure-up.lxc network attach-profile conjureup0 '
+            'default eth1 eth1')
+
         if out.returncode != 0:
-            raise Exception(
-                "Failed to create conjureup0 network bridge: "
-                "{}".format(out.stderr.decode()))
+            # Skip if device already exists
+            if 'device already exists' not in out.stderr.decode():
+                raise Exception(
+                    "Failed to attach LXD conjureup0 network profile: "
+                    "{}".format(out.stderr.decode()))

--- a/test/test_controllers_lxdsetup_gui.py
+++ b/test/test_controllers_lxdsetup_gui.py
@@ -48,7 +48,6 @@ class LXDSetupGUIRenderTestCase(unittest.TestCase):
         self.controller = LXDSetupController()
         self.controller.next_screen = MagicMock()
         self.controller.setup = MagicMock()
-        self.controller.set_default_profile = MagicMock()
 
     def tearDown(self):
         self.utils_patcher.stop()
@@ -108,7 +107,6 @@ class LXDSetupGUIFinishTestCase(unittest.TestCase):
 
         self.controller = LXDSetupController()
         self.controller.flag_file = MagicMock()
-        self.controller.set_default_profile = MagicMock()
 
     def tearDown(self):
         self.controllers_patcher.stop()


### PR DESCRIPTION
Reverts conjure-up/conjure-up#922

This seems to be causing issues on subsequent runs attempting to acquire dhcp addresses during bootstrap.