### PR TITLE
Improves on LXD error handling and reporting

### DIFF
--- a/conjureup/models/provider.py
+++ b/conjureup/models/provider.py
@@ -389,6 +389,10 @@ class Localhost(BaseProvider):
         bridges = OrderedDict()
         for net in networks:
             net_info = await self.query(net)
+            if 'config' in net_info and 'ipv6.address' in net_info['config']:
+                # Juju doesn't support ipv6
+                if net_info['config']['ipv6.address'] != 'none':
+                    continue
             if net_info['type'] == "bridge":
                 bridges[net_info['name']] = net_info
                 if net_info['name'] == 'lxdbr0':

--- a/conjureup/ui/views/cloud.py
+++ b/conjureup/ui/views/cloud.py
@@ -143,9 +143,14 @@ class CloudView(WidgetWrap):
                         Color.info_context(
                             Padding.center_90(
                                 Text(
-                                    "LXD not found, please install with "
-                                    "`sudo snap install lxd && lxd init` "
-                                    "and wait for this message to disappear."))
+                                    "LXD not found, please install and wait "
+                                    "for this message to disappear:\n\n"
+                                    "  $ sudo snap install lxd\n"
+                                    "  $ /snap/bin/lxd init --auto\n"
+                                    "  $ /snap/bin/lxc network create lxdbr0 "
+                                    "ipv4.address=auto ipv4.nat=true "
+                                    "ipv6.address=none ipv6.nat=false "
+                                ))
                         )
                     )
                 else:

--- a/conjureup/ui/views/lxdsetup.py
+++ b/conjureup/ui/views/lxdsetup.py
@@ -38,8 +38,11 @@ class LXDSetupView(BaseView):
                 "Could not locate any network or storage "
                 "devices to continue. Please make sure you "
                 "have at least 1 network bridge and 1 storage "
-                "pool: see `lxc network list` and `lxc storage "
-                "list`")
+                "pool: see `/snap/bin/lxc network list` and "
+                "`/snap/bin/lxc storage list`.  \n\n"
+                "Also note that the network bridge must not have "
+                "ipv6 enabled, to disable run `/snap/bin/lxc network set "
+                "lxdbr0 ipv6.address none ipv6.nat false`")
         super().__init__(*args, **kwargs)
 
     def build_buttons(self):


### PR DESCRIPTION
Improves checking of certain aspects of LXD setup, mainly that the network
bridge doesn't have ipv6 enabled.

Provides update user feedback to better walk the user through installing and
setting up LXD.

Fixes #1151

Signed-off-by: Adam Stokes <battlemidget@users.noreply.github.com>