### PR TITLE
Improve Sentry reporting and update juju-wait for --retry_errors option

### DIFF
--- a/conjureup/app.py
+++ b/conjureup/app.py
@@ -368,6 +368,7 @@ def main():
     app.sentry = raven.Client(
         dsn=SENTRY_DSN,
         release=VERSION,
+        transport=raven.transport.requests.RequestsHTTPTransport,
         processors=(
             'conjureup.utils.SanitizeDataProcessor',
         )

--- a/conjureup/controllers/bootstrap/common.py
+++ b/conjureup/controllers/bootstrap/common.py
@@ -34,7 +34,7 @@ class BaseBootstrapController:
             err_log = log_file.read_text('utf8').splitlines()
             app.log.error("Error bootstrapping controller: "
                           "{}".format(err_log))
-            app.sentry.context.merge({'extra': {'err_log': err_log}})
+            app.sentry.context.merge({'extra': {'err_log': err_log[-400:]}})
             raise Exception('Unable to bootstrap (cloud type: {})'.format(
                 app.current_cloud_type))
 

--- a/conjureup/controllers/deploystatus/common.py
+++ b/conjureup/controllers/deploystatus/common.py
@@ -1,5 +1,3 @@
-import asyncio
-
 from conjureup import events, utils
 from conjureup.app_config import app
 from conjureup.models.step import StepModel
@@ -11,22 +9,10 @@ async def wait_for_applications(msg_cb):
     app.log.info(msg)
     msg_cb(msg)
 
-    # retry done check a few times to work around
-    # https://bugs.launchpad.net/juju-wait/+bug/1680963
-    for i in range(3):
-        try:
-            step = StepModel({},
-                             filename='00_deploy-done',
-                             name='Deployment Watcher')
-            await utils.run_step(step,
-                                 msg_cb)
-            break
-        except Exception as e:
-            if i < 2 and 'Applications did not start successfully' in str(e):
-                await asyncio.sleep(5)
-                app.log.debug('Retrying 00_deploy-done: {}'.format(i))
-                continue
-            raise
+    step = StepModel({},
+                     filename='00_deploy-done',
+                     name='Deployment Watcher')
+    await utils.run_step(step, msg_cb)
 
     events.ModelSettled.set()
     msg = 'Model settled.'

--- a/conjureup/events.py
+++ b/conjureup/events.py
@@ -146,22 +146,11 @@ def handle_exception(loop, context):
         return  # already reporting an error
     Error.set()
     exc = context['exception']
+    exc_info = (type(exc), exc, exc.__traceback__)
 
     if not (app.noreport or any(pred(exc) for pred in NOTRACK_EXCEPTIONS)):
         track_exception(str(exc))
-        try:
-            exc_info = (type(exc), exc, exc.__traceback__)
-            app.sentry.captureException(exc_info, tags={
-                'spell': app.config.get('spell'),
-                'cloud_type': app.current_cloud_type,
-                'region': app.current_region,
-                'jaas': app.is_jaas,
-                'headless': app.headless,
-                'juju_version': utils.juju_version(),
-                'lxd_version': utils.lxd_version(),
-            })
-        except Exception:
-            app.log.exception('Error reporting error')
+        utils.sentry_report(exc_info=exc_info)
 
     app.log.exception('Unhandled exception', exc_info=exc)
 

--- a/conjureup/juju.py
+++ b/conjureup/juju.py
@@ -2,6 +2,7 @@
 """
 import asyncio
 import json
+import logging
 import os
 from concurrent import futures
 from pathlib import Path
@@ -12,7 +13,7 @@ import yaml
 from bundleplacer.charmstore_api import CharmStoreID
 from juju.model import Model
 
-from conjureup import consts, events
+from conjureup import consts, events, utils
 from conjureup.app_config import app
 from conjureup.utils import is_linux, juju_path, run, spew
 
@@ -333,7 +334,7 @@ def get_regions(cloud):
     if not isinstance(result, dict):
         msg = 'Unexpected response from regions: {}'.format(result)
         app.log.error(msg)
-        app.sentry.captureMessage(msg)
+        utils.sentry_report(msg, level=logging.ERROR)
         result = {}
     return result
 

--- a/conjureup/utils.py
+++ b/conjureup/utils.py
@@ -2,6 +2,7 @@ import asyncio
 import codecs
 import errno
 import json
+import logging
 import os
 import pty
 import re
@@ -162,14 +163,32 @@ async def run_step(step, msg_cb, event_name=None):
                         msg_cb(line)
                     await asyncio.sleep(0.01)
 
+    out_log = Path(step_path + '.out').read_text()
+    err_log = Path(step_path + '.err').read_text()
+
     if proc.returncode != 0:
-        status = run(['juju', 'status', '--format=yaml'])
         app.sentry.context.merge({'extra': {
-            'out_log': Path(step_path + '.out').read_text(),
-            'err_log': Path(step_path + '.err').read_text(),
-            'status': (status.stdout or b'').decode('utf8'),
+            'out_log_tail': out_log[-400:],
+            'err_log_tail': err_log[-400:],
         }})
         raise Exception("Failure in step {}".format(step.filename))
+
+    # special case for 00_deploy-done to report masked
+    # charm hook failures that were retried automatically
+    if not app.noreport:
+        failed_apps = set()  # only report each charm once
+        for line in err_log.splitlines():
+            if 'hook failure, will retry' in line:
+                log_leader = line.split()[0]
+                unit_name = log_leader.split(':')[-1]
+                app_name = unit_name.split('/')[0]
+                failed_apps.add(app_name)
+        for app_name in failed_apps:
+            # report each individually so that Sentry will give us a
+            # breakdown of failures per-charm in addition to per-spell
+            sentry_report('Retried hook failure', tags={
+                'app_name': app_name,
+            })
 
     if event_name is not None:
         track_event(event_name, "Done", "")
@@ -178,6 +197,45 @@ async def run_step(step, msg_cb, event_name=None):
         "conjure-up.{}.{}.result".format(app.config['spell'],
                                          step.filename))
     return (result or b'').decode('utf8')
+
+
+def sentry_report(message=None, exc_info=None, tags=None, **kwargs):
+    if app.noreport:
+        return
+
+    async def _sentry_report(event_type, kwargs):
+        try:
+            default_tags = {
+                'spell': app.config.get('spell'),
+                'cloud_type': app.current_cloud_type,
+                'region': app.current_region,
+                'jaas': app.is_jaas,
+                'headless': app.headless,
+                'juju_version': juju_version(),
+                'lxd_version': lxd_version(),
+            }
+
+            if message is not None and exc_info is None:
+                event_type = 'raven.events.Message'
+                kwargs['message'] = message
+                if 'level' not in kwargs:
+                    kwargs['level'] = logging.WARNING
+            else:
+                event_type = 'raven.events.Exception'
+                if exc_info is None or exc_info is True:
+                    kwargs['exc_info'] = sys.exc_info()
+                else:
+                    kwargs['exc_info'] = exc_info
+                if 'level' not in kwargs:
+                    kwargs['level'] = logging.ERROR
+
+            kwargs['tags'] = dict(default_tags, **(tags or {}))
+
+            app.sentry.capture(event_type, **kwargs)
+        except Exception:
+            app.log.exception('Error reporting error')
+
+    app.loop.create_task(_sentry_report())
 
 
 def can_sudo(password=None):

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ aiofiles==0.3.1
 bundle-placement==0.0.1
 Jinja2==2.9.6
 juju==0.6.0
-juju-wait==2.5.1
+juju-wait==2.6.0
 prettytable==0.7.2
 progressbar2==3.20.0
 PyYAML==3.12


### PR DESCRIPTION
Refactor all Sentry calls to provide the same base tag data and to use an asyncio task with explicit error catching instead of the default threaded transport which can apparently still bubble up some errors.

Fixes #1003
Fixes #970