### PR TITLE
Set auth-type for localhost provider

### DIFF
--- a/conjureup/models/provider.py
+++ b/conjureup/models/provider.py
@@ -326,6 +326,7 @@ class MAAS(BaseProvider):
 class Localhost(BaseProvider):
     def __init__(self):
         super().__init__()
+        self.auth_type = 'interactive'
         self.cloud_type = 'lxd'
         self.network_interface = None
         self.form = Form([Field(


### PR DESCRIPTION
For new credentials this was causing a traceback as localhost can have
certificate based credentials and needs the proper auth-type set.

Signed-off-by: Adam Stokes <battlemidget@users.noreply.github.com>