### PR TITLE
Validate ~/.local/share/juju is accessible

### DIFF
--- a/conjureup/app.py
+++ b/conjureup/app.py
@@ -206,6 +206,21 @@ def main():
         print("")
         sys.exit(1)
 
+    # Verify we can access ~/.local/share/juju if it exists
+    juju_dir = pathlib.Path('~/.local/share/juju').expanduser()
+    if juju_dir.exists():
+        try:
+            for f in juju_dir.iterdir():
+                if f.is_file():
+                    f.read_text()
+        except PermissionError:
+            print("")
+            print("  !! Unable to read from ~/.local/share/juju, please "
+                  "double check your permissions on that directory "
+                  "and its files. !!")
+            print("")
+            sys.exit(1)
+
     utils.set_terminal_title("conjure-up")
     opts = parse_options(sys.argv[1:])
     spell = os.path.basename(os.path.abspath(opts.spell))

--- a/conjureup/events.py
+++ b/conjureup/events.py
@@ -121,8 +121,7 @@ PostDeployComplete = Event('PostDeployComplete')
 # into sentry.
 NOTRACK_EXCEPTIONS = [
     lambda exc: isinstance(exc, OSError) and exc.errno == errno.ENOSPC,
-    lambda exc: isinstance(exc, LXDInvalidUserError),
-    lambda exc: isinstance(exc, PermissionError)
+    lambda exc: isinstance(exc, LXDInvalidUserError)
 ]
 
 

--- a/conjureup/events.py
+++ b/conjureup/events.py
@@ -121,7 +121,8 @@ PostDeployComplete = Event('PostDeployComplete')
 # into sentry.
 NOTRACK_EXCEPTIONS = [
     lambda exc: isinstance(exc, OSError) and exc.errno == errno.ENOSPC,
-    lambda exc: isinstance(exc, LXDInvalidUserError)
+    lambda exc: isinstance(exc, LXDInvalidUserError),
+    lambda exc: isinstance(exc, PermissionError)
 ]
 
 
@@ -143,8 +144,8 @@ def handle_exception(loop, context):
     Error.set()
     exc = context['exception']
 
-    track_exception(str(exc))
     if not (app.noreport or any(pred(exc) for pred in NOTRACK_EXCEPTIONS)):
+        track_exception(str(exc))
         try:
             exc_info = (type(exc), exc, exc.__traceback__)
             app.sentry.captureException(exc_info, tags={


### PR DESCRIPTION
This makes sure that conjure-up can access the juju required files if they
exist.

Also a drive-by to not send analytics on items in the notrack_exceptions list.

Fixes #991

Signed-off-by: Adam Stokes <battlemidget@users.noreply.github.com>