### PR TITLE
Fixes for vSphere network / datastore selection

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: python
 sudo: true
 dist: trusty
 python:
-  - "3.5"
+  - "3.6"
 notifications:
   email: false
   irc:
@@ -24,7 +24,7 @@ before_script:
   - sudo ln -s /snap/bin/juju /usr/bin/juju
   - sudo ln -s /snap/bin/lxc /usr/bin/lxc
 script:
-  - tox -e py35,flake,isort
+  - tox -e py36,flake,isort
   - tox -e conjure-dev
   - sudo -E su $USER -c "source conjure-dev/bin/activate && conjure-up -d --notrack --noreport ghost localhost test-controller test-model"
 after_script:

--- a/Makefile
+++ b/Makefile
@@ -7,16 +7,21 @@ TOPDIR := $(shell basename `pwd`)
 GIT_REV := $(shell git log --oneline -n1| cut -d" " -f1)
 VERSION := $(shell cat VERSION)
 CHANNEL := edge
+PY36 := $(shell apt-cache search --names-only '^python3.6')
 
 .PHONY: sysdeps
 sysdeps:
+	@if [ -z "$(PY36)" ]; then \
+	    sudo add-apt-repository ppa:jonathonf/python-3.6; \
+	fi
 	@sudo apt-get update
-	@sudo apt-get -qqyf install jq python3-yaml bsdtar bridge-utils software-properties-common snapcraft python3-dev tox shellcheck build-essential
+	@sudo apt-get -qqyf install jq bsdtar bridge-utils software-properties-common snapcraft python3.6-dev tox shellcheck build-essential
 
 travis-sysdeps:
+	@sudo add-apt-repository -y ppa:jonathonf/python-3.6
 	@sudo apt-get update -q
 	@sudo apt-get remove -qy lxd lxd-client
-	@sudo apt-get -y install jq bsdtar python3-dev make snapd python-tox
+	@sudo apt-get -y install jq bsdtar python3.6-dev make snapd python-tox
 	@sudo snap install juju --classic --edge
 	@sudo snap refresh lxd --edge
 

--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,8 @@ travis-sysdeps:
 	@sudo add-apt-repository -y ppa:jonathonf/python-3.6
 	@sudo apt-get update -q
 	@sudo apt-get remove -qy lxd lxd-client
-	@sudo apt-get -y install jq bsdtar python3.6-dev make snapd python-tox
+	@sudo apt-get -y install jq bsdtar python3.6-dev make snapd
+	@sudo pip install tox
 	@sudo snap install juju --classic --edge
 	@sudo snap refresh lxd --edge
 

--- a/conjureup/juju.py
+++ b/conjureup/juju.py
@@ -145,12 +145,10 @@ async def bootstrap(controller, cloud, model='conjure-up', series="xenial",
     def add_config(k, v):
         cmd.extend(["--config", "{}={}".format(k, v)])
 
-    def add_model_defaults(k, v):
-        cmd.extend(["--model-default", "{}={}".format(k, v)])
-
     if app.provider.model_defaults:
         for k, v in app.provider.model_defaults.items():
-            add_model_defaults(k, v)
+            if v is not None:
+                add_config(k, v)
 
     add_config("image-stream", "daily")
     if app.argv.http_proxy:
@@ -815,7 +813,8 @@ async def add_model(name, controller, cloud, credential=None):
 
     if app.provider.model_defaults:
         for k, v in app.provider.model_defaults.items():
-            add_model_config(k, v)
+            if v is not None:
+                add_model_config(k, v)
 
     proc = await asyncio.create_subprocess_exec(*cmd,
                                                 stdout=DEVNULL, stderr=PIPE)

--- a/conjureup/juju.py
+++ b/conjureup/juju.py
@@ -809,6 +809,14 @@ async def add_model(name, controller, cloud, credential=None):
     cmd = ['juju', 'add-model', name, cloud, '--controller', controller]
     if credential:
         cmd.extend(['--credential', credential])
+
+    def add_model_config(k, v):
+        cmd.extend(["--config", "{}={}".format(k, v)])
+
+    if app.provider.model_defaults:
+        for k, v in app.provider.model_defaults.items():
+            add_model_config(k, v)
+
     proc = await asyncio.create_subprocess_exec(*cmd,
                                                 stdout=DEVNULL, stderr=PIPE)
     _, stderr = await proc.communicate()

--- a/conjureup/ui/views/addons.py
+++ b/conjureup/ui/views/addons.py
@@ -2,36 +2,32 @@ from operator import attrgetter
 
 from ubuntui.utils import Padding
 from ubuntui.widgets.hr import HR
-from urwid import CheckBox, Columns, Text
+from urwid import Columns, Text
 
 from conjureup.app_config import app
-from conjureup.ui.views.base import BaseView
-
-
-class CheckBoxValued(CheckBox):
-    """
-    Subclass of CheckBox that associates a value with the checkbox.
-    """
-
-    def __init__(self, label, value, *args, **kwargs):
-        super().__init__(label, *args, **kwargs)
-        self.value = value
+from conjureup.ui.views.base import NEXT_SCREEN, BaseView
+from conjureup.ui.widgets.selectors import CheckList
 
 
 class AddonsView(BaseView):
     title = 'Add-on Selection'
     subtitle = 'Choose one or more additional components to add to your spell'
+    footer = ('Select zero or more add-ons using SPACE, then press ENTER '
+              'or select CONTINUE to continue')
 
     def __init__(self, next, back):
         self.next = next
-        self.choices = []
+        self.choices = CheckList()
+        self.extend_command_map({
+            'enter': NEXT_SCREEN,
+        })
         super().__init__(back)
 
     def build_widget(self):
         self.choices.append(HR())
         for addon in sorted(app.addons.values(), key=attrgetter('name')):
-            self.choices.append(CheckBoxValued(addon.friendly_name,
-                                               value=addon.name))
+            self.choices.append_option(label=addon.friendly_name,
+                                       value=addon.name)
             self.choices.append(Padding.line_break(""))
             self.choices.append(
                 Columns([
@@ -40,6 +36,8 @@ class AddonsView(BaseView):
                 ], dividechars=5)
             )
             self.choices.append(HR())
+        if app.addons:
+            self.choices.focus_position = 1
         return self.choices
 
     def build_buttons(self):
@@ -49,5 +47,4 @@ class AddonsView(BaseView):
 
     @property
     def selected(self):
-        return [choice.value for choice in self.choices
-                if isinstance(choice, CheckBoxValued) and choice.state]
+        return self.choices.selected

--- a/conjureup/ui/views/base.py
+++ b/conjureup/ui/views/base.py
@@ -7,6 +7,12 @@ from conjureup import events
 from conjureup.app_config import app
 from conjureup.telemetry import track_screen
 
+SWAP_FOCUS = 'swap focus'
+NEXT_SCREEN = 'next screen'
+PREV_GROUP = 'prev group'
+NEXT_GROUP = 'next group'
+NEXT_GROUP_SUBMIT = 'next group submit'
+
 
 class BaseView(WidgetWrap):
     title = 'Base View'
@@ -23,7 +29,16 @@ class BaseView(WidgetWrap):
         self.frame = Frame(body=self._build_body(),
                            footer=self._build_footer())
         self.buttons_selected = False
+        self.extend_command_map({
+            'tab': SWAP_FOCUS,
+            'shift tab': SWAP_FOCUS,
+        })
         super().__init__(self.frame)
+
+    def extend_command_map(self, command_mappings):
+        self._command_map = self._command_map.copy()
+        for key, command in command_mappings.items():
+            self._command_map[key] = command
 
     def show(self):
         track_screen(self.title)
@@ -85,6 +100,9 @@ class BaseView(WidgetWrap):
         ]))
         return footer
 
+    def next(self):
+        pass
+
     def _swap_focus(self):
         if not self.buttons_selected:
             self.buttons_selected = True
@@ -99,10 +117,16 @@ class BaseView(WidgetWrap):
             self.frame.focus_position = 'body'
 
     def keypress(self, size, key):
-        if key in ['tab', 'shift tab']:
+        command = self._command_map[key]
+        if command == SWAP_FOCUS:
             self._swap_focus()
-        rv = super().keypress(size, key)
-        return rv
+            return
+        elif command == NEXT_SCREEN:
+            self.next()
+            return
+        else:
+            rv = super().keypress(size, key)
+            return rv
 
 
 class SchemaFormView(BaseView):

--- a/conjureup/ui/widgets/selectors.py
+++ b/conjureup/ui/widgets/selectors.py
@@ -1,0 +1,151 @@
+from collections.abc import Mapping, Reversible
+
+from urwid import CheckBox, Pile, RadioButton
+
+
+class ValuedCheckBox(CheckBox):
+    """
+    Subclass of CheckBox that associates a value with the checkbox.
+    """
+
+    def __init__(self, label, value, *args, **kwargs):
+        super().__init__(label, *args, **kwargs)
+        self.value = value
+
+
+class ValuedRadioButton(RadioButton):
+    """
+    Subclass of RadioButton that associates a value with the radio button.
+    """
+
+    def __init__(self, group, label, value, *args, **kwargs):
+        super().__init__(group, label, *args, **kwargs)
+        self.value = value
+
+
+class OptionalValuedRadioButton(ValuedRadioButton):
+    """
+    Subclass of ValuedRadioButton that supports deselection.
+    """
+
+    def __init__(self, group, label, value, state=False, *args, **kwargs):
+        super().__init__(group, label, value, state, *args, **kwargs)
+
+    def toggle_state(self):
+        if self.state is False:
+            self.set_state(True)
+        elif self.state is True:
+            self.set_state(False)
+
+
+class SelectList(Pile):
+    """
+    A generic list of selector widgets.
+
+    The type of widgets used as the options must support both a label and a
+    value.
+    """
+    OPTION_TYPE = None
+
+    def __init__(self, opts=None, option_type=None):
+        """
+        Create a new list.
+
+        :param opts: Optional sequence or mapping containing the initial set
+            of items to select from. If a sequence is provided, the items will
+            be used as both the labels and the values for the items. If a
+            mapping is provided, the keys will be considered the labels and
+            the values the values.  If the mapping is an ``OrderedDict``,
+            the order will be preserved.  Otherwise, the items will be sorted
+            by the labels (keys).
+        """
+        super().__init__([])
+        self.option_type = option_type or self.OPTION_TYPE
+        if self.option_type is None:
+            raise TypeError('Must specify an option type')
+        if not opts:
+            return
+        labels = opts.keys() if isinstance(opts, Mapping) else opts
+        if not isinstance(labels, Reversible):
+            labels = sorted(labels)
+        for label in labels:
+            value = opts[label] if isinstance(opts, Mapping) else label
+            self.append_option(label, value)
+
+    def append_option(self, label, value=None):
+        """
+        Add an option to the list.
+
+        The option can have a value that is different from the label.
+        If no value is given, the label itself will be the value.
+        """
+        if value is None:
+            value = label
+        self.append(self._create_option(label, value))
+
+    def _create_option(self, label, value):
+        return self.option_type(label, value)
+
+    def append(self, widget, height_type='weight', height_amount=1):
+        """
+        Add a child widget to the list.
+
+        :param widget: A child widget.
+        :param height_type: ``'pack'``, ``'given'`` or ``'weight'``
+        :param height_amount: ``None`` for ``'pack'``, a number of rows for
+            ``'fixed'`` or a weight value (number) for ``'weight'``
+        """
+        self.contents.append((widget, self.options(height_type,
+                                                   height_amount)))
+
+    @property
+    def selected(self):
+        """
+        Get the values of all selected options.
+
+        Items are filtered by the ``option_type`` of the list.
+        """
+        return [item[0].value for item in self.contents
+                if isinstance(item[0], self.option_type) and item[0].state]
+
+
+class CheckList(SelectList):
+    OPTION_TYPE = ValuedCheckBox
+
+
+class RadioList(SelectList):
+    OPTION_TYPE = ValuedRadioButton
+
+    def __init__(self, *args, **kwargs):
+        self.group = []
+        super().__init__(*args, **kwargs)
+
+    def _create_option(self, label, value):
+        return self.option_type(self.group, label, value)
+
+    def select_first_option(self):
+        """
+        Select the first option.
+        """
+        for item in self.contents:
+            if isinstance(item, self.option_type):
+                item.set_state(True)
+                break
+
+    def select_option(self, value):
+        """
+        Select an option by value.
+        """
+        for item in self.contents:
+            if isinstance(item, self.option_type):
+                item.set_state(item.value == value)
+
+    @property
+    def value(self):
+        if not self.selected:
+            return None
+        return self.selected[0]
+
+
+class OptionalRadioList(RadioList):
+    OPTION_TYPE = OptionalValuedRadioButton

--- a/tox.ini
+++ b/tox.ini
@@ -1,31 +1,26 @@
 [tox]
-envlist = py35
+envlist = py36
 skipsdist = True
 
 [testenv]
-basepython = python3.5
+basepython = python3.6
 deps =
      -r{toxinidir}/requirements.txt
      -r{toxinidir}/requirements_test.txt
 setenv =
   PYTHONPATH={toxinidir}
-
-[testenv:py35]
 commands =
     nosetests -v {posargs:test}
 
 [testenv:isort]
-basepython = python3.5
 commands =
     {posargs:isort -c -rc -m 3 conjureup test tools}
 
 [testenv:lint]
-basepython = python3.5
 commands =
     pylint conjureup test tools
 
 [testenv:flake]
-basepython = python3.5
 commands = flake8 --ignore E501 {posargs} conjureup test tools
 deps = flake8
 


### PR DESCRIPTION
When adding a new model to an existing controller, the network & datastore selection was being prompted for but not used.

When bootstrapping a new vSphere controller and not choosing an external network (which was optional), one was being applied anyway.  Part of this is a refactor of the input handling, which also contains an improvement for the Add-Ons selection screen.

Fixes #1164