### PR TITLE
Dont track certain exceptions

### DIFF
--- a/conjureup/controllers/spellpicker/gui.py
+++ b/conjureup/controllers/spellpicker/gui.py
@@ -32,9 +32,8 @@ class SpellPickerController:
         elif app.endpoint_type == EndpointType.LOCAL_SEARCH:
             spells = utils.find_spells_matching(app.argv.spell)
         else:
-            e = Exception("Unexpected endpoint type {}".format(
+            raise Exception("Unexpected endpoint type {}".format(
                 app.endpoint_type))
-            app.ui.show_exception_message(e)
 
         # add subdir of spells-dir to spell dict for bundle readme view:
         for category, spell in spells:

--- a/conjureup/models/provider.py
+++ b/conjureup/models/provider.py
@@ -485,9 +485,7 @@ Schema = [
 
 class SchemaError(Exception):
     def __init__(self, cloud):
-        super().__init__("Credentials Error: Could not find schema for: "
-                         "{}".format(cloud))
-        self.user_message = (
+        super().__init__(
             "Unable to find credentials for {}, "
             "you can double check what credentials you "
             "do have available by running "

--- a/conjureup/ui/__init__.py
+++ b/conjureup/ui/__init__.py
@@ -4,23 +4,12 @@ from conjureup import async
 from conjureup.app_config import app
 from conjureup.ui.views.shutdown import ShutdownView
 from ubuntui.ev import EventLoop
-import errno
 
 
 class ConjureUI(Frame):
 
     def show_exception_message(self, ex):
-        if isinstance(ex, async.ThreadCancelledException):
-            pass
-        elif hasattr(ex, 'errno') and ex.errno == errno.ENOENT:
-            # handle oserror
-            errmsg = ex.args[1]
-        elif isinstance(ex, TimeoutError):
-            errmsg = 'Timeout: {}'.format(ex)
-        elif hasattr(ex, 'user_message'):
-            errmsg = ex.user_message
-        else:
-            errmsg = str(ex)
+        errmsg = str(ex)
         errmsg += ("\n\n"
                    "Review log messages at ~/.cache/conjure-up/conjure-up.log "
                    "If appropriate, please submit a bug here: "

--- a/conjureup/ui/views/deploystatus.py
+++ b/conjureup/ui/views/deploystatus.py
@@ -110,6 +110,5 @@ class DeployStatusView(WidgetWrap):
                 unit_w.AgentStatus.set_text(unit['agent-status']['status'])
                 unit_w.Icon.set_text(
                     self.status_icon_state(unit['agent-status']['status']))
-        except Exception as e:
-            self.app.log.exception(e)
-            self.app.ui.show_exception_message(e)
+        except Exception:
+            raise


### PR DESCRIPTION
Handles ENOSPC cases as a no track exception so that we still show the error to
the user but dont treat it as an exception that is considered a bug.

For example, users system's with not enough disk space, nothing for us to fix
other than letting the user know that they've run out of disk space.

Also drive-by removing any outside calls to show_exception_message that's not passed through the events mechanism

Fixes #959
Fixes #963

Signed-off-by: Adam Stokes <battlemidget@users.noreply.github.com>