### PR TITLE
Update Conjurefile templating

### DIFF
--- a/conjureup/app.py
+++ b/conjureup/app.py
@@ -242,6 +242,9 @@ def main():
     # Load conjurefile, merge any overridding options from argv
     if not app.argv.conf_file:
         app.argv.conf_file = []
+    if pathlib.Path('~/.config/conjure-up.conf').expanduser().exists():
+        app.argv.conf_file.insert(
+            0, pathlib.Path('~/.config/conjure-up.conf').expanduser())
     if (pathlib.Path('.') / 'Conjurefile').exists():
         app.argv.conf_file.insert(0, pathlib.Path('.') / 'Conjurefile')
     for conf in app.argv.conf_file:

--- a/conjureup/models/conjurefile.py
+++ b/conjureup/models/conjurefile.py
@@ -1,7 +1,6 @@
 import textwrap
 
 import yaml
-
 from melddict import MeldDict
 
 
@@ -103,7 +102,7 @@ class Conjurefile(MeldDict):
         for k, v in argv_dict.items():
             if v and k in self:
                 self[k] = v
-            if k in posargs:
+            if k in posargs and argv_dict[k]:
                 self[k] = v
 
     @property
@@ -112,6 +111,6 @@ class Conjurefile(MeldDict):
         Returns whether this conjurefile has minimum set of requirements to run
         a headless install
         """
-        if self.get('spell', None) and self.get('cloud', None):
+        if 'cloud' in self and self['cloud']:
             return True
         return False

--- a/conjureup/models/conjurefile.py
+++ b/conjureup/models/conjurefile.py
@@ -61,7 +61,7 @@ class Conjurefile(MeldDict):
     # on_complete: ./my_custom_script.sh
 
     # Debugging
-    debug: true
+    debug: false
 
     # Reporting
     # notrack: false

--- a/conjureup/models/conjurefile.py
+++ b/conjureup/models/conjurefile.py
@@ -1,5 +1,7 @@
-import yaml
 import textwrap
+
+import yaml
+
 from melddict import MeldDict
 
 
@@ -66,6 +68,7 @@ class Conjurefile(MeldDict):
     # notrack: false
     # noreport: false
     """
+
     def __init__(self):
         initial_data = yaml.safe_load(
             textwrap.dedent(Conjurefile.__doc__.strip()))

--- a/conjureup/models/conjurefile.py
+++ b/conjureup/models/conjurefile.py
@@ -1,48 +1,114 @@
 import yaml
+import textwrap
+from melddict import MeldDict
 
 
 class ConjurefileException(Exception):
     pass
 
 
-class Conjurefile(dict):
+class Conjurefile(MeldDict):
     """
-    spell: canonical-kubernetes
-    provider: localhost
-    addons:
-      helm:
-        version: v2.8.1
-    steps:
-      select-network:
-        networkplugin: "calico"
+    # (Required) Name of spell to summon. This can be in the form
+    # of a GitHub repo, filesystem path, or a pre-packaged spell.
+    #
+    # Choose One of:
+    #
+    # A prebundled spell:
+    # spell: canonical-kubernetes
 
-    on_complete:
-      - cat /etc/uptime
+    # A GitHub Repo
+    # spell: battlemidget/ghost
+    #
+    # A local filesystem path
+    # spell: ~/spells/hadoop-spark
 
-    proxy:
-      http-proxy: http://localhost:5252
-      https-proxy: http://localhost:5252
-      apt-http-proxy: http://localhost:5252
-      apt-https-proxy: http://localhost:5252
-      no-proxy: jujucharms.com
+    # (Required) The cloud to use. This can be any cloud listed here:
+    # https://jujucharms.com/docs/stable/clouds#listing-available-clouds
+    # cloud: localhost
+
+    # A provider can also be a cloud/region
+    # cloud: aws/us-east-1
+    #
+    # (Optional) Set any addons you wish to deploy.
+    #
+
+    # (Optional) Controller name. This can be any arbitrary name of your Juju
+    # controller.
+    # controller: us-dc1
+
+    # (Optional) Model name. This can be any arbitrary name of your Juju Model
+    # model: k8s-1
+
+    # For the Kubernetes spell you may want Helm installed so you can deploy
+    # charts to the cluster.
+    # addons:
+    #  helm:
+    #    version: v2.8.1
+
+    # (Optional) Customize any of the steps that are run once the spell is
+    # deployed
+    #
+    # steps:
+    #  01_select-network:
+    #    networkplugin: "flannel"
+
+    # (Optional) Execute a custom script once everything is deployed. This
+    # could be anything you choose, whether it's deploying a Helm chart, to
+    # scaling out your cluster.
+    #
+    # on_complete: ./my_custom_script.sh
+
+    # Debugging
+    debug: true
+
+    # Reporting
+    # notrack: false
+    # noreport: false
     """
-
-    def __init__(self, data):
-        super().__init__(data)
+    def __init__(self):
+        initial_data = yaml.safe_load(
+            textwrap.dedent(Conjurefile.__doc__.strip()))
+        super().__init__(self.add(initial_data))
 
     @classmethod
-    def load(cls, path):
-        """ Load spell metadata
+    def print_tpl(cls):
+        """ Prints a Conjurefile template
         """
-        return Conjurefile(
-            yaml.safe_load(path.read_text()))
+        print(textwrap.dedent(Conjurefile.__doc__))
+
+    @classmethod
+    def load(cls, paths):
+        """ Load spell metadata
+
+        Arguments:
+        paths: list of path names to pull in for updating
+               conjurefile
+        """
+        cf = Conjurefile()
+        for p in paths:
+            cf += yaml.safe_load(p.read_text())
+        return cf
 
     def merge_argv(self, argv):
         """
         Overrides options in the conjurefile with
         those passed in via sys.argv
         """
+        posargs = ['spell', 'cloud', 'controller', 'model']
         argv_dict = vars(argv)
         for k, v in argv_dict.items():
             if v and k in self:
                 self[k] = v
+            if k in posargs:
+                self[k] = v
+
+    @property
+    def is_valid(self):
+        """
+        Returns whether this conjurefile has minimum set of requirements to run
+        a headless install
+        """
+        if self.get('spell', None) and self.get('cloud', None):
+            return True
+        return False

--- a/requirements.txt
+++ b/requirements.txt
@@ -19,3 +19,4 @@ psutil==5.2.2
 awscli==1.11.123
 pyvmomi==6.5.0.2017.5-1
 kv==0.3.0
+melddict==1.0.1

--- a/test/Conjurefile
+++ b/test/Conjurefile
@@ -2,3 +2,5 @@
 
 cache_dir: '/tmp/testxxxx'
 registry: 'https://github.com/battlemidget/spells.git'
+
+cloud: 'aws'

--- a/test/Conjurefile2
+++ b/test/Conjurefile2
@@ -1,3 +1,3 @@
 # -*- mode:yaml; -*-
 
-debug: false
+cloud: 'gce'

--- a/test/test_conjurefile.py
+++ b/test/test_conjurefile.py
@@ -17,7 +17,7 @@ class ConjurefileTestCase(unittest.TestCase):
     def setUp(self):
         self.tests_dir = Path(__file__).absolute().parent
         self.conjurefile_path = self.tests_dir / 'Conjurefile'
-        self.conjurefile = Conjurefile.load(self.conjurefile_path)
+        self.conjurefile = Conjurefile.load([self.conjurefile_path])
 
     def test_conjurefile_argv_override(self):
         "conjurefile.test_argv_override"
@@ -28,3 +28,29 @@ class ConjurefileTestCase(unittest.TestCase):
         self.conjurefile.merge_argv(args)
         assert self.conjurefile['registry'] == (
             'https://github.com/conjure-up/spells.git')
+
+    def test_conjurefile_debug_enabled(self):
+        "conjurefile.test_debug_enabled"
+        assert self.conjurefile['debug']
+
+    def test_conjurefile_melddict_level_1(self):
+        "conjurefile.test_melddict_level_1"
+        assert self.conjurefile['cloud'] == 'aws'
+
+    def test_conjurefile_melddict_level_2(self):
+        "conjurefile.test_melddict_level_2"
+        self.conjurefile_path2 = self.tests_dir / 'Conjurefile2'
+        self.conjurefile = Conjurefile.load([
+            self.conjurefile_path,
+            self.conjurefile_path2
+        ])
+        assert self.conjurefile['cloud'] == 'gce'
+
+    def test_conjurefile_argv_spell_cloud(self):
+        "conjurefile.test_argv_spell_cloud"
+        args = argparse.Namespace()
+        args.spell = 'canonical-kubernetes'
+        args.cloud = 'aws/us-east-1'
+        self.conjurefile.merge_argv(args)
+        assert self.conjurefile['spell'] == 'canonical-kubernetes'
+        assert self.conjurefile['cloud'] == 'aws/us-east-1'


### PR DESCRIPTION
This provides ability to generate a skeleton Conjurefile with `conjure-up --gen-config` based on the docstring for our conjurefile class (which is also our source of truth for what is supported)

Also, this pulls in any positional args for backward compatibility with the current method of headless installs.

We also drop the use of configparser which was reading `~/.config/conjure-up.conf` for setting 2 options for notrack/noreport. This was also brought into the Conjurefile now.

Signed-off-by: Adam Stokes <battlemidget@users.noreply.github.com>