### PR TITLE
Fix detail log files not being written to

### DIFF
--- a/conjureup/controllers/bootstrap/common.py
+++ b/conjureup/controllers/bootstrap/common.py
@@ -1,6 +1,6 @@
 from pathlib import Path
 
-from conjureup import events, juju
+from conjureup import errors, events, juju
 from conjureup.app_config import app
 from conjureup.telemetry import track_event
 
@@ -50,9 +50,11 @@ class BaseBootstrapController:
             err_log = log_file.read_text('utf8').splitlines()
             app.log.error("Error bootstrapping controller: "
                           "{}".format(err_log))
-            app.sentry.context.merge({'extra': {'err_log': err_log[-400:]}})
-            raise Exception('Unable to bootstrap (cloud type: {})'.format(
-                app.provider.cloud_type))
+            err_tail = err_log[-400:]
+            app.sentry.context.merge({'extra': {'err_tail': err_tail}})
+            raise errors.BootstrapError(
+                'Unable to bootstrap (cloud type: {})'.format(
+                    app.provider.cloud_type))
 
         self.emit('Bootstrap complete.')
         track_event("Juju Bootstrap", "Done", "")

--- a/conjureup/errors.py
+++ b/conjureup/errors.py
@@ -1,3 +1,9 @@
+class BootstrapError(Exception):
+    "An error when bootstrapping a new controller"
+
+
+class BootstrapInterrupt(BootstrapError):
+    "The bootstrap was interrupted by the user"
 
 
 class ControllerNotFoundException(Exception):
@@ -5,4 +11,4 @@ class ControllerNotFoundException(Exception):
 
 
 class DeploymentFailure(Exception):
-    "A failure from a deployed model."
+    "A failure from a deployed model"

--- a/conjureup/events.py
+++ b/conjureup/events.py
@@ -7,7 +7,7 @@ from pathlib import Path
 from ubuntui.ev import EventLoop
 from urwid import ExitMainLoop
 
-from conjureup import utils
+from conjureup import errors, utils
 from conjureup.app_config import app
 from conjureup.telemetry import track_exception
 from conjureup.ui.views.lxdsetup import LXDSetupViewError
@@ -124,7 +124,8 @@ LXDAvailable = Event('LXDAvailable')
 NOTRACK_EXCEPTIONS = [
     lambda exc: isinstance(exc, OSError) and exc.errno == errno.ENOSPC,
     lambda exc: isinstance(exc, utils.SudoError),
-    lambda exc: isinstance(exc, LXDSetupViewError)
+    lambda exc: isinstance(exc, LXDSetupViewError),
+    lambda exc: isinstance(exc, errors.BootstrapInterrupt),
 ]
 
 


### PR DESCRIPTION
It seems that something with the snap confinement is causing passing file handles to asyncio.subprocess to fail silently.  The files get created but are left empty.  This doesn't happen when run outside of the snap.  This gets around it by handling the file streaming in explicit tasks that we control.  It also allows for some duplication to be removed, so that's nice.

Fixes #1220