### PR TITLE
Verify running user can access LXD daemon

### DIFF
--- a/conjureup/controllers/lxdsetup/common.py
+++ b/conjureup/controllers/lxdsetup/common.py
@@ -19,12 +19,6 @@ class LXDInvalidUserError(Exception):
     pass
 
 
-class LXDInvalidGroupError(Exception):
-    """ LXD group does not exist, should be created
-    """
-    pass
-
-
 class BaseLXDSetupController:
     def __init__(self):
         snap_user_data = os.environ.get('SNAP_USER_DATA', None)
@@ -48,25 +42,15 @@ class BaseLXDSetupController:
         """ Makes sure the user is in the LXD group so they can
         access the daemon
         """
-        try:
-            lxd_group = grp.getgrnam('lxd')
-            if os.environ.get('USER', None) not in lxd_group.gr_mem:
-                raise LXDInvalidUserError(
-                    "Your user does not exist in the LXD group, "
-                    "you can create it with:\n\n"
-                    " $ sudo usermod -a -G lxd $USER"
-                    "\n\n"
-                    "Once complete either log your user out completely, "
-                    "reboot, or run: \n\n"
-                    " $ newgrp lxd"
-                )
-        except KeyError:
-            raise LXDInvalidGroupError(
-                "LXD Group does not exist, you can create it with:\n\n"
-                " $ sudo groupadd lxd && sudo usermod -a -G lxd $USER"
+        lxd_group = grp.getgrnam('lxd')
+        if os.environ.get('USER', None) not in lxd_group.gr_mem:
+            raise LXDInvalidUserError(
+                "Your user does not exist in the LXD group, "
+                "you can create it with:\n\n"
+                " $ sudo usermod -a -G lxd $USER"
                 "\n\n"
-                "Once complete either log your user out completely, reboot, "
-                "or run: \n\n"
+                "Once complete either log your user out completely, "
+                "reboot, or run: \n\n"
                 " $ newgrp lxd"
             )
 

--- a/conjureup/controllers/lxdsetup/common.py
+++ b/conjureup/controllers/lxdsetup/common.py
@@ -1,7 +1,7 @@
+import grp
 import os
 import textwrap
 import time
-import grp
 from functools import partial
 from pathlib import Path
 from tempfile import NamedTemporaryFile

--- a/conjureup/events.py
+++ b/conjureup/events.py
@@ -8,11 +8,11 @@ from urwid import ExitMainLoop
 
 from conjureup import utils
 from conjureup.app_config import app
-from conjureup.telemetry import track_exception
 from conjureup.controllers.lxdsetup.common import (
-    LXDInvalidUserError,
-    LXDInvalidGroupError
+    LXDInvalidGroupError,
+    LXDInvalidUserError
 )
+from conjureup.telemetry import track_exception
 
 
 class Event(asyncio.Event):

--- a/conjureup/events.py
+++ b/conjureup/events.py
@@ -120,7 +120,7 @@ PostDeployComplete = Event('PostDeployComplete')
 # Keep a list of exceptions we know that shouldn't be logged
 # into sentry.
 NOTRACK_EXCEPTIONS = [
-    lambda exc: exc is OSError and exc.errno == errno.ENOSPC,
+    lambda exc: isinstance(exc, OSError) and exc.errno == errno.ENOSPC,
     lambda exc: isinstance(exc, LXDInvalidUserError)
 ]
 

--- a/conjureup/events.py
+++ b/conjureup/events.py
@@ -9,6 +9,10 @@ from urwid import ExitMainLoop
 from conjureup import utils
 from conjureup.app_config import app
 from conjureup.telemetry import track_exception
+from conjureup.controllers.lxdsetup.common import (
+    LXDInvalidUserError,
+    LXDInvalidGroupError
+)
 
 
 class Event(asyncio.Event):
@@ -119,7 +123,8 @@ PostDeployComplete = Event('PostDeployComplete')
 # Keep a list of exceptions we know that shouldn't be logged
 # into sentry.
 NOTRACK_EXCEPTIONS = [
-    lambda exc: exc is OSError and exc.errno == errno.ENOSPC
+    lambda exc: exc is OSError and exc.errno == errno.ENOSPC,
+    lambda exc: exc is LXDInvalidUserError or exc is LXDInvalidGroupError
 ]
 
 

--- a/conjureup/events.py
+++ b/conjureup/events.py
@@ -144,7 +144,7 @@ def handle_exception(loop, context):
     exc = context['exception']
 
     track_exception(str(exc))
-    if not app.noreport or not any(pred(exc) for pred in NOTRACK_EXCEPTIONS):
+    if not (app.noreport or any(pred(exc) for pred in NOTRACK_EXCEPTIONS)):
         try:
             exc_info = (type(exc), exc, exc.__traceback__)
             app.sentry.captureException(exc_info, tags={

--- a/conjureup/events.py
+++ b/conjureup/events.py
@@ -8,10 +8,7 @@ from urwid import ExitMainLoop
 
 from conjureup import utils
 from conjureup.app_config import app
-from conjureup.controllers.lxdsetup.common import (
-    LXDInvalidGroupError,
-    LXDInvalidUserError
-)
+from conjureup.controllers.lxdsetup.common import LXDInvalidUserError
 from conjureup.telemetry import track_exception
 
 
@@ -124,7 +121,7 @@ PostDeployComplete = Event('PostDeployComplete')
 # into sentry.
 NOTRACK_EXCEPTIONS = [
     lambda exc: exc is OSError and exc.errno == errno.ENOSPC,
-    lambda exc: exc is LXDInvalidUserError or exc is LXDInvalidGroupError
+    lambda exc: isinstance(exc, LXDInvalidUserError)
 ]
 
 

--- a/conjureup/events.py
+++ b/conjureup/events.py
@@ -144,7 +144,7 @@ def handle_exception(loop, context):
     exc = context['exception']
 
     track_exception(str(exc))
-    if not app.noreport or any(pred(exc) for pred in NOTRACK_EXCEPTIONS):
+    if not app.noreport or not any(pred(exc) for pred in NOTRACK_EXCEPTIONS):
         try:
             exc_info = (type(exc), exc, exc.__traceback__)
             app.sentry.captureException(exc_info, tags={

--- a/snap/hooks/configure
+++ b/snap/hooks/configure
@@ -42,13 +42,16 @@ if [[ ! -f /snap/bin/juju ]]; then
     ln -s conjure-up.juju /snap/bin/juju
 fi
 
+# Make sure the LXD group exists as we don't want to assume users have installed
+# LXD from a deb package or previous snap
+groupadd lxd || true
+
 # Make sure that LXD ownership is correct
 if [[ -d $SNAP_COMMON/lxd ]]; then
     chown root:root "$SNAP_COMMON/lxd"
 fi
 
 if [[ -f $SNAP_COMMON/lxd/unix.socket ]]; then
-    groupadd lxd || true
     chown root:lxd "$SNAP_COMMON/lxd/unix.socket"
     chmod 0660 "$SNAP_COMMON/lxd/unix.socket"
 fi

--- a/snap/hooks/configure
+++ b/snap/hooks/configure
@@ -48,6 +48,7 @@ if [[ -d $SNAP_COMMON/lxd ]]; then
 fi
 
 if [[ -f $SNAP_COMMON/lxd/unix.socket ]]; then
+    groupadd lxd || true
     chown root:lxd "$SNAP_COMMON/lxd/unix.socket"
     chmod 0660 "$SNAP_COMMON/lxd/unix.socket"
 fi

--- a/test/test_controllers_lxdsetup_gui.py
+++ b/test/test_controllers_lxdsetup_gui.py
@@ -102,12 +102,18 @@ class LXDSetupGUIFinishTestCase(unittest.TestCase):
             'conjureup.controllers.lxdsetup.common.parse_version'
         )
         self.mock_parse_version = self.parse_version_patcher.start()
+        self.grp_patcher = patch(
+            'conjureup.controllers.lxdsetup.common.grp'
+        )
+        self.mock_grp = self.grp_patcher.start()
+
         events.Shutdown.clear()
 
         self.controller = LXDSetupController()
         self.controller.flag_file = MagicMock()
         self.controller.next_screen = MagicMock()
         self.controller.set_default_profile = MagicMock()
+        self.controller.can_user_acces_lxd = MagicMock()
         self.mock_utils.snap_version.return_value = parse_version('2.25')
         self.mock_parse_version.return_value = parse_version('2.25')
 
@@ -118,6 +124,7 @@ class LXDSetupGUIFinishTestCase(unittest.TestCase):
         self.app_patcher.stop()
         self.ev_app_patcher.stop()
         self.parse_version_patcher.stop()
+        self.grp_patcher.stop()
 
     def test_snap_version_incompatible(self):
         """ Test that an invalid snap version fails correctly


### PR DESCRIPTION
Make sure the user is in the LXD group, if group doesn't exist or user is not in
the group give them a clear exception message on how to fix. Additonally, these
errors do not need to be tracked as it is understood that users with improper
permissions will never be able to access the lxd daemon bundled or not.

Fixes #973

Signed-off-by: Adam Stokes <battlemidget@users.noreply.github.com>