### PR TITLE
Allow reading from a Conjurefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,7 @@ travis-sysdeps:
 	@sudo apt-get -y install jq bsdtar python3.6-dev make snapd libsodium-dev
 	@sudo pip install tox
 	@sudo snap install juju --classic
-	@sudo snap refresh lxd --edge
+	@sudo snap refresh lxd
 	@sudo snap install juju-wait --classic
 
 .PHONY: install

--- a/conjureup/app.py
+++ b/conjureup/app.py
@@ -37,6 +37,7 @@ from conjureup.download import (
 )
 from conjureup.log import setup_logging
 from conjureup.models.addon import AddonModel
+from conjureup.models.conjurefile import Conjurefile
 from conjureup.models.provider import SchemaErrorUnknownCloud, load_schema
 from conjureup.models.step import StepModel
 from conjureup.telemetry import SENTRY_DSN, track_event, track_screen
@@ -217,6 +218,7 @@ def main():
 
     utils.set_terminal_title("conjure-up")
     opts = parse_options(sys.argv[1:])
+
     spell = os.path.basename(os.path.abspath(opts.spell))
 
     if not os.path.isdir(opts.cache_dir):
@@ -230,6 +232,12 @@ def main():
     app.env['KV_DB'] = kv_db
     app.config = {'metadata': None}
     app.argv = opts
+
+    # Load conjurefile, merge any overridding options from argv
+    if (pathlib.Path('.') / 'Conjurefile').exists():
+        app.conjurefile = Conjurefile.load(pathlib.Path('.') / 'Conjurefile')
+        app.conjurefile.merge_argv(app.argv)
+
     app.log = setup_logging(app,
                             os.path.join(opts.cache_dir, 'conjure-up.log'),
                             opts.debug)

--- a/conjureup/app_config.py
+++ b/conjureup/app_config.py
@@ -62,6 +62,9 @@ class AppConfig:
     # Contains spell name
     config = None
 
+    # Conjurefile
+    conjurefile = None
+
     # Spell metadata
     metadata = None
 

--- a/conjureup/models/conjurefile.py
+++ b/conjureup/models/conjurefile.py
@@ -1,0 +1,48 @@
+import yaml
+
+
+class ConjurefileException(Exception):
+    pass
+
+
+class Conjurefile(dict):
+    """
+    spell: canonical-kubernetes
+    provider: localhost
+    addons:
+      helm:
+        version: v2.8.1
+    steps:
+      select-network:
+        networkplugin: "calico"
+
+    on_complete:
+      - cat /etc/uptime
+
+    proxy:
+      http-proxy: http://localhost:5252
+      https-proxy: http://localhost:5252
+      apt-http-proxy: http://localhost:5252
+      apt-https-proxy: http://localhost:5252
+      no-proxy: jujucharms.com
+    """
+
+    def __init__(self, data):
+        super().__init__(data)
+
+    @classmethod
+    def load(cls, path):
+        """ Load spell metadata
+        """
+        return Conjurefile(
+            yaml.safe_load(path.read_text()))
+
+    def merge_argv(self, argv):
+        """
+        Overrides options in the conjurefile with
+        those passed in via sys.argv
+        """
+        argv_dict = vars(argv)
+        for k, v in argv_dict.items():
+            if v and k in self:
+                self[k] = v

--- a/docs/Conjurefile
+++ b/docs/Conjurefile
@@ -1,0 +1,4 @@
+# -*- mode:yaml; -*-
+
+cache_dir: '/tmp/testxxxx'
+registry: 'https://github.com/battlemidget/spells.git'

--- a/test/Conjurefile
+++ b/test/Conjurefile
@@ -1,0 +1,4 @@
+# -*- mode:yaml; -*-
+
+cache_dir: '/tmp/testxxxx'
+registry: 'https://github.com/battlemidget/spells.git'

--- a/test/test_conjurefile.py
+++ b/test/test_conjurefile.py
@@ -1,0 +1,30 @@
+#!/usr/bin/env python
+#
+# tests bundle loading, merging, output
+#
+# Copyright 2016-2018 Canonical, Ltd.
+
+
+import argparse
+import unittest
+from pathlib import Path
+
+from conjureup.models.conjurefile import Conjurefile
+
+
+class ConjurefileTestCase(unittest.TestCase):
+
+    def setUp(self):
+        self.tests_dir = Path(__file__).absolute().parent
+        self.conjurefile_path = self.tests_dir / 'Conjurefile'
+        self.conjurefile = Conjurefile.load(self.conjurefile_path)
+
+    def test_conjurefile_argv_override(self):
+        "conjurefile.test_argv_override"
+        args = argparse.Namespace()
+        args.registry = 'https://github.com/conjure-up/spells.git'
+        assert self.conjurefile['registry'] == (
+            'https://github.com/battlemidget/spells.git')
+        self.conjurefile.merge_argv(args)
+        assert self.conjurefile['registry'] == (
+            'https://github.com/conjure-up/spells.git')


### PR DESCRIPTION
This also adds a simple method for pulling in any argv options and overridding
what's defined in the Conjurefile

Signed-off-by: Adam Stokes <battlemidget@users.noreply.github.com>