### PR TITLE
Fix lxc query defaults

### DIFF
--- a/conjureup/models/provider.py
+++ b/conjureup/models/provider.py
@@ -379,8 +379,7 @@ class Localhost(BaseProvider):
             segment_prefix = Path('/1.0')
             url = str(segment_prefix / segment)
         try:
-            cmd = [self.lxc_bin, 'query', '--wait', '-X', method.upper(),
-                   url]
+            cmd = [self.lxc_bin, 'query', '--wait', url]
             app.log.debug("LXD query cmd: {}".format(" ".join(cmd)))
             _, out, err = await utils.arun(cmd)
             return json.loads(out)

--- a/conjureup/models/provider.py
+++ b/conjureup/models/provider.py
@@ -442,7 +442,7 @@ class Localhost(BaseProvider):
         """ Checks if LXC version is compatible with conjure-up
         """
         try:
-            _, out, err = await utils.arun([self.lxc_bin, 'version'])
+            _, out, err = await utils.arun([self.lxc_bin, '--version'])
             server_ver = out.strip()
             return parse_version(server_ver) >= self.minimum_support_version
         except CalledProcessError as e:


### PR DESCRIPTION
The default is to perform a GET, which is all we use. The option changed from -X
to --X in the 2 to 3 switch.

Signed-off-by: Adam Stokes <battlemidget@users.noreply.github.com>