### PR TITLE
Convert Deploy Status screen to BaseView to enable scrolling

### DIFF
--- a/conjureup/controllers/bootstrap/gui.py
+++ b/conjureup/controllers/bootstrap/gui.py
@@ -14,7 +14,7 @@ class BootstrapController(common.BaseBootstrapController):
 
     @property
     def msg_cb(self):
-        return app.ui.set_footer
+        return self.view.set_footer
 
     def render(self):
         if app.is_jaas or self.is_existing_controller():
@@ -29,12 +29,12 @@ class BootstrapController(common.BaseBootstrapController):
             msg = 'Controller'
 
         self.bootstrapping.set()
-        view = InterstitialView(
+        self.view = InterstitialView(
             title=title,
             message="Juju {} is initializing. Please wait.".format(msg),
             event=self.bootstrapping,
             watch_file=bootstrap_stderr_path)
-        view.show()
+        self.view.show()
 
         app.loop.create_task(self.run())
         app.loop.create_task(self.wait())

--- a/conjureup/controllers/deploy/gui.py
+++ b/conjureup/controllers/deploy/gui.py
@@ -14,18 +14,12 @@ class DeployController:
         """ Render deploy status view
         """
         track_screen("Deploy")
-        view = DeployStatusView(app)
+        view = DeployStatusView()
+        view.show()
 
-        try:
-            name = app.config['metadata']['friendly-name']
-        except KeyError:
-            name = app.config['spell']
-        app.ui.set_header(title="Conjuring up {}".format(name))
-        app.ui.set_body(view)
-
-        app.loop.create_task(common.do_deploy(app.ui.set_footer))
+        app.loop.create_task(common.do_deploy(view.set_footer))
         app.loop.create_task(self._refresh(view))
-        app.loop.create_task(self._wait_for_applications())
+        app.loop.create_task(self._wait_for_applications(view))
 
     async def _refresh(self, view):
         applications = sorted(app.metadata_controller.bundle.services,
@@ -86,8 +80,8 @@ class DeployController:
                 })
         return view_data
 
-    async def _wait_for_applications(self):
-        await common.wait_for_applications(app.ui.set_footer)
+    async def _wait_for_applications(self, view):
+        await common.wait_for_applications(view.set_footer)
         controllers.use('runsteps').render()
 
 

--- a/conjureup/controllers/deploy/gui.py
+++ b/conjureup/controllers/deploy/gui.py
@@ -3,7 +3,6 @@ from operator import attrgetter
 
 from conjureup import controllers, events
 from conjureup.app_config import app
-from conjureup.telemetry import track_screen
 from conjureup.ui.views.deploystatus import DeployStatusView
 
 from . import common
@@ -13,7 +12,6 @@ class DeployController:
     def render(self):
         """ Render deploy status view
         """
-        track_screen("Deploy")
         view = DeployStatusView()
         view.show()
 

--- a/conjureup/controllers/showsteps/gui.py
+++ b/conjureup/controllers/showsteps/gui.py
@@ -42,7 +42,7 @@ class ShowStepsController:
             app.sudo_pass = step_widget.sudo_input.value
         for field in step_widget.fields:
             app.steps_data[step.name][field.key] = field.input.value
-        await step.after_input(app.ui.set_footer)
+        await step.after_input(self.view.set_footer)
 
     def finish(self):
         steps = app.steps + AddonModel.selected_addons_steps()

--- a/conjureup/ui/views/ControllerListView.py
+++ b/conjureup/ui/views/ControllerListView.py
@@ -17,6 +17,7 @@ class ControllerListView(BaseView):
               'for you for free, so that you can focus on your applications '
               'and solutions. Alternatively, you can host and manage your own '
               'controller on the cloud to which you deploy.')
+    footer_align = 'left'
 
     def __init__(self, app, controllers, submit_cb, back_cb):
         self.app = app

--- a/conjureup/ui/views/app_architecture_view.py
+++ b/conjureup/ui/views/app_architecture_view.py
@@ -19,6 +19,7 @@ from conjureup.ui.widgets.juju_machines_list import JujuMachinesList
 
 
 class AppArchitectureView(BaseView):
+    metrics_title = 'Architect Application'
 
     def __init__(self, application, controller, close_cb):
         """

--- a/conjureup/ui/views/applicationconfigure.py
+++ b/conjureup/ui/views/applicationconfigure.py
@@ -13,6 +13,7 @@ from conjureup.ui.widgets.option_widget import OptionWidget
 
 
 class ApplicationConfigureView(BaseView):
+    metrics_title = 'Configure Application'
 
     def __init__(self, application, close_cb):
         self.title = "Configure {}".format(application.service_name)

--- a/conjureup/ui/views/applicationlist.py
+++ b/conjureup/ui/views/applicationlist.py
@@ -77,6 +77,7 @@ class ApplicationListView(BaseView):
     title = "Configure Applications"
     subtitle = ""  # set by __init__
     footer = ""  # set by after_keypress
+    footer_align = "left"
 
     def __init__(self, applications, deploy_one, deploy_all,
                  config_cb, arch_cb, back_cb):

--- a/conjureup/ui/views/base.py
+++ b/conjureup/ui/views/base.py
@@ -49,6 +49,7 @@ class BaseView(WidgetWrap):
     footer_align = 'center'
     show_back_button = True
     body_valign = 'top'
+    metrics_title = None  # in case we want to track screen w/ different name
 
     focusable_widget_types = (
         Edit,
@@ -131,7 +132,7 @@ class BaseView(WidgetWrap):
         self._command_handlers.update(command_handlers)
 
     def show(self):
-        track_screen(self.title)
+        track_screen(self.metrics_title or self.title)
         app.ui.set_header(title=self.title,
                           excerpt=self.subtitle)
         app.ui.set_body(self)

--- a/conjureup/ui/views/base.py
+++ b/conjureup/ui/views/base.py
@@ -46,6 +46,7 @@ class BaseView(WidgetWrap):
     subtitle = None
     footer = ''
     footer_height = 'auto'
+    footer_align = 'center'
     show_back_button = True
     body_valign = 'top'
 
@@ -190,7 +191,7 @@ class BaseView(WidgetWrap):
         buttons.append(('fixed', 2, Text("")))
         self.button_row = Columns(buttons, 2)
 
-        self.footer_msg = Text(self.footer)
+        self.footer_msg = Text(self.footer, align=self.footer_align)
         footer_widget = Columns([
             Text(''),
             ('pack', self.footer_msg),
@@ -381,6 +382,7 @@ class BaseView(WidgetWrap):
         if key != 'enter':
             result = super().keypress(size, key)
             if result != key:
+                self.after_keypress()
                 return result
         # not handled, so dispatch via _command_handlers (see __init__)
         command = self._command_map[key]

--- a/conjureup/ui/views/deploystatus.py
+++ b/conjureup/ui/views/deploystatus.py
@@ -29,6 +29,7 @@ class PileTable(Table):
 
 class DeployStatusView(BaseView):
     show_back_button = False
+    metrics_title = 'Deploy Status'
 
     def __init__(self):
         try:

--- a/test/test_controllers_deploy_gui.py
+++ b/test/test_controllers_deploy_gui.py
@@ -19,12 +19,8 @@ class DeployGUIRenderTestCase(unittest.TestCase):
         self.app_patcher = patch(
             'conjureup.controllers.deploy.gui.app')
         self.mock_app = self.app_patcher.start()
-        self.mock_app.ui = MagicMock(name="app.ui")
 
         self.controller = DeployController()
-        self.track_screen_patcher = patch(
-            'conjureup.controllers.deploy.gui.track_screen')
-        self.mock_track_screen = self.track_screen_patcher.start()
         self.controller._wait_for_applications = MagicMock()
         self.controller._refresh = MagicMock()
         self.common_patcher = patch(
@@ -35,7 +31,6 @@ class DeployGUIRenderTestCase(unittest.TestCase):
         self.common_patcher.stop()
         self.view_patcher.stop()
         self.app_patcher.stop()
-        self.track_screen_patcher.stop()
 
     def test_render(self):
         "call render"


### PR DESCRIPTION
Also fixed an issue tracking screens with dynamic titles (i.e., ones where the title contains the spell or application name) so that they're consistent and we can get good metrics.

I did see some oddness in the rendering of the scrollbar on the Deploy Status screen, but that might have just been my terminal, and it didn't affect the functionality in any way.