### PR TITLE
Fix NoneType error from no step result

### DIFF
--- a/conjureup/utils.py
+++ b/conjureup/utils.py
@@ -168,7 +168,7 @@ async def run_step(step, msg_cb, event_name=None):
     result = app.state.get(
         "conjure-up.{}.{}.result".format(app.config['spell'],
                                          step.filename))
-    return result.decode('utf8')
+    return (result or b'').decode('utf8')
 
 
 def can_sudo(password=None):


### PR DESCRIPTION
From sentry (https://sentry.io/canonical-pj/conjure-up/issues/295595983/):

```
AttributeError: 'NoneType' object has no attribute 'decode'
  File "conjureup/controllers/steps/tui.py", line 24, in do_steps
    utils.info)
  File "conjureup/controllers/steps/common.py", line 92, in do_step
    return await utils.run_step(step_model, msg_cb)
  File "conjureup/utils.py", line 171, in run_step
    return result.decode('utf8')
```