### PR TITLE
Skip logging Sentry errors

### DIFF
--- a/conjureup/utils.py
+++ b/conjureup/utils.py
@@ -198,7 +198,7 @@ def _sentry_report(message=None, exc_info=None, tags=None, **kwargs):
 
         app.sentry.capture(event_type, **kwargs)
     except Exception:
-        app.log.exception('Error reporting error')
+        pass
 
 
 async def can_sudo(password=None):


### PR DESCRIPTION
Errors reporting to Sentry.io are ignored but logged. These log messages aren't really useful, and they can lead to confusion in tracking down the actual failure.