### PR TITLE
Fail with a error message on incompatible lxd versions

### DIFF
--- a/conjureup/controllers/clouds/gui.py
+++ b/conjureup/controllers/clouds/gui.py
@@ -8,6 +8,7 @@ from conjureup.consts import CUSTOM_PROVIDERS
 from conjureup.models.provider import Localhost as LocalhostProvider
 from conjureup.models.provider import (
     LocalhostError,
+    LocalhostIncompatibleError,
     LocalhostJSONError,
     SchemaErrorUnknownCloud,
     load_schema
@@ -102,6 +103,13 @@ class CloudsController(BaseCloudController):
                     self.cancel_monitor.set()
                     cb()
                     return
+                else:
+                    raise LocalhostIncompatibleError(
+                        "Currently installed LXD version is not compatible "
+                        "with conjure-up. Please upgrade your version of LXD, "
+                        "refer to "
+                        "https://docs.conjure-up.io/devel/en/#users-of-lxd "
+                        "for more information.")
             except (LocalhostError, LocalhostJSONError, FileNotFoundError):
                 pass
             await run_with_interrupt(asyncio.sleep(2),

--- a/conjureup/controllers/clouds/gui.py
+++ b/conjureup/controllers/clouds/gui.py
@@ -105,11 +105,9 @@ class CloudsController(BaseCloudController):
                     return
                 else:
                     raise LocalhostIncompatibleError(
-                        "Currently installed LXD version is not compatible "
-                        "with conjure-up. Please upgrade your version of LXD, "
-                        "refer to "
-                        "https://docs.conjure-up.io/devel/en/#users-of-lxd "
-                        "for more information.")
+                        "conjure-up requires a newer version of LXD. "
+                        "To upgrade, see "
+                        "https://docs.conjure-up.io/devel/en/#users-of-lxd")
             except (LocalhostError, LocalhostJSONError, FileNotFoundError):
                 pass
             await run_with_interrupt(asyncio.sleep(2),

--- a/conjureup/models/provider.py
+++ b/conjureup/models/provider.py
@@ -334,6 +334,10 @@ class LocalhostError(Exception):
     pass
 
 
+class LocalhostIncompatibleError(Exception):
+    pass
+
+
 class LocalhostJSONError(Exception):
     pass
 
@@ -344,7 +348,7 @@ class Localhost(BaseProvider):
         self.auth_type = 'interactive'
         self.cloud_type = cloud_types.LOCALHOST
         self.network_interface = None
-        self.minimum_support_version = parse_version('2.17')
+        self.minimum_support_version = parse_version('3.0.0')
         self.available = False
         self.lxc_bin = None
         self._set_lxd_dir_env()


### PR DESCRIPTION
Now only supporting LXD 3.x which can only be retrieved from snap store. Those
not using a snap now only have access to 2.0.x debs which conjure-up doesn't
support. Add a friendly error message and a link on how to install the required LXD.

Signed-off-by: Adam Stokes <battlemidget@users.noreply.github.com>