### PR TITLE
Fix existing controller detection

### DIFF
--- a/conjureup/controllers/controllerpicker/common.py
+++ b/conjureup/controllers/controllerpicker/common.py
@@ -30,7 +30,7 @@ class BaseControllerPicker:
         else:
             app.current_controller = controller
 
-        if app.current_controller not in juju.get_controllers():
+        if app.current_controller not in juju.get_controllers()['controllers']:
             return controllers.use('bootstrap').render()
 
         c_info = juju.get_controller_info(app.current_controller)


### PR DESCRIPTION
PR #947 had a bug which caused it to never detect existing controllers due to not using the proper dictionary key.

Fixes #950