### PR TITLE
skip field input validate if boolean

### DIFF
--- a/conjureup/ui/widgets/step.py
+++ b/conjureup/ui/widgets/step.py
@@ -210,7 +210,7 @@ class StepForm(WidgetWrap):
                     self.model.required:
                 missing = True
             elif field.input_type == 'boolean' and \
-                    field.input_type.value is None and \
+                    field.input.value is None and \
                     self.model.required:
                 missing = True
             if missing:

--- a/conjureup/ui/widgets/step.py
+++ b/conjureup/ui/widgets/step.py
@@ -205,7 +205,7 @@ class StepForm(WidgetWrap):
                 self.clear_output()
         for field in self.fields:
             if not field.input.value \
-               and not field.input_type == 'boolean' \
+               and not isinstance(field.input_type, YesNo) \
                and self.model.required:
                 field.label_widget.set_text(
                     ('error_major',

--- a/conjureup/ui/widgets/step.py
+++ b/conjureup/ui/widgets/step.py
@@ -152,9 +152,10 @@ class StepForm(WidgetWrap):
                 if input_type == SelectorHorizontal:
                     select_w = input_type([choice for choice in i['choices']])
                     select_w.set_default(i['default'], True)
-                    field = StepField(key, label, select_w)
+                    field = StepField(key, label, select_w, i['type'])
                 else:
-                    field = StepField(key, label, input_type(default=value))
+                    field = StepField(key, label,
+                                      input_type(default=value), i['type'])
                 self.fields.append(field)
             column_input = [
                 ('weight', 0.5, Padding.left(field.label_widget, left=5))
@@ -203,7 +204,9 @@ class StepForm(WidgetWrap):
             else:
                 self.clear_output()
         for field in self.fields:
-            if not field.input.value and self.model.required:
+            if not field.input.value \
+               and not field.input_type == 'boolean' \
+               and self.model.required:
                 field.label_widget.set_text(
                     ('error_major',
                      "{}: Missing required input.".format(field.label)))
@@ -229,11 +232,12 @@ class StepForm(WidgetWrap):
 
 
 class StepField:
-    def __init__(self, key, label, input):
+    def __init__(self, key, label, input, input_type):
         self.key = key
         self.label = label
         self.label_widget = Text(('body', label))
         self.input = input
+        self.input_type = input_type
 
 
 class StepResult(WidgetWrap):

--- a/conjureup/ui/widgets/step.py
+++ b/conjureup/ui/widgets/step.py
@@ -204,9 +204,16 @@ class StepForm(WidgetWrap):
             else:
                 self.clear_output()
         for field in self.fields:
-            if not field.input.value \
-               and not isinstance(field.input_type, YesNo) \
-               and self.model.required:
+            missing = False
+            if field.input_type != 'boolean' and \
+                    not field.input.value and \
+                    self.model.required:
+                missing = True
+            elif field.input_type == 'boolean' and \
+                    field.input_type.value is None and \
+                    self.model.required:
+                missing = True
+            if missing:
                 field.label_widget.set_text(
                     ('error_major',
                      "{}: Missing required input.".format(field.label)))


### PR DESCRIPTION
Since boolean inputs can have a default of 'False' (No) the validation check
will fail even though 'False' in this case is actually a valid answer.

Signed-off-by: Adam Stokes <battlemidget@users.noreply.github.com>