### PR TITLE
This prepends the $SNAP/lib to ld_library_path

### DIFF
--- a/snap/wrappers/conjure-down
+++ b/snap/wrappers/conjure-down
@@ -8,7 +8,7 @@ export LC_ALL=$APPLOC
 export LANG=$APPLOC
 export LANGUAGE=${APPLANG%_*}
 export LD_LIBRARY_PATH
-LD_LIBRARY_PATH=$SNAP/usr/lib/$(uname -p)-linux-gnu/
+LD_LIBRARY_PATH=$SNAP/lib:$SNAP/usr/lib/$(uname -p)-linux-gnu/
 export LXD_DIR=${SNAP_COMMON}/lxd/
 
 # Make sure we access our python and juju binaries first

--- a/snap/wrappers/conjure-up
+++ b/snap/wrappers/conjure-up
@@ -10,7 +10,7 @@ export LC_ALL=$APPLOC
 export LANG=$APPLOC
 export LANGUAGE=${APPLANG%_*}
 export LD_LIBRARY_PATH
-LD_LIBRARY_PATH=$SNAP/usr/lib/$(uname -p)-linux-gnu/
+LD_LIBRARY_PATH=$SNAP/lib:$SNAP/usr/lib/$(uname -p)-linux-gnu/
 export LXD_DIR=${SNAP_COMMON}/lxd/
 
 # Make sure we access our python and juju binaries first

--- a/snap/wrappers/daemon.start
+++ b/snap/wrappers/daemon.start
@@ -10,7 +10,7 @@ export LXD_LXC_TEMPLATE_CONFIG="${SNAP}/lxc/config/"
 export HOME="/tmp/"
 export PATH=$SNAP/bin:$SNAP/usr/bin:/snap/bin:$PATH
 export LD_LIBRARY_PATH
-LD_LIBRARY_PATH=$SNAP/usr/lib/$(uname -p)-linux-gnu/
+LD_LIBRARY_PATH=$SNAP/lib:$SNAP/usr/lib/$(uname -p)-linux-gnu/
 
 # Setup a functional /etc
 if mountpoint -q /etc; then

--- a/snap/wrappers/daemon.stop
+++ b/snap/wrappers/daemon.stop
@@ -3,7 +3,7 @@ set -eu
 
 export PATH=$SNAP/bin:$SNAP/usr/bin:/snap/bin:$PATH
 export LD_LIBRARY_PATH
-LD_LIBRARY_PATH=$SNAP/usr/lib/$(uname -p)-linux-gnu/
+LD_LIBRARY_PATH=$SNAP/lib:$SNAP/usr/lib/$(uname -p)-linux-gnu/
 
 if [ -d /sys/kernel/security/apparmor ] && [ "$(cat /proc/self/attr/current)" != "unconfined" ]; then
     exec aa-exec -p unconfined -- "$0" "$@"

--- a/snap/wrappers/juju
+++ b/snap/wrappers/juju
@@ -5,7 +5,6 @@
 export LXD_DIR=${SNAP_COMMON}/lxd/
 export PATH=$SNAP/bin:$SNAP/usr/bin:/snap/bin:$PATH
 export LD_LIBRARY_PATH
-LD_LIBRARY_PATH=$SNAP/usr/lib/$(uname -p)-linux-gnu/
-
+LD_LIBRARY_PATH=$SNAP/lib:$SNAP/usr/lib/$(uname -p)-linux-gnu/
 
 exec "$SNAP/bin/juju" "$@"

--- a/snap/wrappers/lxc
+++ b/snap/wrappers/lxc
@@ -5,6 +5,6 @@ export VISUAL=${EDITOR}
 
 export PATH=$SNAP/bin:$SNAP/usr/bin:/snap/bin:$PATH
 export LD_LIBRARY_PATH
-LD_LIBRARY_PATH=$SNAP/usr/lib/$(uname -p)-linux-gnu/
+LD_LIBRARY_PATH=$SNAP/lib:$SNAP/usr/lib/$(uname -p)-linux-gnu/
 
 exec "$SNAP/bin/lxc" "$@"

--- a/snap/wrappers/lxd
+++ b/snap/wrappers/lxd
@@ -3,7 +3,7 @@ export LXD_DIR=${SNAP_COMMON}/lxd/
 
 export PATH=$SNAP/bin:$SNAP/usr/bin:/snap/bin:$PATH
 export LD_LIBRARY_PATH
-LD_LIBRARY_PATH=$SNAP/usr/lib/$(uname -p)-linux-gnu/
+LD_LIBRARY_PATH=$SNAP/lib:$SNAP/usr/lib/$(uname -p)-linux-gnu/
 
 if [ -d /sys/kernel/security/apparmor ] && [ "$(cat /proc/self/attr/current)" != "unconfined" ]; then
     exec aa-exec -p unconfined -- "$0" "$@"

--- a/snap/wrappers/redis-cli
+++ b/snap/wrappers/redis-cli
@@ -3,6 +3,5 @@ set -eu
 
 export PATH=$SNAP/bin:$SNAP/usr/bin:/snap/bin:$PATH
 export LD_LIBRARY_PATH
-LD_LIBRARY_PATH=$SNAP/usr/lib/$(uname -p)-linux-gnu/
-
+LD_LIBRARY_PATH=$SNAP/lib:$SNAP/usr/lib/$(uname -p)-linux-gnu/
 "$SNAP/bin/redis-cli" -p 6380 "$@"

--- a/snap/wrappers/redis.daemon.start
+++ b/snap/wrappers/redis.daemon.start
@@ -3,7 +3,7 @@ set -eu
 
 export PATH=$SNAP/bin:$SNAP/usr/bin:/snap/bin:$PATH
 export LD_LIBRARY_PATH
-LD_LIBRARY_PATH=$SNAP/usr/lib/$(uname -p)-linux-gnu/
+LD_LIBRARY_PATH=$SNAP/lib:$SNAP/usr/lib/$(uname -p)-linux-gnu/
 
 ## Start redis-server
 "$SNAP/bin/redis-server" --port 6380 "$@"


### PR DESCRIPTION
Looking at our snap fs layout we see that liblxc.so.1 is in

```
squashfs-root/lib/liblxc.so.1
squashfs-root/lib/liblxc.so.1.2.0
squashfs-root/lib/liblxcfs.so
```

Previously, we were only looking in $SNAP/usr/lib/$(uname -p)-linux-gnu/, this
patch adds the additional directory to check for bundled libraries.

References #955

Signed-off-by: Adam Stokes <battlemidget@users.noreply.github.com>