### PR TITLE
Show disabled clouds and why they're disabled

### DIFF
--- a/conjureup/controllers/clouds/common.py
+++ b/conjureup/controllers/clouds/common.py
@@ -1,31 +1,4 @@
-import asyncio
-
-from juju.utils import run_with_interrupt
-
-from conjureup import events
-from conjureup.models.provider import LocalhostError, LocalhostJSONError
 
 
 class BaseCloudController:
-
-    cancel_monitor = asyncio.Event()
-
-    async def _monitor_localhost(self, provider, cb):
-        """ Checks that localhost/lxd is available and listening,
-        updates widget accordingly
-        """
-
-        while not self.cancel_monitor.is_set():
-            try:
-                provider._set_lxd_dir_env()
-                client_compatible = await provider.is_client_compatible()
-                server_compatible = await provider.is_server_compatible()
-                if client_compatible and server_compatible:
-                    events.LXDAvailable.set()
-                    self.cancel_monitor.set()
-                    cb()
-                    return
-            except (LocalhostError, LocalhostJSONError, FileNotFoundError):
-                pass
-            await run_with_interrupt(asyncio.sleep(2),
-                                     self.cancel_monitor)
+    pass

--- a/conjureup/juju.py
+++ b/conjureup/juju.py
@@ -358,8 +358,13 @@ def get_compatible_clouds(cloud_types=None):
     Returns:
     List of cloud types
     """
-    clouds = get_clouds()
-    cloud_types = set(cloud_types or (c['type'] for c in clouds.values()))
+    if cloud_types is None:
+        clouds = get_clouds()
+        cloud_types = set(c['type'] for c in clouds.values())
+        # custom providers don't show up in list-clouds but are valid types
+        cloud_types |= set(consts.CUSTOM_PROVIDERS)
+    else:
+        cloud_types = set(cloud_types)
 
     _normalize_cloud_types(cloud_types)
 


### PR DESCRIPTION
Hiding the clouds that are not availabe entirely can be confusing and make it seem like we don't support all clouds.  Instead, this shows them in a greyed-out state and provides an explanation as to why they're
disabled.  (I didn't include the specific reason, spell vs add-on, but I don't think that's really necessary after all.)

Fixes #1222 

![conjure-up-disabled-clouds1](https://user-images.githubusercontent.com/406082/33046134-addcee02-ce1d-11e7-8e4a-be64320e3a54.png)

![conjure-up-disable-clouds2](https://user-images.githubusercontent.com/406082/33046055-4f0b527e-ce1d-11e7-9289-96206092eea1.png)
