### PR TITLE
Re-add openstack as a provider option

### DIFF
--- a/conjureup/consts.py
+++ b/conjureup/consts.py
@@ -4,7 +4,7 @@ UNSPECIFIED_SPELL = '_unspecified_spell'
 JAAS_CLOUDS = {'ec2', 'azure', 'gce'}
 JAAS_DOMAIN = 'jimm.jujucharms.com'
 JAAS_ENDPOINT = JAAS_DOMAIN + ':443'
-PROVIDER_TYPES = ['localhost', 'maas', 'vsphere', 'openstack']
+CUSTOM_PROVIDERS = ['localhost', 'maas', 'vsphere', 'openstack']
 
 
 class cloud_types:

--- a/conjureup/consts.py
+++ b/conjureup/consts.py
@@ -4,6 +4,7 @@ UNSPECIFIED_SPELL = '_unspecified_spell'
 JAAS_CLOUDS = {'ec2', 'azure', 'gce'}
 JAAS_DOMAIN = 'jimm.jujucharms.com'
 JAAS_ENDPOINT = JAAS_DOMAIN + ':443'
+PROVIDER_TYPES = ['localhost', 'maas', 'vsphere', 'openstack']
 
 
 class cloud_types:

--- a/conjureup/controllers/clouds/gui.py
+++ b/conjureup/controllers/clouds/gui.py
@@ -18,7 +18,7 @@ class CloudsController(BaseCloudController):
         """
         self.cancel_monitor.set()
 
-        if cloud in ['localhost', 'vsphere', 'maas']:
+        if cloud in ['localhost', 'vsphere', 'maas', 'openstack']:
             app.provider = load_schema(cloud)
         else:
             app.provider = load_schema(juju.get_cloud_types_by_name()[cloud])

--- a/conjureup/controllers/clouds/gui.py
+++ b/conjureup/controllers/clouds/gui.py
@@ -1,5 +1,6 @@
 from conjureup import controllers, juju, utils
 from conjureup.app_config import app
+from conjureup.consts import CUSTOM_PROVIDERS
 from conjureup.models.provider import Localhost as LocalhostProvider
 from conjureup.models.provider import SchemaErrorUnknownCloud, load_schema
 from conjureup.telemetry import track_event, track_screen
@@ -18,7 +19,7 @@ class CloudsController(BaseCloudController):
         """
         self.cancel_monitor.set()
 
-        if cloud in ['localhost', 'vsphere', 'maas', 'openstack']:
+        if cloud in CUSTOM_PROVIDERS:
             app.provider = load_schema(cloud)
         else:
             app.provider = load_schema(juju.get_cloud_types_by_name()[cloud])

--- a/conjureup/controllers/credentials/gui.py
+++ b/conjureup/controllers/credentials/gui.py
@@ -4,7 +4,7 @@ import yaml
 
 from conjureup import controllers, juju, utils
 from conjureup.app_config import app
-from conjureup.consts import cloud_types
+from conjureup.consts import PROVIDER_TYPES, cloud_types
 from conjureup.ui.views.credentials import (
     CredentialPickerView,
     NewCredentialView
@@ -97,7 +97,7 @@ class CredentialsController(common.BaseCredentialsController):
 
         # if it's a new MAAS or VSphere cloud, save it now that
         # we have a credential
-        if app.provider.cloud_type in ['maas', 'vsphere', 'openstack']:
+        if app.provider.cloud_type in PROVIDER_TYPES:
             try:
                 juju.get_cloud(app.provider.cloud)
             except LookupError:

--- a/conjureup/controllers/credentials/gui.py
+++ b/conjureup/controllers/credentials/gui.py
@@ -97,7 +97,7 @@ class CredentialsController(common.BaseCredentialsController):
 
         # if it's a new MAAS or VSphere cloud, save it now that
         # we have a credential
-        if app.provider.cloud_type in ['maas', 'vsphere']:
+        if app.provider.cloud_type in ['maas', 'vsphere', 'openstack']:
             try:
                 juju.get_cloud(app.provider.cloud)
             except LookupError:

--- a/conjureup/controllers/credentials/gui.py
+++ b/conjureup/controllers/credentials/gui.py
@@ -4,7 +4,7 @@ import yaml
 
 from conjureup import controllers, juju, utils
 from conjureup.app_config import app
-from conjureup.consts import PROVIDER_TYPES, cloud_types
+from conjureup.consts import CUSTOM_PROVIDERS, cloud_types
 from conjureup.ui.views.credentials import (
     CredentialPickerView,
     NewCredentialView
@@ -97,7 +97,7 @@ class CredentialsController(common.BaseCredentialsController):
 
         # if it's a new MAAS or VSphere cloud, save it now that
         # we have a credential
-        if app.provider.cloud_type in PROVIDER_TYPES:
+        if app.provider.cloud_type in CUSTOM_PROVIDERS:
             try:
                 juju.get_cloud(app.provider.cloud)
             except LookupError:

--- a/conjureup/juju.py
+++ b/conjureup/juju.py
@@ -439,7 +439,7 @@ def get_cloud_types_by_name():
         if cloud_type == 'lxd':
             clouds[name] = 'localhost'
 
-    for provider in consts.PROVIDER_TYPES:
+    for provider in consts.CUSTOM_PROVIDERS:
         if provider not in clouds:
             clouds[provider] = provider
 

--- a/conjureup/juju.py
+++ b/conjureup/juju.py
@@ -439,19 +439,9 @@ def get_cloud_types_by_name():
         if cloud_type == 'lxd':
             clouds[name] = 'localhost'
 
-    # Since MAAS is a provider type and not identified as a cloud
-    # we special case this so that selecting MAAS acts like any
-    # other cloud selection.
-    if 'maas' not in clouds:
-        clouds['maas'] = 'maas'
-
-    # vSphere is treated in the same vein as MAAS
-    if 'vsphere' not in clouds:
-        clouds['vsphere'] = 'vsphere'
-
-    # Add OpenStack provider type
-    if 'openstack' not in clouds:
-        clouds['openstack'] = 'openstack'
+    for provider in consts.PROVIDER_TYPES:
+        if provider not in clouds:
+            clouds[provider] = provider
 
     return clouds
 

--- a/conjureup/juju.py
+++ b/conjureup/juju.py
@@ -449,6 +449,10 @@ def get_cloud_types_by_name():
     if 'vsphere' not in clouds:
         clouds['vsphere'] = 'vsphere'
 
+    # Add OpenStack provider type
+    if 'openstack' not in clouds:
+        clouds['openstack'] = 'openstack'
+
     return clouds
 
 

--- a/conjureup/ui/views/cloud.py
+++ b/conjureup/ui/views/cloud.py
@@ -5,7 +5,7 @@ from ubuntui.widgets.hr import HR
 from urwid import Columns, Filler, Frame, Pile, Text, WidgetWrap
 
 from conjureup import juju
-from conjureup.consts import cloud_types
+from conjureup.consts import PROVIDER_TYPES, cloud_types
 
 
 class CloudView(WidgetWrap):
@@ -124,8 +124,7 @@ class CloudView(WidgetWrap):
                     )
                 )
             self._add_item(Padding.line_break(""))
-        new_clouds = juju.get_compatible_clouds(
-            ['localhost', 'maas', 'vsphere', 'openstack'])
+        new_clouds = juju.get_compatible_clouds(PROVIDER_TYPES)
         if new_clouds:
             self._add_item(Text("Configure a New Cloud"))
             self._add_item(HR())

--- a/conjureup/ui/views/cloud.py
+++ b/conjureup/ui/views/cloud.py
@@ -5,7 +5,7 @@ from ubuntui.widgets.hr import HR
 from urwid import Columns, Filler, Frame, Pile, Text, WidgetWrap
 
 from conjureup import juju
-from conjureup.consts import PROVIDER_TYPES, cloud_types
+from conjureup.consts import CUSTOM_PROVIDERS, cloud_types
 
 
 class CloudView(WidgetWrap):
@@ -124,7 +124,7 @@ class CloudView(WidgetWrap):
                     )
                 )
             self._add_item(Padding.line_break(""))
-        new_clouds = juju.get_compatible_clouds(PROVIDER_TYPES)
+        new_clouds = juju.get_compatible_clouds(CUSTOM_PROVIDERS)
         if new_clouds:
             self._add_item(Text("Configure a New Cloud"))
             self._add_item(HR())

--- a/conjureup/ui/views/cloud.py
+++ b/conjureup/ui/views/cloud.py
@@ -125,7 +125,7 @@ class CloudView(WidgetWrap):
                 )
             self._add_item(Padding.line_break(""))
         new_clouds = juju.get_compatible_clouds(
-            ['localhost', 'maas', 'vsphere'])
+            ['localhost', 'maas', 'vsphere', 'openstack'])
         if new_clouds:
             self._add_item(Text("Configure a New Cloud"))
             self._add_item(HR())


### PR DESCRIPTION
This was missed during some of the refactoring, adding this option back in so
custom openstack clouds can be utilized.

Fixes #1171

Signed-off-by: Adam Stokes <battlemidget@users.noreply.github.com>