### PR TITLE
Azure tenant id no longer required

### DIFF
--- a/conjureup/models/provider.py
+++ b/conjureup/models/provider.py
@@ -247,11 +247,6 @@ class Azure(BaseProvider):
             widget=StringEditor(),
             key='subscription-id'
         )
-        self.tenant_id = Field(
-            label='tenant id',
-            widget=StringEditor(),
-            key='tenant-id'
-        )
         self.application_password = Field(
             label='application password',
             widget=PasswordEditor(),
@@ -262,7 +257,6 @@ class Azure(BaseProvider):
         return [
             self.application_id,
             self.subscription_id,
-            self.tenant_id,
             self.application_password
         ]
 


### PR DESCRIPTION
Juju is able to determine the tenant-id utilizing the subscription id.

Fixes #1013

Signed-off-by: Adam Stokes <battlemidget@users.noreply.github.com>