### PR TITLE
Fix CredentialManagerInvalidCloudType

### DIFF
--- a/conjureup/controllers/credentials/gui.py
+++ b/conjureup/controllers/credentials/gui.py
@@ -17,10 +17,10 @@ class CredentialsController(common.BaseCredentialsController):
         if app.provider.cloud_type == 'localhost':
             # no credentials required for localhost
             self.finish()
-        elif not app.provider.credential:
-            self.render_form()
         elif len(self.credentials) >= 1:
             self.render_picker()
+        elif not app.provider.credential:
+            self.render_form()
         else:
             self.finish()
 

--- a/conjureup/vsphere.py
+++ b/conjureup/vsphere.py
@@ -14,11 +14,11 @@ class VSphereInvalidLogin(vim.fault.InvalidLogin):
 
 
 class VSphereClient:
-    def __init__(self, username, password, host, port=443):
+    def __init__(self, credential, host, port=443):
         self.host = host
         self.port = port
-        self.username = username
-        self.password = password
+        self.username = credential.username
+        self.password = credential.password
         self.si = None
         self.content = None
 


### PR DESCRIPTION
Refactor CredentialManager to resolve invalid credential type error for non-vsphere clouds.  Also fix the credential picker not showing for clouds with multiple creds.