### PR TITLE
State storage for Application config

### DIFF
--- a/conjureup/app_config.py
+++ b/conjureup/app_config.py
@@ -127,13 +127,22 @@ class AppConfig:
     # exit code for conjure-up to terminate with
     exit_code = 0
 
+    def __setattr__(self, name, value):
+        """ Gaurds against setting attributes that don't already exist
+        """
+        try:
+            getattr(AppConfig, name)
+        except AttributeError:
+            raise Exception(
+                "Attempted to set an unknown attribute for application config")
+        setattr(self.__class__, name, value)
+
     @property
     def _redis_key(self):
         """ Internal, formatted redis namespace key
         """
-        return "conjure-up.{}.{}.{}".format(self.config['spell'],
-                                            self.current_controller,
-                                            self.current_model)
+        return "conjure-up.{}.{}".format(self.current_cloud_type,
+                                         self.config['spell'])
 
     def to_json(self):
         """

--- a/conjureup/app_config.py
+++ b/conjureup/app_config.py
@@ -163,7 +163,7 @@ class AppConfig:
 
     async def save(self):
         self.log.info('Storing conjure-up state')
-        if self.juju.is_authenticated:
+        if self.juju.authenticated:
             await self.juju.client.set_config(
                 {'extra-info': self.to_json()})
             self.log.info('State saved in model config')
@@ -176,7 +176,7 @@ class AppConfig:
     async def restore(self):
         self.log.info('Attempting to load conjure-up cached state.')
         try:
-            if self.juju.is_authenticated:
+            if self.juju.authenticated:
                 result = await self.juju.client.get_config()
                 if 'extra-info' in result:
                     self.log.info(

--- a/conjureup/app_config.py
+++ b/conjureup/app_config.py
@@ -140,7 +140,7 @@ class AppConfig:
         every invocation of conjure-up. Also blacklist env for security
         precautions.
         """
-        blacklist = ['loop', 'log', 'maas',
+        blacklist = ['loop', 'log', 'maas', 'argv',
                      'juju', 'ui', 'bootstrap',
                      'metadata_controller', 'state',
                      'env', 'sentry']

--- a/conjureup/app_config.py
+++ b/conjureup/app_config.py
@@ -121,6 +121,9 @@ class AppConfig:
     # Sentry endpoint
     sentry = None,
 
+    # Spells index
+    spells_index = None,
+
     # exit code for conjure-up to terminate with
     exit_code = 0
 
@@ -140,7 +143,7 @@ class AppConfig:
         every invocation of conjure-up. Also blacklist env for security
         precautions.
         """
-        blacklist = ['loop', 'log', 'maas', 'argv',
+        blacklist = ['loop', 'log', 'maas', 'argv', 'spells_index',
                      'juju', 'ui', 'bootstrap',
                      'metadata_controller', 'state',
                      'env', 'sentry']

--- a/conjureup/app_config.py
+++ b/conjureup/app_config.py
@@ -180,6 +180,9 @@ class AppConfig:
             setattr(self, k, v)
 
     async def save(self):
+        if not self.config.get('spell'):
+            # don't bother saving if they haven't even picked a spell yet
+            return
         self.log.info('Storing conjure-up state')
         if self.juju.authenticated:
             await self.juju.client.set_config(

--- a/conjureup/app_config.py
+++ b/conjureup/app_config.py
@@ -82,6 +82,9 @@ class AppConfig:
     # Current Juju cloud region
     current_region = None
 
+    # Current credential name selected
+    current_credential = None
+
     # Current UI View rendered
     current_view = None
 

--- a/conjureup/app_config.py
+++ b/conjureup/app_config.py
@@ -1,5 +1,6 @@
 """ application config
 """
+import json
 from types import SimpleNamespace
 
 bootstrap = SimpleNamespace(
@@ -29,86 +30,169 @@ juju = SimpleNamespace(
     authenticated=False
 )
 
-app = SimpleNamespace(
+
+class AppConfig:
+    """ Application config storage
+    """
+
     # Juju bootstrap details
-    bootstrap=bootstrap,
+    bootstrap = bootstrap
 
     # MAAS client
-    maas=maas,
+    maas = maas
 
     # Juju Client
-    juju=juju,
+    juju = juju
 
     # The conjure-up UI framework
-    ui=None,
+    ui = None
 
     # Contains metadata and spell name
-    config=None,
+    config = None
 
     # List of multiple bundles, usually from a charmstore search
-    bundles=None,
+    bundles = None
 
     # Selected bundle from a Variant view
-    current_bundle=None,
+    current_bundle = None
 
     # cli opts
-    argv=None,
+    argv = None
 
     # Is JAAS supported by the current spell
-    jaas_ok=True,
+    jaas_ok = True
 
     # Which controller, if any, is the JAAS controller
-    jaas_controller=None,
+    jaas_controller = None
 
     # Whether the JAAS controller is selected
-    is_jaas=False,
+    is_jaas = False
 
-    current_model=None,
+    current_model = None
 
     # Current Juju controller selected
-    current_controller=None,
+    current_controller = None
 
     # Current Juju cloud selected
-    current_cloud=None,
+    current_cloud = None
 
     # Current Juju cloud type selected
-    current_cloud_type=None,
+    current_cloud_type = None
 
     # Current Juju cloud region
-    current_region=None,
+    current_region = None
+
+    # Current UI View rendered
+    current_view = None
 
     # Session ID for current deployment
-    session_id=None,
+    session_id = None
 
     # Application logger
-    log=None,
+    log = None
 
     # Charm store metadata API client
-    metadata_controller=None,
+    metadata_controller = None
 
     # disable telemetry tracking
-    notrack=False,
+    notrack = False
 
     # disable automatic error reporting
-    noreport=False,
+    noreport = False
 
     # Application environment passed to processing steps
-    env=None,
+    env = None
 
     # Did deployment complete
-    complete=False,
+    complete = False
 
     # Run in non interactive mode
-    headless=False,
+    headless = False
 
     # Remote endpoint type (An enum, see download.py)
-    endpoint_type=None,
+    endpoint_type = None
 
     # Reference to asyncio loop so that it can be accessed from other threads
-    loop=None,
+    loop = None
 
     # Redis State storage endpoint
-    state=None,
+    state = None
 
     # exit code for conjure-up to terminate with
-    exit_code=0)
+    exit_code = 0
+
+    @property
+    def _redis_key(self):
+        """ Internal, formatted redis namespace key
+        """
+        return "conjure-up.{}.{}.{}".format(self.config['spell'],
+                                            self.current_controller,
+                                            self.current_model)
+
+    def to_json(self):
+        """
+        Serialize application config to JSON
+
+        We blacklist several items as they are intended to be reloaded during
+        every invocation of conjure-up. Also blacklist env for security
+        precautions.
+        """
+        blacklist = ['loop', 'log', 'maas',
+                     'juju', 'ui', 'bootstrap',
+                     'metadata_controller', 'state',
+                     'env']
+        new_dict = {}
+        for k, v in self.__dict__.items():
+            if k.startswith('__') or callable(getattr(self, k)):
+                continue
+            if k in blacklist:
+                continue
+            new_dict[k] = v
+        return json.dumps(new_dict)
+
+    def from_json(self, data):
+        """ Deserializes application state and updates app_config
+        """
+        state = json.loads(data.decode('utf8'))
+        for k, v in state.items():
+            try:
+                getattr(self, k)
+            except AttributeError:
+                continue
+            setattr(self, k, v)
+
+    async def save(self):
+        self.log.info('Storing conjure-up state')
+        if self.juju.is_authenticated:
+            await self.juju.client.set_config(
+                {'extra-info': self.to_json()})
+            self.log.info('State saved in model config')
+            # Check for existing redis key and clear it
+            self.state.delete(self._redis_key)
+        else:
+            self.state.set(self._redis_key, self.to_json())
+            self.log.info('State saved in redis')
+
+    async def restore(self):
+        self.log.info('Attempting to load conjure-up cached state.')
+        try:
+            if self.juju.is_authenticated:
+                result = await self.juju.client.get_config()
+                if 'extra-info' in result:
+                    self.log.info(
+                        "Found cached state from Juju model, reloading.")
+                    self.from_json(result['extra-info'].value)
+                    return
+            result = self.state.get(self._redis_key)
+            if result:
+                self.log.info("Found cached state in Redis, reloading.")
+                self.from_json(result.decode('utf8'))
+        except json.JSONDecodeError as e:
+            # Dont fail fatally if state information is incorrect. Just log it
+            # and move on
+            self.log.debug(
+                "State information possibly corrupt "
+                "or malformed: {}".format(e))
+
+
+app = AppConfig()

--- a/conjureup/app_config.py
+++ b/conjureup/app_config.py
@@ -118,6 +118,9 @@ class AppConfig:
     # Redis State storage endpoint
     state = None
 
+    # Sentry endpoint
+    sentry = None,
+
     # exit code for conjure-up to terminate with
     exit_code = 0
 
@@ -140,7 +143,7 @@ class AppConfig:
         blacklist = ['loop', 'log', 'maas',
                      'juju', 'ui', 'bootstrap',
                      'metadata_controller', 'state',
-                     'env']
+                     'env', 'sentry']
         new_dict = {}
         for k, v in self.__dict__.items():
             if k.startswith('__') or callable(getattr(self, k)):

--- a/conjureup/app_config.py
+++ b/conjureup/app_config.py
@@ -138,7 +138,7 @@ class AppConfig:
         except AttributeError:
             raise Exception(
                 "Attempted to set an unknown attribute for application config")
-        setattr(self.__class__, name, value)
+        super().__setattr__(name, value)
 
     @property
     def _redis_key(self):

--- a/conjureup/events.py
+++ b/conjureup/events.py
@@ -203,7 +203,6 @@ async def shutdown_watcher():
             # cancel all other tasks
             if getattr(task, '_coro', None) is not shutdown_watcher:
                 task.cancel()
-        app.loop.stop()
-    except Exception:
-        app.log.exception('Error in cleanup code')
-        raise
+    except Exception as e:
+        app.log.exception('Error in cleanup code: {}'.format(e))
+    app.loop.stop()

--- a/conjureup/events.py
+++ b/conjureup/events.py
@@ -188,6 +188,9 @@ async def shutdown_watcher():
         app.ui.show_shutdown_message()
 
     try:
+        # Store application configuration state
+        await app.save()
+
         if app.juju.authenticated:
             app.log.info('Disconnecting model')
             await app.juju.client.disconnect()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,8 @@
 aiofiles==0.3.1
 bundle-placement==0.0.1
 Jinja2==2.9.6
-juju==0.5.3
+# juju==0.5.3
+git+https://github.com/juju/python-libjuju@17b26ef
 juju-wait==2.5.1
 prettytable==0.7.2
 progressbar2==3.20.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,7 @@
 aiofiles==0.3.1
 bundle-placement==0.0.1
 Jinja2==2.9.6
-# juju==0.5.3
-git+https://github.com/juju/python-libjuju@17b26ef
+juju==0.6.0
 juju-wait==2.5.1
 prettytable==0.7.2
 progressbar2==3.20.0

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -7,3 +7,4 @@ tox
 q
 ipython
 ipdb
+fakeredis

--- a/test/helpers.py
+++ b/test/helpers.py
@@ -1,5 +1,6 @@
 import asyncio
 from contextlib import contextmanager
+from unittest.mock import MagicMock
 
 
 @contextmanager
@@ -12,3 +13,8 @@ def test_loop():
     finally:
         asyncio.set_event_loop(old_loop)
         new_loop.close()
+
+
+class AsyncMock(MagicMock):
+    async def __call__(self, *args, **kwargs):
+        return super().__call__(*args, **kwargs)

--- a/test/test_app_config.py
+++ b/test/test_app_config.py
@@ -106,6 +106,6 @@ class AppConfigTestCase(unittest.TestCase):
         assert self.app.current_controller == 'moo'
 
     def test_config_guard_unknown_attribute(self):
-        "app_config.test_config_gard_unknown_attribute"
+        "app_config.test_config_guard_unknown_attribute"
         with self.assertRaises(Exception):
             self.app.chimichanga = "Yum"

--- a/test/test_app_config.py
+++ b/test/test_app_config.py
@@ -45,6 +45,7 @@ class AppConfigTestCase(unittest.TestCase):
         self.app.state = fakeredis.FakeStrictRedis()
         self.app.current_controller = "fake-tester-controller"
         self.app.current_model = "fake-tester-model"
+        self.app.current_cloud_type = "ec2"
         self.app.config = {'spell': 'kubernetes-core'}
 
         self.app.juju.client = AsyncMock()
@@ -52,7 +53,6 @@ class AppConfigTestCase(unittest.TestCase):
 
     def test_config_redis_save(self):
         "app_config.test_config_redis_save"
-
         self.app.juju.authenticated = False
         with test_loop() as loop:
             loop.run_until_complete(self.app.save())
@@ -104,3 +104,8 @@ class AppConfigTestCase(unittest.TestCase):
         with test_loop() as loop:
             loop.run_until_complete(self.app.restore())
         assert self.app.current_controller == 'moo'
+
+    def test_config_guard_unknown_attribute(self):
+        "app_config.test_config_gard_unknown_attribute"
+        with self.assertRaises(Exception):
+            self.app.chimichanga = "Yum"

--- a/test/test_app_config.py
+++ b/test/test_app_config.py
@@ -1,0 +1,113 @@
+#!/usr/bin/env python
+#
+# tests app_config
+#
+# Copyright 2016-2017 Canonical, Ltd.
+
+
+import json
+import unittest
+from unittest.mock import patch
+
+import fakeredis
+
+from conjureup.app_config import app
+
+from .helpers import AsyncMock, test_loop
+
+
+class AppConfigTestCase(unittest.TestCase):
+
+    def setUp(self):
+        self.expected_keys = [
+            'config',
+            'bundles',
+            'current_bundle',
+            'argv',
+            'jaas_ok',
+            'jaas_controller',
+            'is_jaas',
+            'current_model',
+            'current_controller',
+            'current_cloud',
+            'current_cloud_type',
+            'current_region',
+            'current_view',
+            'session_id',
+            'notrack',
+            'noreport',
+            'complete',
+            'headless',
+            'endpoint_type',
+            'exit_code'
+        ]
+        app.state = fakeredis.FakeStrictRedis()
+        app.current_controller = "fake-tester-controller"
+        app.current_model = "fake-tester-model"
+        app.config = {'spell': 'kubernetes-core'}
+
+        self.juju_patcher = patch(
+            'conjureup.app_config.app.juju', AsyncMock())
+        self.mock_juju = self.juju_patcher.start()
+        self.log_patcher = patch(
+            'conjureup.app_config.app.log')
+        self.mock_log = self.log_patcher.start()
+
+    def tearDown(self):
+        self.juju_patcher.stop()
+        self.log_patcher.stop()
+
+    def test_config_redis_save(self):
+        "app_config.test_config_redis_save"
+
+        self.mock_juju.is_authenticated = False
+        with test_loop() as loop:
+            loop.run_until_complete(app.save())
+
+        results = app.state.get(app._redis_key)
+        json.loads(results.decode('utf8')).keys() == self.expected_keys
+
+    def test_config_juju_model_save(self):
+        "app_config.test_config_juju_model_save"
+
+        self.mock_juju.is_authenticated = True
+        with test_loop() as loop:
+            loop.run_until_complete(app.save())
+
+        assert self.mock_juju.client.set_config.called
+
+    def test_config_juju_model_save_removes_redis_cache(self):
+        "app_config.test_config_juju_model_save_remove_redis_cache"
+
+        app.state.set(app._redis_key, "fake data")
+        self.mock_juju.is_authenticated = True
+        with test_loop() as loop:
+            loop.run_until_complete(app.save())
+
+        assert app.state.get(app._redis_key) is None
+
+    def test_config_redis_restore(self):
+        "app_config.test_config_redis_restore"
+        self.mock_juju.is_authenticated = False
+
+        with test_loop() as loop:
+            yield app.save()
+            loop.run_until_complete(app.restore())
+
+        results_json = app.state.get(app._redis_key)
+        results = json.loads(results_json.decode('utf8'))
+
+        assert app.current_controller == results['current_controller']
+
+    def test_config_juju_restore(self):
+        "app_config.test_config_juju_restore"
+        class FakeExtraInfo:
+            def __init__(self):
+                self.value = b'{"current_controller": "moo"}'
+
+        self.mock_juju.is_authenticated = True
+        self.mock_juju.client.get_config.return_value = {
+            "extra-info": FakeExtraInfo()}
+        with test_loop() as loop:
+            loop.run_until_complete(app.restore())
+        assert app.current_controller == 'moo'

--- a/test/test_controllers_lxdsetup_gui.py
+++ b/test/test_controllers_lxdsetup_gui.py
@@ -114,6 +114,7 @@ class LXDSetupGUIFinishTestCase(unittest.TestCase):
         self.controller.next_screen = MagicMock()
         self.controller.set_default_profile = MagicMock()
         self.controller.can_user_acces_lxd = MagicMock()
+        self.controller.kill_dnsmasq = MagicMock()
         self.mock_utils.snap_version.return_value = parse_version('2.25')
         self.mock_utils.get_open_port.return_value = '12001'
         self.mock_parse_version.return_value = parse_version('2.25')


### PR DESCRIPTION
This provides a mechanism for storing current application state so that future
runs can resume failed/interrupted conjure-up deployments.

Also a drive-by fix to not try and access dnsmasq.pid during lxdsetup tests.

Fixes #1010

Signed-off-by: Adam Stokes <battlemidget@users.noreply.github.com>