### PR TITLE
Refactor cloud type handling to fix errors

### DIFF
--- a/conjureup/consts.py
+++ b/conjureup/consts.py
@@ -2,3 +2,20 @@ UNSPECIFIED_SPELL = '_unspecified_spell'
 JAAS_CLOUDS = {'ec2', 'azure', 'gce'}
 JAAS_DOMAIN = 'jimm.jujucharms.com'
 JAAS_ENDPOINT = JAAS_DOMAIN + ':443'
+
+
+class cloud_types:
+    AWS = 'ec2'
+    MAAS = 'maas'
+    AZURE = 'azure'
+    GOOGLE = 'gce'
+    GCE = 'gce'
+    CLOUDSIGMA = 'cloudsigma'
+    JOYENT = 'joyent'
+    OPENSTACK = 'openstack'
+    RACKSPACE = 'openstack'
+    VSPHERE = 'vsphere'
+    ORACLE = 'oracle'
+    LOCALHOST = 'localhost'
+    LOCAL = 'localhost'
+    LXD = 'localhost'

--- a/conjureup/controllers/configapps/gui.py
+++ b/conjureup/controllers/configapps/gui.py
@@ -6,6 +6,7 @@ from bundleplacer.assignmenttype import AssignmentType, atype_to_label
 
 from conjureup import controllers, events, juju
 from conjureup.app_config import app
+from conjureup.consts import cloud_types
 from conjureup.maas import setup_maas
 from conjureup.telemetry import track_screen
 from conjureup.ui.views.app_architecture_view import AppArchitectureView
@@ -210,7 +211,7 @@ class ConfigAppsController:
         """
         cloud_type = juju.get_cloud_types_by_name()[app.provider.cloud]
 
-        if cloud_type == 'maas':
+        if cloud_type == cloud_types.MAAS:
             await events.MAASConnected.wait()
         app_placements = self.get_all_assignments(application)
         juju_machines = app.metadata_controller.bundle.machines
@@ -221,7 +222,7 @@ class ConfigAppsController:
             machine_attrs = {
                 'series': application.csid.series,
             }
-            if cloud_type == 'maas':
+            if cloud_type == cloud_types.MAAS:
                 machine_attrs['constraints'] = \
                     await self.get_maas_constraints(virt_machine_id)
             else:
@@ -313,7 +314,7 @@ class ConfigAppsController:
         self.undeployed_applications = self.applications[:]
 
         cloud_type = juju.get_cloud_types_by_name()[app.provider.cloud]
-        if cloud_type == 'maas':
+        if cloud_type == cloud_types.MAAS:
             app.loop.create_task(self.connect_maas())
 
         self.list_view = ApplicationListView(self.applications,

--- a/conjureup/controllers/credentials/gui.py
+++ b/conjureup/controllers/credentials/gui.py
@@ -4,6 +4,7 @@ import yaml
 
 from conjureup import controllers, juju, utils
 from conjureup.app_config import app
+from conjureup.consts import cloud_types
 from conjureup.ui.views.credentials import (
     CredentialPickerView,
     NewCredentialView
@@ -14,7 +15,7 @@ from . import common
 
 class CredentialsController(common.BaseCredentialsController):
     def render(self):
-        if app.provider.cloud_type == 'localhost':
+        if app.provider.cloud_type == cloud_types.LOCAL:
             # no credentials required for localhost
             self.finish()
         elif len(self.credentials) >= 1:

--- a/conjureup/controllers/credentials/tui.py
+++ b/conjureup/controllers/credentials/tui.py
@@ -1,12 +1,13 @@
 from conjureup import events, utils
 from conjureup.app_config import app
+from conjureup.consts import cloud_types
 
 from . import common
 
 
 class CredentialsController(common.BaseCredentialsController):
     def render(self):
-        if app.provider.cloud_type == 'lxd':
+        if app.provider.cloud_type == cloud_types.LOCAL:
             # no credentials required for localhost
             self.finish()
         elif not self.credentials:

--- a/conjureup/controllers/regions/common.py
+++ b/conjureup/controllers/regions/common.py
@@ -1,5 +1,6 @@
 from conjureup import controllers, juju
 from conjureup.app_config import app
+from conjureup.consts import cloud_types
 from conjureup.models.provider import load_schema
 
 
@@ -46,9 +47,9 @@ class BaseRegionsController:
 
     def finish(self, region):
         app.provider.region = region
-        if app.provider.cloud_type == 'localhost':
+        if app.provider.cloud_type == cloud_types.LOCAL:
             controllers.use('lxdsetup').render()
-        elif app.provider.cloud_type == 'vsphere':
+        elif app.provider.cloud_type == cloud_types.VSPHERE:
             controllers.use('vspheresetup').render()
         else:
             controllers.use('controllerpicker').render()

--- a/conjureup/models/provider.py
+++ b/conjureup/models/provider.py
@@ -13,6 +13,7 @@ from ubuntui.widgets.input import (
 from urwid import Text
 
 from conjureup.app_config import app
+from conjureup.consts import cloud_types
 from conjureup.juju import get_cloud
 from conjureup.models.credential import CredentialManager
 from conjureup.utils import (
@@ -201,7 +202,7 @@ class AWS(BaseProvider):
     def __init__(self):
         super().__init__()
         self.auth_type = 'access-key'
-        self.cloud_type = 'ec2'
+        self.cloud_type = cloud_types.AWS
         self.access_key = None
         self.secret_key = None
         self.form = Form([Field(label='AWS Access Key',
@@ -239,7 +240,7 @@ class MAAS(BaseProvider):
     def __init__(self):
         super().__init__()
         self.auth_type = 'oauth1'
-        self.cloud_type = 'maas'
+        self.cloud_type = cloud_types.MAAS
         self.endpoint = None
         self.apikey = None
         self.form = Form(
@@ -330,7 +331,7 @@ class Localhost(BaseProvider):
     def __init__(self):
         super().__init__()
         self.auth_type = 'interactive'
-        self.cloud_type = 'localhost'
+        self.cloud_type = cloud_types.LOCALHOST
         self.network_interface = None
         self.form = Form([Field(
             label='network interface to create a LXD bridge for',
@@ -345,7 +346,7 @@ class Azure(BaseProvider):
     def __init__(self):
         super().__init__()
         self.auth_type = 'service-principal-secret'
-        self.cloud_type = 'azure'
+        self.cloud_type = cloud_types.AZURE
         self.application_id = None
         self.subscription_id = None
         self.application_password = None
@@ -373,7 +374,7 @@ class Google(BaseProvider):
     def __init__(self):
         super().__init__()
         self.auth_type = 'oauth2'
-        self.cloud_type = 'gce'
+        self.cloud_type = cloud_types.GCE
         self.private_key = None
         self.project_id = None
         self.client_id = None
@@ -407,7 +408,7 @@ class CloudSigma(BaseProvider):
     def __init__(self):
         super().__init__()
         self.auth_type = 'userpass'
-        self.cloud_type = 'cloudsigma'
+        self.cloud_type = cloud_types.CLOUDSIGMA
         self.username = None
         self.password = None
         self.form = Form([
@@ -429,7 +430,7 @@ class Joyent(BaseProvider):
     def __init__(self):
         super().__init__()
         self.auth_type = 'userpass'
-        self.cloud_type = 'joyent'
+        self.cloud_type = cloud_types.JOYENT
         self.sdc_user = None
         self.sdc_key_id = None
         self.private_key = None
@@ -462,7 +463,7 @@ class OpenStack(BaseProvider):
     def __init__(self):
         super().__init__()
         self.auth_type = 'userpass'
-        self.cloud_type = 'openstack'
+        self.cloud_type = cloud_types.OPENSTACK
         self.username = None
         self.password = None
         self.domain_name = None
@@ -507,7 +508,7 @@ class VSphere(BaseProvider):
     def __init__(self):
         super().__init__()
         self.auth_type = 'userpass'
-        self.cloud_type = 'vsphere'
+        self.cloud_type = cloud_types.VSPHERE
         self.endpoint = None
         self.user = None
         self.password = None
@@ -578,7 +579,7 @@ class Oracle(BaseProvider):
     def __init__(self):
         super().__init__()
         self.auth_type = 'userpass'
-        self.cloud_type = 'oracle'
+        self.cloud_type = cloud_types.ORACLE
         self.identity_domain = None
         self.password = None
         self.username = None

--- a/conjureup/models/step.py
+++ b/conjureup/models/step.py
@@ -83,7 +83,7 @@ class StepModel:
         app.env['JUJU_CREDENTIAL'] = app.provider.credential or ''
         app.env['JUJU_CONTROLLER'] = app.provider.controller
         app.env['JUJU_MODEL'] = app.provider.model
-        app.env['JUJU_REGION'] = app.provider.region
+        app.env['JUJU_REGION'] = app.provider.region or ''
         app.env['CONJURE_UP_SPELLSDIR'] = app.argv.spells_dir
 
         if provider_type == "maas":

--- a/conjureup/models/step.py
+++ b/conjureup/models/step.py
@@ -94,6 +94,12 @@ class StepModel:
             for key, value in step_data.items():
                 app.env[key.upper()] = step_data[key]
 
+        for key, value in app.env.items():
+            if value is None:
+                app.log.warning('Env {} is None; '
+                                'replacing with empty string'.format(key))
+                app.env[key] = ''
+
         app.log.debug("Storing environment")
         async with aiofiles.open(step_path + ".env", 'w') as outf:
             for k, v in app.env.items():

--- a/conjureup/ui/views/app_architecture_view.py
+++ b/conjureup/ui/views/app_architecture_view.py
@@ -12,6 +12,7 @@ from ubuntui.widgets.hr import HR
 from urwid import Columns, Filler, Frame, Pile, Text, WidgetWrap
 
 from conjureup.app_config import app
+from conjureup.consts import cloud_types
 from conjureup.juju import (
     constraints_from_dict,
     constraints_to_dict,
@@ -85,7 +86,7 @@ class AppArchitectureView(WidgetWrap):
 
     def build_widgets(self):
         cloud_type = get_cloud_types_by_name()[app.provider.cloud]
-        controller_is_maas = cloud_type == 'maas'
+        controller_is_maas = cloud_type == cloud_types.MAAS
         if controller_is_maas:
             extra = (" Press enter on a machine ID to pin it to "
                      "a specific MAAS node.")


### PR DESCRIPTION
We had inconsistent references to cloud types that were causing issues.
Using consts now to ensure that they're always correct / consistent.