### PR TITLE
Better handling of determining which juju/juju-wait binaries to use

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,6 +25,7 @@ travis-sysdeps:
 	@sudo pip install tox
 	@sudo snap install juju --classic --edge
 	@sudo snap refresh lxd --edge
+	@sudo snap install juju-wait --classic
 
 .PHONY: install
 install: snap

--- a/conjureup/app.py
+++ b/conjureup/app.py
@@ -199,10 +199,6 @@ def main():
         print("")
         sys.exit(1)
 
-    # Make sure juju paths are setup
-    juju.set_bin_path()
-    juju.set_wait_path()
-
     # Verify we can access ~/.local/share/juju if it exists
     juju_dir = pathlib.Path('~/.local/share/juju').expanduser()
     if juju_dir.exists():
@@ -236,6 +232,10 @@ def main():
     app.log = setup_logging(app,
                             os.path.join(opts.cache_dir, 'conjure-up.log'),
                             opts.debug)
+
+    # Make sure juju paths are setup
+    juju.set_bin_path()
+    juju.set_wait_path()
 
     if app.argv.conf_file.expanduser().exists():
         conf = configparser.ConfigParser()

--- a/conjureup/app.py
+++ b/conjureup/app.py
@@ -199,6 +199,10 @@ def main():
         print("")
         sys.exit(1)
 
+    # Make sure juju paths are setup
+    juju.set_bin_path()
+    juju.set_wait_path()
+
     # Verify we can access ~/.local/share/juju if it exists
     juju_dir = pathlib.Path('~/.local/share/juju').expanduser()
     if juju_dir.exists():

--- a/conjureup/app_config.py
+++ b/conjureup/app_config.py
@@ -3,6 +3,11 @@
 import json
 from types import SimpleNamespace
 
+
+class AppConfigAttributeError(Exception):
+    pass
+
+
 bootstrap = SimpleNamespace(
     # Is bootstrap running
     running=False,

--- a/conjureup/app_config.py
+++ b/conjureup/app_config.py
@@ -27,7 +27,13 @@ juju = SimpleNamespace(
     client=None,
 
     # Is authenticated?
-    authenticated=False
+    authenticated=False,
+
+    # Path to juju binary
+    bin_path=None,
+
+    # Path to juju-wait binary
+    wait_path=None
 )
 
 

--- a/conjureup/app_config.py
+++ b/conjureup/app_config.py
@@ -3,11 +3,6 @@
 import json
 from types import SimpleNamespace
 
-
-class AppConfigAttributeError(Exception):
-    pass
-
-
 bootstrap = SimpleNamespace(
     # Is bootstrap running
     running=False,

--- a/conjureup/errors.py
+++ b/conjureup/errors.py
@@ -12,3 +12,11 @@ class ControllerNotFoundException(Exception):
 
 class DeploymentFailure(Exception):
     "A failure from a deployed model"
+
+
+class JujuBinaryNotFound(Exception):
+    "A failure finding juju or juju-wait executable"
+
+
+class AppConfigAttributeError(Exception):
+    "A failure to lookup attribute in app_config object"

--- a/conjureup/juju.py
+++ b/conjureup/juju.py
@@ -14,20 +14,12 @@ from bundleplacer.charmstore_api import CharmStoreID
 from juju.model import Model
 
 from conjureup import consts, errors, events, utils
-from conjureup.app_config import AppConfigAttributeError, app
+from conjureup.app_config import app
 from conjureup.utils import is_linux, juju_path, run, spew
 
 JUJU_ASYNC_QUEUE = "juju-async-queue"
 
 PENDING_DEPLOYS = 0
-
-
-class JujuBinaryNotFound(Exception):
-    pass
-
-
-class JujuAttributeError(Exception):
-    pass
 
 
 def _check_bin_candidates(candidates, bin_property):
@@ -38,7 +30,7 @@ def _check_bin_candidates(candidates, bin_property):
     # we don't use $PATH because we have definite preferences which one we use
     # and we don't want to leave it up to the user
     if not hasattr(app.juju, bin_property):
-        raise AppConfigAttributeError(
+        raise errors.AppConfigAttributeError(
             "Unknown juju property: {}".format(bin_property))
     for candidate in candidates:
         if os.access(candidate, os.X_OK):
@@ -46,7 +38,7 @@ def _check_bin_candidates(candidates, bin_property):
             app.log.debug("{} candidate found".format(bin_property))
             break
     else:
-        raise JujuBinaryNotFound(
+        raise errors.JujuBinaryNotFound(
             "Unable to locate a candidate executable for {}.".format(
                 candidates))
 

--- a/conjureup/utils.py
+++ b/conjureup/utils.py
@@ -265,7 +265,7 @@ async def can_sudo(password=None):
 def juju_version():
     """ Get current Juju version
     """
-    cmd = run_script('juju version')
+    cmd = run_script('{} version'.format(app.juju.bin_path))
     if cmd.returncode == 0:
         return parse_version(cmd.stdout.decode().strip())
     else:

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -18,6 +18,9 @@ apps:
     - conjure-down
   juju:
     command: wrappers/juju
+  juju-wait:
+    command: wrappers/juju-wait
+
 parts:
   conjure-up:
     source: .

--- a/snap/wrappers/juju-wait
+++ b/snap/wrappers/juju-wait
@@ -2,18 +2,7 @@
 
 
 # Make sure we access our python and juju binaries first
-debian_socket=/var/lib/lxd
-snap_lxd_socket=/var/snap/lxd/common/lxd
-
 export PATH=$SNAP/bin:$SNAP/usr/bin:/snap/bin:$PATH
-lxd_binary=$(which lxd)
-
-# Prefer snap installed lxd, if availible
-if [ "$lxd_binary" = "/snap/bin/lxd" ]; then
-    export LXD_DIR=$snap_lxd_socket
-elif [ "$lxd_binary" = "/usr/bin/lxd" ]; then
-    export LXD_DIR=$debian_socket
-fi
 export LD_LIBRARY_PATH
 LD_LIBRARY_PATH=$SNAP/lib:$SNAP/usr/lib/$(uname -p)-linux-gnu/
 

--- a/snap/wrappers/juju-wait
+++ b/snap/wrappers/juju-wait
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+
+# Make sure we access our python and juju binaries first
+debian_socket=/var/lib/lxd
+snap_lxd_socket=/var/snap/lxd/common/lxd
+
+export PATH=$SNAP/bin:$SNAP/usr/bin:/snap/bin:$PATH
+lxd_binary=$(which lxd)
+
+# Prefer snap installed lxd, if availible
+if [ "$lxd_binary" = "/snap/bin/lxd" ]; then
+    export LXD_DIR=$snap_lxd_socket
+elif [ "$lxd_binary" = "/usr/bin/lxd" ]; then
+    export LXD_DIR=$debian_socket
+fi
+export LD_LIBRARY_PATH
+LD_LIBRARY_PATH=$SNAP/lib:$SNAP/usr/lib/$(uname -p)-linux-gnu/
+
+exec "$SNAP/bin/juju-wait" "$@"


### PR DESCRIPTION
In snaps we need to make sure that correct binaries are executed properly.
Rather than calling `juju wait` for the plugin `juju-wait` we call `juju-wait`
explicitly here. Also we are smarter about the order in which we pick certain
binaries to use.  This also supports OSX.

Fixes #1242

Signed-off-by: Adam Stokes <battlemidget@users.noreply.github.com>