### PR TITLE
fix logger and print output in hooklib writer

### DIFF
--- a/conjureup/hooklib/writer.py
+++ b/conjureup/hooklib/writer.py
@@ -1,7 +1,7 @@
-import json
 import os
 import sys
 
+from conjureup.app_config import app
 from conjureup.log import setup_logging
 
 CACHEDIR = os.getenv('CONJURE_UP_CACHEDIR',
@@ -9,43 +9,32 @@ CACHEDIR = os.getenv('CONJURE_UP_CACHEDIR',
 SPELL_NAME = os.getenv('CONJURE_UP_SPELL', '_unspecified_spell')
 LOGFILE = os.path.join(CACHEDIR, '{spell}.log'.format(spell=SPELL_NAME))
 
-log = setup_logging("conjure-up/{}".format(SPELL_NAME), LOGFILE, True)
+app.config = {'metadata': None,
+              'spell': SPELL_NAME}
+log = setup_logging(app, LOGFILE, True)
 
 
 def success(msg):
     """ Returns a successful step
     """
-    print(json.dumps({
-        'message': msg,
-        'returnCode': 0,
-        'isComplete': True
-    }))
+    print(msg)
     sys.exit(0)
 
 
 def fail(msg):
-    """ Logs a failed step, does not stop step execution
+    """ Logs a failed step, does stop step execution
     """
-    print(json.dumps({
-        'message': msg,
-        'returnCode': 0,
-        'isComplete': False
-    }))
-    sys.exit(0)
+    print(msg)
+    sys.exit(1)
 
 
 def error(msg):
     """ Logs a fatal error, does stop step execution
     """
-    print(json.dumps({
-        'message': msg,
-        'returnCode': 1,
-        'isComplete': False
-    }))
-    sys.exit(0)
+    print(msg)
+    sys.exit(1)
 
 
 def info(msg):
-    print(json.dumps({
-        'message': msg}))
+    print(msg)
     sys.stdout.flush()


### PR DESCRIPTION
Eventually, I'd like to remove hooklib in favor of seperate modules like sh and
env to assist users in writing spells. Also to reduce maintenance burden.

Fixes #938

Signed-off-by: Adam Stokes <battlemidget@users.noreply.github.com>