### PR TITLE
Move deploy-done script into conjure-up

### DIFF
--- a/conjureup/controllers/deploy/common.py
+++ b/conjureup/controllers/deploy/common.py
@@ -61,10 +61,7 @@ async def wait_for_applications(msg_cb):
     app.log.info(msg)
     msg_cb(msg)
 
-    step = StepModel({'title': 'Deployment Watcher'},
-                     filename='00_deploy-done',
-                     name='00_deploy-done')
-    await step.run(msg_cb)
+    await juju.wait_for_deployment()
 
     events.ModelSettled.set()
     msg = 'Model settled.'

--- a/conjureup/juju.py
+++ b/conjureup/juju.py
@@ -878,3 +878,18 @@ def version():
         return out.pop()
     else:
         return out
+
+
+async def wait_for_deployment(retries=5):
+    """ Waits for all deployed applications to settle
+    """
+    if 'CONJURE_UP_MODE' in app.env and app.env['CONJURE_UP_MODE'] == "test":
+        retries = 0
+
+    cmd = ['juju', 'wait', "-r{}".format(retries),
+           "-vwm", "{}:{}".format(app.provider.controller,
+                                  app.provider.model)]
+    ret, _, err = await utils.arun(cmd, env=app.env)
+    if ret != 0:
+        app.log.error(err.decode('utf8'))
+        raise Exception("Some applications failed to start successfully.")


### PR DESCRIPTION
This moves the functionality of 00_deploy-done in all spells into conjure-up.

Signed-off-by: Adam Stokes <battlemidget@users.noreply.github.com>