### PR TITLE
Fix subordinates not showing on Deploy Status

### DIFF
--- a/conjureup/controllers/deploy/gui.py
+++ b/conjureup/controllers/deploy/gui.py
@@ -44,11 +44,13 @@ class DeployController:
         for service in applications:
             units = {}
             view_data[service.service_name] = {'units': units}
+            num_units = service.num_units
             if service.service_name in app.juju.client.applications:
                 juju_app = app.juju.client.applications[service.service_name]
+                num_units = max(service.num_units, len(juju_app.units))
             else:
                 juju_app = None
-            for unit_num in range(service.num_units):
+            for unit_num in range(num_units):
                 if juju_app and len(juju_app.units) > unit_num:
                     unit = juju_app.units[unit_num]
                     name = unit.name


### PR DESCRIPTION
In #1042, placeholders were added to the Deploy Status screen to avoid it being empty when first shown.  However, since the placeholders are based on the expected number of units, which for subordinates is 0,
placeholders can not be created for subordinates, and the view didn't account for them being added later.  They will now be added as they appear in the model.