### PR TITLE
Add ability to show steps per provider type

### DIFF
--- a/conjureup/controllers/showsteps/gui.py
+++ b/conjureup/controllers/showsteps/gui.py
@@ -24,6 +24,9 @@ class ShowStepsController:
         for step in filter(attrgetter('viewable'), steps):
             if not (step.additional_input or step.needs_sudo):
                 continue
+            if step.cloud_whitelist and app.provider.cloud_type \
+               not in step.cloud_whitelist:
+                continue
             await self.show_step(step)
 
         return self.finish()

--- a/conjureup/models/step.py
+++ b/conjureup/models/step.py
@@ -50,6 +50,7 @@ class StepModel:
         self.viewable = step.get('viewable', False)
         self.needs_sudo = step.get('sudo', False)
         self.additional_input = step.get('additional-input', [])
+        self.cloud_whitelist = step.get('cloud-whitelist', [])
         self.filename = filename
         self.name = name
 
@@ -70,10 +71,11 @@ class StepModel:
             return getattr(StepModel, attr)
 
     def __repr__(self):
-        return "<t: {} d: {} v: {} p:>".format(self.title,
-                                               self.description,
-                                               self.viewable,
-                                               self.filename)
+        return "<t: {} d: {} v: {} c: {} f: {}>".format(self.title,
+                                                        self.description,
+                                                        self.viewable,
+                                                        self.cloud_whitelist,
+                                                        self.filename)
 
     async def run(self, msg_cb, event_name=None):
         # Define STEP_NAME for use in determining where to store


### PR DESCRIPTION
In some situations a different step metadata and step execution needs to be
shown that is applicable only to a certain cloud.

Fixes #1110

Signed-off-by: Adam Stokes <battlemidget@users.noreply.github.com>