### PR TITLE
Do not filter out interfaces if run inside a container

### DIFF
--- a/conjureup/utils.py
+++ b/conjureup/utils.py
@@ -531,11 +531,17 @@ def set_terminal_title(title):
 
 def get_physical_network_interfaces():
     """ Returns a list of physical network interfaces
+
+    We whitelist eth due to some instances where users run
+    conjure-up inside a single LXD container. At that point
+    all devices are considered virtual and all network device
+    naming follows the ethX pattern.
     """
     sys_class_net = Path('/sys/class/net')
     devices = []
     for device in sys_class_net.glob("*"):
-        if "virtual" in str(device.resolve()):
+        parts = str(device.resolve()).split('/')
+        if "virtual" in parts or not parts[-1].startswith('eth'):
             continue
         try:
             if not get_physical_network_ipaddr(device.name):

--- a/conjureup/utils.py
+++ b/conjureup/utils.py
@@ -541,7 +541,7 @@ def get_physical_network_interfaces():
     devices = []
     for device in sys_class_net.glob("*"):
         parts = str(device.resolve()).split('/')
-        if "virtual" in parts or not parts[-1].startswith('eth'):
+        if "virtual" in parts and not parts[-1].startswith('eth'):
             continue
         try:
             if not get_physical_network_ipaddr(device.name):


### PR DESCRIPTION
If conjure-up is run inside a single lxd container then all network interfaces
are presented as virtual. The best approach to fixing this is to whitelist 'eth'
as this is the pattern for network device naming within containers. So for now
we check if virtual or if the device name doesn't start with eth.

Fixes #916

Signed-off-by: Adam Stokes <battlemidget@users.noreply.github.com>