### PR TITLE
Remove dnsmasq hold on an interface during network creation

### DIFF
--- a/conjureup/controllers/lxdsetup/common.py
+++ b/conjureup/controllers/lxdsetup/common.py
@@ -5,9 +5,9 @@ from functools import partial
 from pathlib import Path
 from tempfile import NamedTemporaryFile
 
+import psutil
 from pkg_resources import parse_version
 
-import psutil
 from conjureup import controllers, utils
 from conjureup.app_config import app
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,4 +16,4 @@ git+https://github.com/battlemidget/env.git@1.0.0
 sh==1.12.13
 redis==2.10.5
 raven==6.1.0
-psutil=5.2.2
+psutil==5.2.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,3 +16,4 @@ git+https://github.com/battlemidget/env.git@1.0.0
 sh==1.12.13
 redis==2.10.5
 raven==6.1.0
+psutil=5.2.2


### PR DESCRIPTION
In some cases, primarily during upgrades, dnsmasq will hold onto an interface
that needs to be managed by LXD. This causes issues during network creation
where it will give 'Address in use' even though the network is created at random.

https://sentry.io/canonical-pj/conjure-up/issues/296744258/

Signed-off-by: Adam Stokes <battlemidget@users.noreply.github.com>