### PR TITLE
Refactor how steps are run

### DIFF
--- a/conjureup/controllers/deploy/common.py
+++ b/conjureup/controllers/deploy/common.py
@@ -1,7 +1,7 @@
 import asyncio
 from operator import attrgetter
 
-from conjureup import events, juju, utils
+from conjureup import events, juju
 from conjureup.app_config import app
 from conjureup.models.step import StepModel
 
@@ -48,20 +48,10 @@ async def pre_deploy(msg_cb):
     """ runs pre deploy script if exists
     """
     await events.ModelConnected.wait()
-
-    # Set provider type for post-bootstrap
-    app.env['JUJU_PROVIDERTYPE'] = app.juju.client.info.provider_type
-    # Set current credential name (localhost doesn't have one)
-    app.env['JUJU_CREDENTIAL'] = app.provider.credential or ''
-    app.env['JUJU_CONTROLLER'] = app.provider.controller
-    app.env['JUJU_MODEL'] = app.provider.model
-    app.env['CONJURE_UP_SPELLSDIR'] = app.argv.spells_dir
-
     step = StepModel({},
                      filename='00_pre-deploy',
                      name='pre-deploy')
-    await utils.run_step(step,
-                         msg_cb)
+    await step.run(msg_cb)
     events.PreDeployComplete.set()
 
 
@@ -74,7 +64,7 @@ async def wait_for_applications(msg_cb):
     step = StepModel({'title': 'Deployment Watcher'},
                      filename='00_deploy-done',
                      name='00_deploy-done')
-    await utils.run_step(step, msg_cb)
+    await step.run(msg_cb)
 
     events.ModelSettled.set()
     msg = 'Model settled.'

--- a/conjureup/controllers/runsteps/common.py
+++ b/conjureup/controllers/runsteps/common.py
@@ -1,56 +1,6 @@
 from pathlib import Path
 
-from conjureup import utils
 from conjureup.app_config import app
-
-
-def set_env(step_model):
-    """ Sets the application environment with the key/value from the steps
-    input so they can be made available in the step shell scripts
-    """
-    step_data = app.steps_data[step_model.name]
-    for key, value in step_data.items():
-        env_key = key.upper()
-        value = step_data[key]
-        app.env[env_key] = value
-        app.log.info("Setting environment var: {}={}".format(env_key, value))
-
-
-async def do_step(step_model, msg_cb):
-    """ Processes steps in the background
-
-    Arguments:
-    step_model: a step to run
-    message_cb: log writer
-    gui: optionally set an UI components if GUI
-
-    Returns:
-    Step title and results message
-    """
-    provider_type = app.juju.client.info.provider_type
-
-    # Set our provider type environment var so that it is
-    # exposed in future processing tasks
-    app.env['JUJU_PROVIDERTYPE'] = provider_type
-
-    # Set current credential name (localhost doesn't have one)
-    app.env['JUJU_CREDENTIAL'] = app.provider.credential or ''
-
-    # Set current juju controller and model
-    app.env['JUJU_CONTROLLER'] = app.provider.controller
-    app.env['JUJU_MODEL'] = app.provider.model
-
-    if provider_type == "maas":
-        app.log.debug("MAAS CONFIG: {}".format(app.maas))
-
-        # Expose MAAS endpoints and tokens
-        app.env['MAAS_ENDPOINT'] = app.maas.endpoint
-        app.env['MAAS_APIKEY'] = app.maas.api_key
-
-    # Set environment variables so they can be accessed from the step scripts
-    set_env(step_model)
-
-    return await utils.run_step(step_model, msg_cb)
 
 
 def save_step_results():

--- a/conjureup/controllers/runsteps/gui.py
+++ b/conjureup/controllers/runsteps/gui.py
@@ -14,7 +14,7 @@ class RunStepsController:
     async def run_steps(self, view):
         for step in app.steps:
             view.mark_step_running(step)
-            step.result = await common.do_step(step, app.ui.set_footer)
+            step.result = await step.run(app.ui.set_footer)
             view.mark_step_complete(step)
         common.save_step_results()
         events.PostDeployComplete.set()

--- a/conjureup/controllers/runsteps/tui.py
+++ b/conjureup/controllers/runsteps/tui.py
@@ -16,7 +16,7 @@ class RunStepsController:
     async def run_steps(self):
         utils.info("Running post-deployment steps")
         for step in app.steps:
-            step.result = await common.do_step(step, utils.info)
+            step.result = await step.run(utils.info)
 
         common.save_step_results()
         self.show_summary()

--- a/conjureup/models/step.py
+++ b/conjureup/models/step.py
@@ -1,6 +1,15 @@
 """ Step model
 """
+import asyncio
+import os
+from pathlib import Path
+
+import aiofiles
+
+from conjureup import juju
 from conjureup.app_config import app
+from conjureup.telemetry import track_event
+from conjureup.utils import SudoError, can_sudo, is_linux, sentry_report
 
 
 class StepModel:
@@ -36,3 +45,100 @@ class StepModel:
                                                self.description,
                                                self.viewable,
                                                self.filename)
+
+    async def run(self, msg_cb, event_name=None):
+        # Define STEP_NAME for use in determining where to store
+        # our step results,
+        #  redis-cli set "conjure-up.$SPELL_NAME.$STEP_NAME.result" "val"
+        app.env['CONJURE_UP_STEP'] = self.name
+
+        step_path = Path(app.config['spell-dir']) / 'steps' / self.filename
+
+        if not step_path.is_file():
+            return
+
+        step_path = str(step_path)
+
+        msg = "Running step: {}.".format(self.name)
+        app.log.info(msg)
+        msg_cb(msg)
+        if event_name is not None:
+            track_event(event_name, "Started", "")
+
+        if not os.access(step_path, os.X_OK):
+            raise Exception("Step {} not executable".format(self.title))
+
+        if is_linux() and self.needs_sudo and not await can_sudo():
+            raise SudoError('Step "{}" requires sudo: {}'.format(
+                self.title,
+                'password failed' if app.sudo_pass else
+                'passwordless sudo required',
+            ))
+
+        cloud_types = juju.get_cloud_types_by_name()
+        provider_type = cloud_types[app.provider.cloud]
+
+        app.env['JUJU_PROVIDERTYPE'] = provider_type
+        # not all providers have a credential, e.g., localhost
+        app.env['JUJU_CREDENTIAL'] = app.provider.credential or ''
+        app.env['JUJU_CONTROLLER'] = app.provider.controller
+        app.env['JUJU_MODEL'] = app.provider.model
+        app.env['JUJU_REGION'] = app.provider.region
+        app.env['CONJURE_UP_SPELLSDIR'] = app.argv.spells_dir
+
+        if provider_type == "maas":
+            app.env['MAAS_ENDPOINT'] = app.maas.endpoint
+            app.env['MAAS_APIKEY'] = app.maas.api_key
+
+        for step_name, step_data in app.steps_data.items():
+            for key, value in step_data.items():
+                app.env[key.upper()] = step_data[key]
+
+        app.log.debug("Executing script: {}".format(step_path))
+
+        async with aiofiles.open(step_path + ".out", 'w') as outf:
+            async with aiofiles.open(step_path + ".err", 'w') as errf:
+                proc = await asyncio.create_subprocess_exec(step_path,
+                                                            env=app.env,
+                                                            stdout=outf,
+                                                            stderr=errf)
+                async with aiofiles.open(step_path + '.out', 'r') as f:
+                    while proc.returncode is None:
+                        async for line in f:
+                            msg_cb(line)
+                        await asyncio.sleep(0.01)
+
+        out_log = Path(step_path + '.out').read_text()
+        err_log = Path(step_path + '.err').read_text()
+
+        if proc.returncode != 0:
+            app.sentry.context.merge({'extra': {
+                'out_log_tail': out_log[-400:],
+                'err_log_tail': err_log[-400:],
+            }})
+            raise Exception("Failure in step {}".format(self.filename))
+
+        # special case for 00_deploy-done to report masked
+        # charm hook failures that were retried automatically
+        if not app.noreport:
+            failed_apps = set()  # only report each charm once
+            for line in err_log.splitlines():
+                if 'hook failure, will retry' in line:
+                    log_leader = line.split()[0]
+                    unit_name = log_leader.split(':')[-1]
+                    app_name = unit_name.split('/')[0]
+                    failed_apps.add(app_name)
+            for app_name in failed_apps:
+                # report each individually so that Sentry will give us a
+                # breakdown of failures per-charm in addition to per-spell
+                sentry_report('Retried hook failure', tags={
+                    'app_name': app_name,
+                })
+
+        if event_name is not None:
+            track_event(event_name, "Done", "")
+
+        result_key = "conjure-up.{}.{}.result".format(app.config['spell'],
+                                                      self.name)
+        result = app.state.get(result_key)
+        return (result or b'').decode('utf8')

--- a/test/test_controllers_clouds_gui.py
+++ b/test/test_controllers_clouds_gui.py
@@ -83,12 +83,19 @@ class CloudsGUIFinishTestCase(unittest.TestCase):
             'conjureup.controllers.clouds.gui.track_event')
         self.mock_track_event = self.track_event_patcher.start()
 
+        self.mock_provider = MagicMock()
+        self.load_schema_patcher = patch(
+            'conjureup.controllers.clouds.gui.load_schema',
+            self.mock_provider)
+        self.mock_load_schema = self.load_schema_patcher.start()
+
     def tearDown(self):
         self.controllers_patcher.stop()
         self.render_patcher.stop()
         self.app_patcher.stop()
         self.track_event_patcher.stop()
         self.utils_patcher.stop()
+        self.load_schema_patcher.stop()
 
     def test_finish_no_controller(self):
         "clouds.finish without existing controller"

--- a/test/test_controllers_deploy_common.py
+++ b/test/test_controllers_deploy_common.py
@@ -23,9 +23,6 @@ class DeployCommonDoDeployTestCase(unittest.TestCase):
         self.pre_deploy_patcher = patch(
             'conjureup.controllers.deploy.common.pre_deploy')
         self.mock_pre_deploy = self.pre_deploy_patcher.start()
-        self.utils_patcher = patch(
-            'conjureup.controllers.deploy.common.utils')
-        self.mock_utils = self.utils_patcher.start()
         self.app_patcher = patch(
             'conjureup.controllers.deploy.common.app')
         self.mock_app = self.app_patcher.start()
@@ -43,7 +40,6 @@ class DeployCommonDoDeployTestCase(unittest.TestCase):
 
     def tearDown(self):
         self.pre_deploy_patcher.stop()
-        self.utils_patcher.stop()
         self.app_patcher.stop()
         self.events_app_patcher.stop()
         self.juju_patcher.stop()


### PR DESCRIPTION
Change how steps are run, and how `app.env` is populated for the steps, to ensure a consistent environment for all steps.  This also makes it so that all steps have access to all step data, in case they want to use it for something (this enabled data to be prompted for steps such as `pre-deploy`).  Also include `JUJU_REGION` in the `env` data.

Finally, fix one of the tests creating a spurious `.local` dir.