### PR TITLE
Differentiate DeploymentFailure error

### DIFF
--- a/conjureup/errors.py
+++ b/conjureup/errors.py
@@ -1,0 +1,8 @@
+
+
+class ControllerNotFoundException(Exception):
+    "An error when a controller can't be found in juju's config"
+
+
+class DeploymentFailure(Exception):
+    "A failure from a deployed model."


### PR DESCRIPTION
Make DeploymentFailures their own exception type so they're easier to find in Sentry.

Also remove retry logic that was recently added back in to wait_for_applications because it's handled in juju-wait.