### PR TITLE
Replace charmhelpers with kv

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,4 +30,4 @@ script:
 after_script:
   - cat ~/.cache/conjure-up/conjure-up.log
   - cat ~/.cache/conjure-up/ghost/*.err
-  - cat ~/.cache/conjure-up/ghost/steps/*.err
+  - cat ~/.cache/conjure-up/ghost/steps/*/*.err

--- a/conjureup/app.py
+++ b/conjureup/app.py
@@ -16,7 +16,7 @@ import uuid
 
 import raven
 import yaml
-from charmhelpers.core import unitdata
+from kv import KV
 from prettytable import PrettyTable
 from raven.transport.requests import RequestsHTTPTransport
 from termcolor import colored
@@ -222,10 +222,11 @@ def main():
         os.makedirs(opts.cache_dir)
 
     # Application Config
-    os.environ['UNIT_STATE_DB'] = os.path.join(opts.cache_dir, '.state.db')
-    app.state = unitdata.kv()
+    kv_db = os.path.join(opts.cache_dir, '.state.db')
+    app.state = KV(kv_db)
 
     app.env = os.environ.copy()
+    app.env['KV_DB'] = kv_db
     app.config = {'metadata': None}
     app.argv = opts
     app.log = setup_logging(app,

--- a/conjureup/app_config.py
+++ b/conjureup/app_config.py
@@ -193,7 +193,7 @@ class AppConfig:
                 {'extra-info': self.to_json()})
             self.log.info('State saved in model config')
             # Check for existing key and clear it
-            self.state.unset(self._internal_state_key)
+            self.state.pop(self._internal_state_key, None)
         else:
             self.state.set(self._internal_state_key, self.to_json())
             self.state.flush()

--- a/conjureup/controllers/lxdsetup/common.py
+++ b/conjureup/controllers/lxdsetup/common.py
@@ -28,8 +28,7 @@ class BaseLXDSetupController:
 
     def set_state(self, key, value):
         key = "{}.{}".format(self.state_key, key)
-        ret = app.state.set(key, str(value))
-        app.state.flush()
+        ret = app.state[key] = str(value)
         return ret
 
     def get_state(self, key):

--- a/conjureup/models/step.py
+++ b/conjureup/models/step.py
@@ -139,8 +139,7 @@ class StepModel:
                                                   self.name,
                                                   phase.value,
                                                   key)
-        app.state.set(key, value)
-        app.state.flush()
+        app.state[key] = value
 
     @property
     def step_dir(self):

--- a/requirements.txt
+++ b/requirements.txt
@@ -18,4 +18,4 @@ raven==6.1.0
 psutil==5.2.2
 awscli==1.11.123
 pyvmomi==6.5.0.2017.5-1
-charmhelpers==0.18.1
+kv==0.3.0

--- a/test/test_app_config.py
+++ b/test/test_app_config.py
@@ -6,12 +6,11 @@
 
 
 import json
-import os
 import tempfile
 import unittest
 from unittest.mock import MagicMock
 
-from charmhelpers.core import unitdata
+from kv import KV
 from ubuntui.widgets.input import StringEditor
 
 from conjureup.app_config import AppConfig
@@ -29,8 +28,7 @@ class AppConfigTestCase(unittest.TestCase):
         ]
         self.app = AppConfig()
         self.db_file = tempfile.NamedTemporaryFile()
-        os.environ['UNIT_STATE_DB'] = self.db_file.name
-        self.app.state = unitdata.kv()
+        self.app.state = KV(self.db_file.name)
         self.app.provider = AWS()
         self.app.provider.controller = "fake-tester-controller"
         self.app.provider.model = "fake-tester-model"


### PR DESCRIPTION
The charmhelpers library contains a lot more code than we need, since we only use the sqlite-backed KV store, and it doesn't work on Mac OS.

Fixes #1231