### PR TITLE
Fix error in shutdown_watcher

### DIFF
--- a/conjureup/events.py
+++ b/conjureup/events.py
@@ -198,7 +198,8 @@ async def shutdown_watcher():
         for task in asyncio.Task.all_tasks(app.loop):
             # cancel all other tasks
             coro = getattr(task, '_coro', None)
-            if coro and coro.cr_code is not shutdown_watcher.__code__:
+            cr_code = getattr(coro, 'cr_code', None)
+            if cr_code is not shutdown_watcher.__code__:
                 app.log.debug('Cancelling pending task: {}'.format(task))
                 task.cancel()
         await asyncio.sleep(0.1)  # give tasks a chance to see the cancel


### PR DESCRIPTION
Fixes the following:

```
2017-08-08 17:04:48,799 [ERROR] conjure-up/kubernetes-core - events.py:206 - Error in cleanup code: 'generator' object has no attribute 'cr_code'
Traceback (most recent call last):
  File "/snap/conjure-up/589/lib/python3.6/site-packages/conjureup/events.py", line 201, in shutdown_watcher
    if coro and coro.cr_code is not shutdown_watcher.__code__:
AttributeError: 'generator' object has no attribute 'cr_code'
```