### PR TITLE
Explicitly ignore errors posting telemetry

### DIFF
--- a/conjureup/controllers/clouds/tui.py
+++ b/conjureup/controllers/clouds/tui.py
@@ -21,18 +21,14 @@ class CloudsController(BaseCloudController):
         utils.info(
             "Summoning {} to {}".format(app.argv.spell, app.provider.cloud))
         if app.provider.cloud_type == cloud_types.LOCALHOST:
-
-            try:
-                app.provider._set_lxd_dir_env()
-                client_compatible = await app.provider.is_client_compatible()
-                server_compatible = await app.provider.is_server_compatible()
-                if client_compatible and server_compatible:
-                    return self.finish()
-                else:
-                    utils.error("LXD Server or LXC client not compatible")
-                    events.Shutdown.set(1)
-            except app.provider.LocalhostError:
-                raise
+            app.provider._set_lxd_dir_env()
+            client_compatible = await app.provider.is_client_compatible()
+            server_compatible = await app.provider.is_server_compatible()
+            if client_compatible and server_compatible:
+                return self.finish()
+            else:
+                utils.error("LXD Server or LXC client not compatible")
+                events.Shutdown.set(1)
         self.finish()
 
     def render(self):

--- a/conjureup/juju.py
+++ b/conjureup/juju.py
@@ -355,12 +355,15 @@ def get_credential(cloud, cred_name=None):
 
 
 def get_credentials():
-    """ List credentials
+    """ Get all locally cached credentials from Juju.
 
     Returns:
-    List of credentials
+    Dict of credentials by cloud.
     """
-    return FileJujuData().credentials()
+    try:
+        return FileJujuData().credentials()
+    except FileNotFoundError:
+        return {}
 
 
 def get_regions(cloud):

--- a/conjureup/telemetry.py
+++ b/conjureup/telemetry.py
@@ -60,5 +60,8 @@ def _post_track(arg_dict):
                   av=VERSION, an="Conjure-Up")
 
     params.update(arg_dict)
-    requests.post("http://www.google-analytics.com/collect",
-                  data=params)
+    try:
+        requests.post("http://www.google-analytics.com/collect",
+                      data=params)
+    except Exception:
+        pass  # ignore failures to submit telemetry


### PR DESCRIPTION
Since the telemetry is done in a separate thread, failures should be silently ignored anyway, but this makes it more explicit.

Resolves #1358