### PR TITLE
Normalize bundle top level keys for application/services

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 aiofiles==0.3.1
 bundle-placement==0.0.2
 Jinja2==2.9.6
-git+https://github.com/juju/python-libjuju@bug/191-observer-race#egg=juju
+git+https://github.com/juju/python-libjuju@master#egg=juju
 juju-wait==2.6.2
 prettytable==0.7.2
 progressbar2==3.20.0


### PR DESCRIPTION
Some bundles still use old "services" key for defining charms where others use
the new format of "application". This normalizes those to whatever the original
bundle uses so that bundle fragments get merged in properly.

Fixes #1270

Signed-off-by: Adam Stokes <battlemidget@users.noreply.github.com>