### PR TITLE
Add support for choices in steps

### DIFF
--- a/conjureup/ui/widgets/step.py
+++ b/conjureup/ui/widgets/step.py
@@ -6,6 +6,7 @@ from ubuntui.widgets.hr import HR
 from ubuntui.widgets.input import (
     IntegerEditor,
     PasswordEditor,
+    SelectorHorizontal,
     StringEditor,
     YesNo
 )
@@ -20,6 +21,7 @@ class StepForm(WidgetWrap):
         'password': PasswordEditor,
         'boolean': YesNo,
         'integer': IntegerEditor,
+        'choice': SelectorHorizontal
     }
 
     def __init__(self, app, step_model):
@@ -147,7 +149,12 @@ class StepForm(WidgetWrap):
             else:
                 input_type = self.INPUT_TYPES[i['type']]
                 value = self.app.steps_data[self.model.name][key]
-                field = StepField(key, label, input_type(default=value))
+                if input_type == SelectorHorizontal:
+                    select_w = input_type([choice for choice in i['choices']])
+                    select_w.set_default(i['default'], True)
+                    field = StepField(key, label, select_w)
+                else:
+                    field = StepField(key, label, input_type(default=value))
                 self.fields.append(field)
             column_input = [
                 ('weight', 0.5, Padding.left(field.label_widget, left=5))


### PR DESCRIPTION
This adds ability to define choices in your step metadata and they will be
presented as a radio selection list.

Metdata used for this test:

```
title: Choose Kubernetes Network Plugin
description: Choose the type of network plugin you wish to use for your cluster
viewable: True
additional-input:
  - label: Network Plugin
    key: NETWORKPLUGIN
    type: choice
    default: flannel
    choices:
      - flannel
      - calico
```

Fixes #1167

![selection_043](https://user-images.githubusercontent.com/51892/30725895-cb369b38-9f15-11e7-94ec-9510a9872cae.png)


Signed-off-by: Adam Stokes <battlemidget@users.noreply.github.com>