### PR TITLE
Address some of the lxd issues

### DIFF
--- a/conjureup/app.py
+++ b/conjureup/app.py
@@ -371,6 +371,7 @@ def main():
         AddonModel.load_spell_addons()
 
     app.env['CONJURE_UP_CACHEDIR'] = app.argv.cache_dir
+    app.env['PATH'] = "/snap/bin:{}".format(app.env['PATH'])
 
     if app.argv.show_env:
         if app.endpoint_type in [None, EndpointType.LOCAL_SEARCH]:

--- a/conjureup/controllers/clouds/common.py
+++ b/conjureup/controllers/clouds/common.py
@@ -17,15 +17,14 @@ class BaseCloudController:
 
         while not self.cancel_monitor.is_set():
             try:
+                provider._set_lxd_dir_env()
                 compatible = await provider.is_server_compatible()
                 if compatible:
                     events.LXDAvailable.set()
                     self.cancel_monitor.set()
                     cb()
                     return
-            except (LocalhostError, LocalhostJSONError):
-                provider._set_lxd_dir_env()
-            except FileNotFoundError:
+            except (LocalhostError, LocalhostJSONError, FileNotFoundError):
                 pass
             await run_with_interrupt(asyncio.sleep(2),
                                      self.cancel_monitor)

--- a/conjureup/controllers/clouds/common.py
+++ b/conjureup/controllers/clouds/common.py
@@ -17,6 +17,11 @@ class BaseCloudController:
 
         while not self.cancel_monitor.is_set():
             try:
+                compatible = await provider.is_server_compatible()
+                if not compatible:
+                    return await run_with_interrupt(asyncio.sleep(2),
+                                                    self.cancel_monitor)
+
                 await provider.is_server_available()
                 events.LXDAvailable.set()
                 self.cancel_monitor.set()

--- a/conjureup/controllers/clouds/common.py
+++ b/conjureup/controllers/clouds/common.py
@@ -19,13 +19,14 @@ class BaseCloudController:
             try:
                 compatible = await provider.is_server_compatible()
                 if not compatible:
-                    return await run_with_interrupt(asyncio.sleep(2),
-                                                    self.cancel_monitor)
-
-                await provider.is_server_available()
-                events.LXDAvailable.set()
-                self.cancel_monitor.set()
-                cb()
+                    await run_with_interrupt(asyncio.sleep(2),
+                                             self.cancel_monitor)
+                else:
+                    await provider.is_server_available()
+                    events.LXDAvailable.set()
+                    self.cancel_monitor.set()
+                    cb()
+                    return
             except (LocalhostError, LocalhostJSONError):
                 provider._set_lxd_dir_env()
                 await run_with_interrupt(asyncio.sleep(2),

--- a/conjureup/controllers/clouds/common.py
+++ b/conjureup/controllers/clouds/common.py
@@ -18,8 +18,9 @@ class BaseCloudController:
         while not self.cancel_monitor.is_set():
             try:
                 provider._set_lxd_dir_env()
-                compatible = await provider.is_server_compatible()
-                if compatible:
+                client_compatible = await provider.is_client_compatible()
+                server_compatible = await provider.is_server_compatible()
+                if client_compatible and server_compatible:
                     events.LXDAvailable.set()
                     self.cancel_monitor.set()
                     cb()

--- a/conjureup/controllers/clouds/common.py
+++ b/conjureup/controllers/clouds/common.py
@@ -18,19 +18,14 @@ class BaseCloudController:
         while not self.cancel_monitor.is_set():
             try:
                 compatible = await provider.is_server_compatible()
-                if not compatible:
-                    await run_with_interrupt(asyncio.sleep(2),
-                                             self.cancel_monitor)
-                else:
-                    await provider.is_server_available()
+                if compatible:
                     events.LXDAvailable.set()
                     self.cancel_monitor.set()
                     cb()
                     return
             except (LocalhostError, LocalhostJSONError):
                 provider._set_lxd_dir_env()
-                await run_with_interrupt(asyncio.sleep(2),
-                                         self.cancel_monitor)
             except FileNotFoundError:
-                await run_with_interrupt(asyncio.sleep(5),
-                                         self.cancel_monitor)
+                pass
+            await run_with_interrupt(asyncio.sleep(2),
+                                     self.cancel_monitor)

--- a/conjureup/controllers/clouds/tui.py
+++ b/conjureup/controllers/clouds/tui.py
@@ -1,6 +1,4 @@
-from pathlib import Path
-
-from conjureup import controllers, events, juju, utils
+from conjureup import controllers, juju, utils
 from conjureup.app_config import app
 from conjureup.consts import cloud_types
 
@@ -23,10 +21,10 @@ class CloudsController(BaseCloudController):
         utils.info(
             "Summoning {} to {}".format(app.argv.spell, app.provider.cloud))
         if app.provider.cloud_type == cloud_types.LOCALHOST:
-            if not Path('/snap/bin/lxc').exists():
-                utils.error("Unable to find lxc executable, please make "
-                            "sure LXD is installed: `sudo snap install lxd`")
-                events.Shutdown.set(1)
+            try:
+                app.provider._set_lxd_dir_env()
+            except app.provider.LocalhostError:
+                raise
         self.finish()
 
 

--- a/conjureup/models/provider.py
+++ b/conjureup/models/provider.py
@@ -426,19 +426,21 @@ class Localhost(BaseProvider):
                 _pools.move_to_end('default', last=False)
         return _pools
 
-    async def is_server_available(self):
+    async def is_server_compatible(self):
         """ Waits and checks if LXD server becomes available
 
         We'll want to loop here and ignore most errors until have retries have
         been met
         """
         try:
-            return await self.query()
+            out = await self.query()
+            server_ver = out['environment']['server_version']
+            return parse_version(server_ver) >= self.minimum_support_version
         except (LocalhostError, LocalhostJSONError, FileNotFoundError):
-            raise
+            return False
 
-    async def is_server_compatible(self):
-        """ Checks if LXD server version is compatible with conjure-up
+    async def is_client_compatible(self):
+        """ Checks if LXC version is compatible with conjure-up
         """
         try:
             _, out, err = await utils.arun([self.lxc_bin, 'version'])

--- a/conjureup/models/provider.py
+++ b/conjureup/models/provider.py
@@ -356,8 +356,8 @@ class Localhost(BaseProvider):
             app.env['LXD_DIR'] = str(self.lxd_socket_dir)
         else:
             raise LocalhostError(
-                "Unable to find /snap/bin/lxd. Make sure `snap list` "
-                "shows lxd as installed, otherwise, run `sudo snap "
+                "Unable to find /snap/bin/lxd. Make sure `snap info lxd` "
+                "shows as installed, otherwise, run `sudo snap "
                 "install lxd` and restart conjure-up.")
 
     async def query(self, segment='', method="GET"):

--- a/conjureup/ui/views/cloud.py
+++ b/conjureup/ui/views/cloud.py
@@ -146,6 +146,7 @@ class CloudView(WidgetWrap):
                                     "for this message to disappear:\n\n"
                                     "  $ sudo snap install lxd\n"
                                     "  $ sudo usermod -a -G lxd <youruser>\n"
+                                    "  $ newgrp lxd\n"
                                     "  $ /snap/bin/lxd init --auto\n"
                                     "  $ /snap/bin/lxc network create lxdbr0 "
                                     "ipv4.address=auto ipv4.nat=true "

--- a/conjureup/ui/views/cloud.py
+++ b/conjureup/ui/views/cloud.py
@@ -145,6 +145,7 @@ class CloudView(WidgetWrap):
                                     "LXD not found, please install and wait "
                                     "for this message to disappear:\n\n"
                                     "  $ sudo snap install lxd\n"
+                                    "  $ sudo usermod -a -G lxd <youruser>\n"
                                     "  $ /snap/bin/lxd init --auto\n"
                                     "  $ /snap/bin/lxc network create lxdbr0 "
                                     "ipv4.address=auto ipv4.nat=true "

--- a/snap/wrappers/juju
+++ b/snap/wrappers/juju
@@ -7,11 +7,11 @@ snap_lxd_socket=/var/snap/lxd/common/lxd
 
 lxd_binary=$(which lxd)
 
-# Prefer debian installed lxd, if availible
-if [ "$lxd_binary" = "/usr/bin/lxd" ]; then
-    export LXD_DIR=$debian_socket
-elif [ "$lxd_binary" = "/snap/bin/lxd" ]; then
+# Prefer snap installed lxd, if availible
+if [ "$lxd_binary" = "/snap/bin/lxd" ]; then
     export LXD_DIR=$snap_lxd_socket
+elif [ "$lxd_binary" = "/usr/bin/lxd" ]; then
+    export LXD_DIR=$debian_socket
 fi
 export PATH=$SNAP/bin:$SNAP/usr/bin:/snap/bin:$PATH
 export LD_LIBRARY_PATH

--- a/snap/wrappers/juju
+++ b/snap/wrappers/juju
@@ -5,6 +5,7 @@
 debian_socket=/var/lib/lxd
 snap_lxd_socket=/var/snap/lxd/common/lxd
 
+export PATH=$SNAP/bin:$SNAP/usr/bin:/snap/bin:$PATH
 lxd_binary=$(which lxd)
 
 # Prefer snap installed lxd, if availible
@@ -13,7 +14,6 @@ if [ "$lxd_binary" = "/snap/bin/lxd" ]; then
 elif [ "$lxd_binary" = "/usr/bin/lxd" ]; then
     export LXD_DIR=$debian_socket
 fi
-export PATH=$SNAP/bin:$SNAP/usr/bin:/snap/bin:$PATH
 export LD_LIBRARY_PATH
 LD_LIBRARY_PATH=$SNAP/lib:$SNAP/usr/lib/$(uname -p)-linux-gnu/
 

--- a/test/test_controllers_clouds_tui.py
+++ b/test/test_controllers_clouds_tui.py
@@ -47,11 +47,12 @@ class CloudsTUIRenderTestCase(unittest.TestCase):
 
     def test_render(self):
         "Rendering with a known cloud should call finish"
+        self.controller._check_lxd_compat = MagicMock()
         self.mock_app.provider.cloud = "aws"
         t = ['aws']
         self.mock_juju.get_clouds.return_value.keys.return_value = t
         self.controller.render()
-        self.mock_finish.assert_called_once_with()
+        assert self.mock_app.loop.create_task.called
 
 
 class CloudsTUIFinishTestCase(unittest.TestCase):


### PR DESCRIPTION
This primarily forces conjure-up to only look at /snap/bin/lxc. In some cases
the environment variable for lxd (LXD_DIR) may be incorrectly set if
/snap/bin/lxd was not found. For those cases we error out completely and direct
the user to `snap install lxd`.

A few other helpful error messages to get the user in the right direction have
been added as well.

Fixes #1187
Fixes #1200
Fixes #1190

Signed-off-by: Adam Stokes <battlemidget@users.noreply.github.com>