### PR TITLE
Handle unknown ipaddress in lxd setup

### DIFF
--- a/conjureup/controllers/lxdsetup/gui.py
+++ b/conjureup/controllers/lxdsetup/gui.py
@@ -25,7 +25,13 @@ class LXDSetupController(common.BaseLXDSetupController):
         self.set_state('lxd-network-name', network['name'])
         phys_iface_addr = utils.get_physical_network_ipaddr(
             network['name'])
-        iface = ipaddress.IPv4Interface("{}/24".format(phys_iface_addr))
+        try:
+            iface = ipaddress.IPv4Interface("{}/24".format(phys_iface_addr))
+        except ipaddress.AddressValueError:
+            raise LXDSetupControllerError(
+                "Unable to determine ip address of {}, please double check "
+                "`/snap/bin/lxc network edit {}` and make sure an address "
+                "is associated with that bridge.".format(network['name']))
         self.set_state('lxd-network', iface.network)
         self.set_state('lxd-gateway', iface.ip)
         self.set_state('lxd-network-dhcp-range-start',

--- a/conjureup/controllers/lxdsetup/gui.py
+++ b/conjureup/controllers/lxdsetup/gui.py
@@ -29,9 +29,10 @@ class LXDSetupController(common.BaseLXDSetupController):
             iface = ipaddress.IPv4Interface("{}/24".format(phys_iface_addr))
         except ipaddress.AddressValueError:
             raise LXDSetupControllerError(
-                "Unable to determine ip address of {}, please double check "
-                "`/snap/bin/lxc network edit {}` and make sure an address "
-                "is associated with that bridge.".format(network['name']))
+                "Unable to determine ip address of {network}, please double "
+                "check `/snap/bin/lxc network edit {network}` and make "
+                "sure an address is associated with that bridge.".format(
+                    network=network['name']))
         self.set_state('lxd-network', iface.network)
         self.set_state('lxd-gateway', iface.ip)
         self.set_state('lxd-network-dhcp-range-start',

--- a/tox.ini
+++ b/tox.ini
@@ -21,7 +21,7 @@ commands =
     pylint conjureup test tools
 
 [testenv:flake]
-commands = flake8 --ignore E501 {posargs} conjureup test tools
+commands = flake8 --ignore E501,E722,E741 {posargs} conjureup test tools
 deps = flake8
 
 [testenv:docs]


### PR DESCRIPTION
Fixes #1152

Also, disable flake8 latest update to make E722 and E741 errors fatal. Filed a
bug for getting that addressed here:

https://github.com/conjure-up/conjure-up/issues/1202

Signed-off-by: Adam Stokes <battlemidget@users.noreply.github.com>