### PR TITLE
Fix a few issues with enhanced keyboard navigation

### DIFF
--- a/conjureup/controllers/runsteps/gui.py
+++ b/conjureup/controllers/runsteps/gui.py
@@ -18,7 +18,7 @@ class RunStepsController:
             if not step.has_after_deploy:
                 continue
             view.mark_step_running(step)
-            step.result = await step.after_deploy(app.ui.set_footer)
+            step.result = await step.after_deploy(view.set_footer)
             view.mark_step_complete(step)
         common.save_step_results()
         events.PostDeployComplete.set()

--- a/conjureup/ui/views/applicationlist.py
+++ b/conjureup/ui/views/applicationlist.py
@@ -2,7 +2,6 @@
 
 """
 import logging
-from functools import partial
 
 from juju.model import CharmStore
 from urwid import Columns, Text
@@ -121,8 +120,7 @@ class ApplicationListView(BaseView):
             label = 'DEPLOY REMAINING'
         else:
             label = 'DEPLOY ALL'
-        return [self.button(label, partial(app.loop.create_task,
-                                           self._deploy_all))]
+        return [self.button(label, self.submit)]
 
     def after_keypress(self):
         "Check if focused widget changed, then update readme."
@@ -196,3 +194,6 @@ class ApplicationListView(BaseView):
             app.loop.create_task(self._deploy_one(application))
         else:
             app.loop.create_task(self._deploy_all())
+
+    def submit(self):
+        app.loop.create_task(self._deploy_all())

--- a/conjureup/ui/views/shutdown.py
+++ b/conjureup/ui/views/shutdown.py
@@ -27,6 +27,8 @@ class ShutdownView(WidgetWrap):
             ]),
             Padding.line_break(""),
         ])))
+        if events.Error.is_set():
+            self.confirm()
 
     def confirm(self):
         self.message.set_text("Conjure-up is shutting down, please wait.")
@@ -42,4 +44,10 @@ class ShutdownView(WidgetWrap):
             if result == 'right':
                 result = super().keypress(size, 'left')
             return result
+        if key.lower() == 'y':
+            self.confirm()
+            return None
+        if key.lower() == 'n':
+            self.cancel()
+            return None
         return super().keypress(size, key)

--- a/conjureup/ui/views/steps.py
+++ b/conjureup/ui/views/steps.py
@@ -61,7 +61,6 @@ class RunStepsView(BaseView):
     def mark_complete(self):
         app.ui.set_header(title="Post-Deploy Steps Complete",
                           excerpt="Your deployment is now complete")
-        app.ui.set_footer("Your big software is deployed, "
-                          "press the (Q) key to exit.")
-        self.frame.focus_position = 'footer'
-        self.buttons.focus_position = 1
+        self.set_footer("Your big software is deployed, "
+                        "press the (Q) key to exit.")
+        self._swap_focus()

--- a/conjureup/ui/views/steps.py
+++ b/conjureup/ui/views/steps.py
@@ -28,6 +28,7 @@ class ShowStepsView(BaseView):
 class RunStepsView(BaseView):
     title = "Running Post-Deploy Steps"
     subtitle = "Please wait while the post-deploy steps are run."
+    show_back_button = False
 
     def build_widget(self):
         self.widgets = {}


### PR DESCRIPTION
* Fix `h` for help screen overriding text input
* Fix error on `DEPLOY ALL`
* Fix error on runsteps after deploy
* Remove need to confirm quit when on error screen
* Allow `y` or `n` for confirm quit dialog
* Improve final "deployment finished" screen interaction and display