### PR TITLE
Copy app constraints to conjure-up created machines

### DIFF
--- a/conjureup/controllers/configapps/gui.py
+++ b/conjureup/controllers/configapps/gui.py
@@ -79,8 +79,10 @@ class ConfigAppsController:
                                         bundle_application.placement_spec))
 
             for n in range(bundle_application.num_units):
-                bundle.add_machine(dict(series=bundle.series),
-                                   str(midx))
+                machine = {'series': bundle.series}
+                if bundle_application.constraints:
+                    machine['constraints'] = bundle_application.constraints
+                bundle.add_machine(machine, str(midx))
                 self.add_assignment(bundle_application, str(midx),
                                     AssignmentType.DEFAULT)
                 midx += 1

--- a/conjureup/juju.py
+++ b/conjureup/juju.py
@@ -552,8 +552,7 @@ def constraints_to_dict(constraints):
             elif constraint in ['root-disk', 'mem', 'cores']:
                 value = int(value)
             else:
-                raise Exception(
-                    "Unsupported constraint: {}".format(constraint))
+                pass
             new_constraints[constraint] = value
         except ValueError as e:
             app.log.debug("Skipping constraint: {} ({})".format(c, e))


### PR DESCRIPTION
If no machines are defined in the bundle, then conjure-up creates some
for you.  However, it was not copying over constraints defined on the
application, so they were getting ignored

Fixes #1272