### PR TITLE
Fix allow JaaS controller not named 'jaas' in GUI

### DIFF
--- a/conjureup/controllers/jaaslogin/gui.py
+++ b/conjureup/controllers/jaaslogin/gui.py
@@ -15,7 +15,8 @@ class JaaSLoginController:
         self.view = None
 
     def render(self, error=None):
-        app.jaas_controller = 'jaas'
+        if not app.jaas_controller:
+            app.jaas_controller = 'jaas'
         self.render_interstitial()
         app.loop.create_task(self._try_token_auth(error))
 


### PR DESCRIPTION
Fixes #1131 