### PR TITLE
Add required attribute to step model

### DIFF
--- a/conjureup/models/step.py
+++ b/conjureup/models/step.py
@@ -57,6 +57,7 @@ class StepModel:
         self.description = step.get('description', '')
         self.result = ''
         self.viewable = step.get('viewable', False)
+        self.required = step.get('required', False)
         self.needs_sudo = step.get('sudo', False)
         self.additional_input = step.get('additional-input', [])
         self.cloud_whitelist = step.get('cloud-whitelist', [])


### PR DESCRIPTION
Note: This will still fail for RadioButton's that have a default set as their
state is never defined and the value property will return empty.

Fixes #1255

Signed-off-by: Adam Stokes <battlemidget@users.noreply.github.com>