### PR TITLE
Dont fail hard on incompatible LXD since it's an optional component

### DIFF
--- a/conjureup/controllers/clouds/gui.py
+++ b/conjureup/controllers/clouds/gui.py
@@ -8,7 +8,6 @@ from conjureup.consts import CUSTOM_PROVIDERS
 from conjureup.models.provider import Localhost as LocalhostProvider
 from conjureup.models.provider import (
     LocalhostError,
-    LocalhostIncompatibleError,
     LocalhostJSONError,
     SchemaErrorUnknownCloud,
     load_schema
@@ -103,11 +102,6 @@ class CloudsController(BaseCloudController):
                     self.cancel_monitor.set()
                     cb()
                     return
-                else:
-                    raise LocalhostIncompatibleError(
-                        "conjure-up requires a newer version of LXD. "
-                        "To upgrade, see "
-                        "https://docs.conjure-up.io/devel/en/#users-of-lxd")
             except (LocalhostError, LocalhostJSONError, FileNotFoundError):
                 pass
             await run_with_interrupt(asyncio.sleep(2),

--- a/conjureup/ui/views/cloud.py
+++ b/conjureup/ui/views/cloud.py
@@ -17,12 +17,9 @@ class CloudView(BaseView):
     default_disabled_msg = 'This cloud is disabled due to your selection of ' \
                            'spell or add-on. Please use the arrow keys to ' \
                            'select another cloud.'
-    lxd_unavailable_msg = ("LXD not found, please install and wait "
-                           "for this message to disappear:\n\n"
-                           "  $ sudo snap install lxd\n"
-                           "  $ sudo usermod -a -G lxd <youruser>\n"
-                           "  $ newgrp lxd\n"
-                           "  $ /snap/bin/lxd init")
+    lxd_unavailable_msg = ("conjure-up requires a newer version of LXD. "
+                           "To upgrade, see "
+                           "https://docs.conjure-up.io/devel/en/#users-of-lxd")
 
     def __init__(self, app, public_clouds, custom_clouds,
                  compatible_cloud_types, cb=None, back=None):

--- a/conjureup/ui/views/cloud.py
+++ b/conjureup/ui/views/cloud.py
@@ -17,8 +17,8 @@ class CloudView(BaseView):
     default_disabled_msg = 'This cloud is disabled due to your selection of ' \
                            'spell or add-on. Please use the arrow keys to ' \
                            'select another cloud.'
-    lxd_unavailable_msg = ("conjure-up requires a newer version of LXD. "
-                           "To upgrade, see "
+    lxd_unavailable_msg = ("LXD version 3.0.0 or greater is required. "
+                           "To install or upgrade, see "
                            "https://docs.conjure-up.io/devel/en/#users-of-lxd")
 
     def __init__(self, app, public_clouds, custom_clouds,


### PR DESCRIPTION
This new way keeps conjure-up running and will perform the validation check in
the background.  While LXD is unavailable the user will still see the newly
defined message and be able to follow along with the steps outlined in the
online docs.

Signed-off-by: Adam Stokes <battlemidget@users.noreply.github.com>