### PR TITLE
Fix JAAS controller selection when token auth succeeds

### DIFF
--- a/conjureup/controllers/jaaslogin/gui.py
+++ b/conjureup/controllers/jaaslogin/gui.py
@@ -50,6 +50,8 @@ class JaaSLoginController:
             await juju.register_controller(app.jaas_controller,
                                            JAAS_DOMAIN,
                                            '', '', '')
+            app.provider.controller = app.jaas_controller
+            app.is_jaas = True
             controllers.use('showsteps').render()
         except CalledProcessError:
             # empty-but-not-None message to skip retrying token auth


### PR DESCRIPTION
This only comes in to play if there is already an existing controller entry for JAAS which is named something other than 'jaas' and the user is authenticated with the IDM but not the controller (i.e., macaroon discharge can happen automatically).