### PR TITLE
Fix Conjurefile opts not being used in some places

### DIFF
--- a/conjureup/app.py
+++ b/conjureup/app.py
@@ -93,16 +93,16 @@ def parse_options(argv):
                         'controller.', metavar='<host>.maas')
     parser.add_argument(
         '--version', action='version', version='%(prog)s {}'.format(VERSION))
-    parser.add_argument('--notrack', action='store_true',
-                        dest='notrack',
+    parser.add_argument('--no-track', '--notrack', action='store_true',
+                        dest='no_track',
                         help='Opt out of sending anonymous usage '
                         'information to Canonical.')
-    parser.add_argument('--noreport', action='store_true',
-                        dest='noreport',
+    parser.add_argument('--no-report', '--noreport', action='store_true',
+                        dest='no_report',
                         help='Opt out of sending anonymous error reports '
                         'to Canonical.')
-    parser.add_argument('--nosync', action='store_true',
-                        dest='nosync',
+    parser.add_argument('--no-sync', '--nosync', action='store_true',
+                        dest='no_sync',
                         help='Opt out of syncing with spells '
                         'registry.')
     parser.add_argument('--color', type=str, default='auto',
@@ -163,12 +163,12 @@ def apply_proxy():
     """ Sets up proxy information.
     """
     # Apply proxy information
-    if app.argv.http_proxy:
-        os.environ['HTTP_PROXY'] = app.argv.http_proxy
-        os.environ['http_proxy'] = app.argv.http_proxy
-    if app.argv.https_proxy:
-        os.environ['HTTPS_PROXY'] = app.argv.https_proxy
-        os.environ['https_proxy'] = app.argv.https_proxy
+    if app.conjurefile['http-proxy']:
+        os.environ['HTTP_PROXY'] = app.conjurefile['http-proxy']
+        os.environ['http_proxy'] = app.conjurefile['http-proxy']
+    if app.conjurefile['https-proxy']:
+        os.environ['HTTPS_PROXY'] = app.conjurefile['https-proxy']
+        os.environ['https_proxy'] = app.conjurefile['https-proxy']
 
 
 def show_env():
@@ -220,6 +220,24 @@ def main():
 
     utils.set_terminal_title("conjure-up")
     opts = parse_options(sys.argv[1:])
+    opt_defaults = parse_options([])
+
+    # Load conjurefile, merge any overridding options from argv
+    if not opts.conf_file:
+        opts.conf_file = []
+    if pathlib.Path('~/.config/conjure-up.conf').expanduser().exists():
+        opts.conf_file.insert(
+            0, pathlib.Path('~/.config/conjure-up.conf').expanduser())
+    if (pathlib.Path('.') / 'Conjurefile').exists():
+        opts.conf_file.insert(0, pathlib.Path('.') / 'Conjurefile')
+    for conf in opts.conf_file:
+        if not conf.exists():
+            print("Unable to locate config {} for processing.".format(
+                str(conf)))
+            sys.exit(1)
+
+    app.conjurefile = Conjurefile.load(opts.conf_file)
+    app.conjurefile.merge_argv(opts, opt_defaults)
 
     if opts.gen_config:
         Conjurefile.print_tpl()
@@ -237,24 +255,6 @@ def main():
     app.env = os.environ.copy()
     app.env['KV_DB'] = kv_db
     app.config = {'metadata': None}
-    app.argv = opts
-
-    # Load conjurefile, merge any overridding options from argv
-    if not app.argv.conf_file:
-        app.argv.conf_file = []
-    if pathlib.Path('~/.config/conjure-up.conf').expanduser().exists():
-        app.argv.conf_file.insert(
-            0, pathlib.Path('~/.config/conjure-up.conf').expanduser())
-    if (pathlib.Path('.') / 'Conjurefile').exists():
-        app.argv.conf_file.insert(0, pathlib.Path('.') / 'Conjurefile')
-    for conf in app.argv.conf_file:
-        if not conf.exists():
-            print("Unable to locate config {} for processing.".format(
-                str(conf)))
-            sys.exit(1)
-
-    app.conjurefile = Conjurefile.load(app.argv.conf_file)
-    app.conjurefile.merge_argv(app.argv)
 
     app.log = setup_logging(app,
                             os.path.join(opts.cache_dir, 'conjure-up.log'),
@@ -264,8 +264,8 @@ def main():
     juju.set_bin_path()
     juju.set_wait_path()
 
-    app.notrack = app.conjurefile.get('notrack', False)
-    app.noreport = app.conjurefile.get('noreport', False)
+    app.no_track = app.conjurefile['no-track']
+    app.no_report = app.conjurefile['no-report']
 
     # Grab current LXD and Juju versions
     app.log.debug("Juju version: {}, "
@@ -279,19 +279,19 @@ def main():
     app.session_id = os.getenv('CONJURE_TEST_SESSION_ID',
                                str(uuid.uuid4()))
 
-    spells_dir = app.argv.spells_dir
+    spells_dir = app.conjurefile['spells-dir']
 
     app.config['spells-dir'] = spells_dir
     spells_index_path = os.path.join(app.config['spells-dir'],
                                      'spells-index.yaml')
     spells_registry_branch = os.getenv('CONJUREUP_REGISTRY_BRANCH', 'master')
 
-    if not app.argv.nosync:
+    if not app.conjurefile['no-sync']:
         if not os.path.exists(spells_dir):
             utils.info("No spells found, syncing from registry, please wait.")
         try:
             download_or_sync_registry(
-                app.argv.registry,
+                app.conjurefile['registry'],
                 spells_dir, branch=spells_registry_branch)
         except subprocess.CalledProcessError as e:
             if not os.path.exists(spells_dir):
@@ -402,10 +402,10 @@ def main():
         StepModel.load_spell_steps()
         AddonModel.load_spell_addons()
 
-    app.env['CONJURE_UP_CACHEDIR'] = app.argv.cache_dir
+    app.env['CONJURE_UP_CACHEDIR'] = app.conjurefile['cache-dir']
     app.env['PATH'] = "/snap/bin:{}".format(app.env['PATH'])
 
-    if app.argv.show_env:
+    if app.conjurefile['show-env']:
         if app.endpoint_type in [None, EndpointType.LOCAL_SEARCH]:
             utils.error("Please specify a spell for headless mode.")
             sys.exit(1)

--- a/conjureup/app_config.py
+++ b/conjureup/app_config.py
@@ -74,9 +74,6 @@ class AppConfig:
     # Selected bundle from a Variant view
     current_bundle = None
 
-    # cli opts
-    argv = None
-
     # Is JAAS supported by the current spell
     jaas_ok = True
 
@@ -99,10 +96,10 @@ class AppConfig:
     metadata_controller = None
 
     # disable telemetry tracking
-    notrack = False
+    no_track = False
 
     # disable automatic error reporting
-    noreport = False
+    no_report = False
 
     # Application environment passed to processing steps
     env = None

--- a/conjureup/controllers/clouds/tui.py
+++ b/conjureup/controllers/clouds/tui.py
@@ -10,8 +10,8 @@ class CloudsController(BaseCloudController):
         return juju.get_controller(controller) is not None
 
     def finish(self):
-        if app.argv.model:
-            app.provider.model = app.argv.model
+        if app.conjurefile['model']:
+            app.provider.model = app.conjurefile['model']
         else:
             app.provider.model = utils.gen_model()
 
@@ -19,7 +19,8 @@ class CloudsController(BaseCloudController):
 
     async def _check_lxd_compat(self):
         utils.info(
-            "Summoning {} to {}".format(app.argv.spell, app.provider.cloud))
+            "Summoning {} to {}".format(app.conjurefile['spell'],
+                                        app.provider.cloud))
         if app.provider.cloud_type == cloud_types.LOCALHOST:
             app.provider._set_lxd_dir_env()
             client_compatible = await app.provider.is_client_compatible()

--- a/conjureup/controllers/controllerpicker/tui.py
+++ b/conjureup/controllers/controllerpicker/tui.py
@@ -6,7 +6,7 @@ from . import common
 class ControllerPicker(common.BaseControllerPicker):
     def render(self):
         self.check_jaas()
-        self.finish(app.argv.controller)
+        self.finish(app.conjurefile['controller'])
 
 
 _controller_class = ControllerPicker

--- a/conjureup/controllers/destroy/tui.py
+++ b/conjureup/controllers/destroy/tui.py
@@ -5,8 +5,8 @@ from conjureup.telemetry import track_event
 
 class Destroy:
     def render(self):
-        app.loop.create_task(self.do_destroy(app.argv.model,
-                                             app.argv.controller))
+        app.loop.create_task(self.do_destroy(app.conjurefile['model'],
+                                             app.conjurefile['controller']))
 
     async def do_destroy(self, model, controller):
         track_event("Destroying model", "Destroy", "")

--- a/conjureup/controllers/spellpicker/gui.py
+++ b/conjureup/controllers/spellpicker/gui.py
@@ -13,7 +13,7 @@ class SpellPickerController:
         if spellname != app.config.get('spell'):
             utils.set_terminal_title("conjure-up {}".format(spellname))
             utils.set_chosen_spell(spellname,
-                                   os.path.join(app.argv.cache_dir,
+                                   os.path.join(app.conjurefile['cache-dir'],
                                                 spellname))
             download_local(os.path.join(app.config['spells-dir'],
                                         spellname),
@@ -29,7 +29,7 @@ class SpellPickerController:
         if app.endpoint_type is None:
             spells += utils.find_spells()
         elif app.endpoint_type == EndpointType.LOCAL_SEARCH:
-            spells = utils.find_spells_matching(app.argv.spell)
+            spells = utils.find_spells_matching(app.conjurefile['spell'])
         else:
             raise Exception("Unexpected endpoint type {}".format(
                 app.endpoint_type))

--- a/conjureup/events.py
+++ b/conjureup/events.py
@@ -150,7 +150,7 @@ def handle_exception(loop, context):
 
     if any(pred(exc) for pred in NOTRACK_EXCEPTIONS):
         app.log.debug('Would not track exception: {}'.format(exc))
-    if not (app.noreport or any(pred(exc) for pred in NOTRACK_EXCEPTIONS)):
+    if not (app.no_report or any(pred(exc) for pred in NOTRACK_EXCEPTIONS)):
         track_exception(str(exc))
         utils.sentry_report(exc_info=exc_info)
 

--- a/conjureup/juju.py
+++ b/conjureup/juju.py
@@ -225,26 +225,26 @@ async def bootstrap(controller, cloud, model='conjure-up', series="xenial",
                 add_config(k, v)
 
     add_config("image-stream", "daily")
-    if app.argv.http_proxy:
-        add_config("http-proxy", app.argv.http_proxy)
-    if app.argv.https_proxy:
-        add_config("https-proxy", app.argv.https_proxy)
-    if app.argv.apt_http_proxy:
-        add_config("apt-http-proxy", app.argv.apt_http_proxy)
-    if app.argv.apt_https_proxy:
-        add_config("apt-https-proxy", app.argv.apt_https_proxy)
-    if app.argv.no_proxy:
-        add_config("no-proxy", app.argv.no_proxy)
-    if app.argv.bootstrap_timeout:
-        add_config("bootstrap-timeout", app.argv.bootstrap_timeout)
-    if app.argv.bootstrap_to:
-        cmd.extend(["--to", app.argv.bootstrap_to])
+    if app.conjurefile['http-proxy']:
+        add_config("http-proxy", app.conjurefile['http-proxy'])
+    if app.conjurefile['https-proxy']:
+        add_config("https-proxy", app.conjurefile['https-proxy'])
+    if app.conjurefile['apt-http-proxy']:
+        add_config("apt-http-proxy", app.conjurefile['apt-http-proxy'])
+    if app.conjurefile['apt-https-proxy']:
+        add_config("apt-https-proxy", app.conjurefile['apt-https-proxy'])
+    if app.conjurefile['no-proxy']:
+        add_config("no-proxy", app.conjurefile['no-proxy'])
+    if app.conjurefile['bootstrap-timeout']:
+        add_config("bootstrap-timeout", app.conjurefile['bootstrap-timeout'])
+    if app.conjurefile['bootstrap-to']:
+        cmd.extend(["--to", app.conjurefile['bootstrap-to']])
 
     cmd.extend(["--bootstrap-series", series])
     if credential is not None:
         cmd.extend(["--credential", credential])
 
-    if app.argv.debug:
+    if app.conjurefile['debug']:
         cmd.append("--debug")
     app.log.debug("bootstrap cmd: {}".format(cmd))
 

--- a/conjureup/models/step.py
+++ b/conjureup/models/step.py
@@ -234,7 +234,7 @@ class StepModel:
         app.env['JUJU_CONTROLLER'] = app.provider.controller
         app.env['JUJU_MODEL'] = app.provider.model
         app.env['JUJU_REGION'] = app.provider.region or ''
-        app.env['CONJURE_UP_SPELLSDIR'] = app.argv.spells_dir
+        app.env['CONJURE_UP_SPELLSDIR'] = app.conjurefile['spells-dir']
         app.env['CONJURE_UP_SESSION_ID'] = app.session_id
 
         if provider_type == "maas":
@@ -276,7 +276,7 @@ class StepModel:
 
         # special case for 00_deploy-done to report masked
         # charm hook failures that were retried automatically
-        if not app.noreport:
+        if not app.no_report:
             failed_apps = set()  # only report each charm once
             for line in err_log.splitlines():
                 if 'hook failure, will retry' in line:

--- a/conjureup/telemetry.py
+++ b/conjureup/telemetry.py
@@ -15,7 +15,7 @@ TELEMETRY_ASYNC_QUEUE = "telemetry-async-queue"
 
 def track_screen(screen_name):
     app.log.debug('Showing screen: {}'.format(screen_name))
-    if app.notrack:
+    if app.no_track:
         return
     args = dict(cd=screen_name,
                 t="screenview")
@@ -29,7 +29,7 @@ def track_screen(screen_name):
 def track_event(category, action, label):
     ""
     app.log.debug('{}: {} {}'.format(category, action, label))
-    if app.notrack:
+    if app.no_track:
         return
     args = dict(ec=category,
                 ea=action,
@@ -43,7 +43,7 @@ def track_event(category, action, label):
 
 def track_exception(description, is_fatal=True):
     ""
-    if app.notrack:
+    if app.no_track:
         return
     exf = 1 if is_fatal else 0
     args = dict(t='exception',

--- a/conjureup/ui/__init__.py
+++ b/conjureup/ui/__init__.py
@@ -13,7 +13,7 @@ from conjureup.ui.views.shutdown import ShutdownView
 class ConjureUI(Frame):
 
     def show_exception_message(self, ex):
-        _cache_dir = Path(app.argv.cache_dir) / 'conjure-up.log'
+        _cache_dir = Path(app.conjurefile['cache-dir']) / 'conjure-up.log'
         errmsg = str(ex)
         errmsg += (
             "\n\n Review log messages at {} "

--- a/conjureup/utils.py
+++ b/conjureup/utils.py
@@ -208,7 +208,7 @@ def sentry_report(message=None, exc_info=None, tags=None, **kwargs):
 
 
 def _sentry_report(message=None, exc_info=None, tags=None, **kwargs):
-    if app.noreport:
+    if app.no_report:
         return
 
     try:
@@ -287,14 +287,14 @@ def snap_version():
 
 
 def send_msg(msg, label, color, attrs=['bold']):
-    if app.argv.color == 'auto':
+    if app.conjurefile['color'] == 'auto':
         colorized = sys.__stdout__.isatty()
-    elif app.argv.color == 'always':
+    elif app.conjurefile['color'] == 'always':
         colorized = True
     else:
         colorized = False
 
-    if app.argv.debug:
+    if app.conjurefile['debug']:
         print("[{}] {}".format(label, msg))
     elif colorized:
         cprint("[{}] ".format(label),
@@ -506,7 +506,7 @@ def setup_metadata_controller():
                 "Could not determine a bundle to download, please make sure "
                 "the spell contains a 'bundle-name' field."
             )
-        bundle_channel = app.argv.channel
+        bundle_channel = app.conjurefile['channel']
 
         app.log.debug("Pulling bundle for {} from channel: {}".format(
             bundle_name, bundle_channel))
@@ -533,11 +533,11 @@ def setup_metadata_controller():
             fragment = yaml.safe_load(step.bundle_add.read_text())
             bundle_data.apply(fragment)
 
-    if app.argv.bundle_remove:
-        fragment = yaml.safe_load(app.argv.bundle_remove.read_text())
+    if app.conjurefile['bundle-remove']:
+        fragment = yaml.safe_load(app.conjurefile['bundle-remove'].read_text())
         bundle_data.subtract(fragment)
-    if app.argv.bundle_add:
-        fragment = yaml.safe_load(app.argv.bundle_add.read_text())
+    if app.conjurefile['bundle-add']:
+        fragment = yaml.safe_load(app.conjurefile['bundle-add'].read_text())
         bundle_data.apply(fragment)
 
     app.current_bundle = bundle_data

--- a/test/Conjurefile
+++ b/test/Conjurefile
@@ -1,6 +1,7 @@
 # -*- mode:yaml; -*-
 
-cache_dir: '/tmp/testxxxx'
+cache-dir: '/tmp/testxxxx'
 registry: 'https://github.com/battlemidget/spells.git'
 
 cloud: 'aws'
+color: 'always'

--- a/test/test_conjurefile.py
+++ b/test/test_conjurefile.py
@@ -23,15 +23,29 @@ class ConjurefileTestCase(unittest.TestCase):
         "conjurefile.test_argv_override"
         args = argparse.Namespace()
         args.registry = 'https://github.com/conjure-up/spells.git'
+        args.cache_dir = '/tmp/testyyyy'  # hyphen, in file
+        args.no_sync = True  # hyphen, not in file
+        args.color = 'auto'  # default, in file
+        args.spell = '_unspecified_spell'  # default, not in file
+        defaults = argparse.Namespace()
+        defaults.registry = None
+        defaults.cache_dir = None
+        defaults.no_sync = False
+        defaults.color = 'auto'
+        defaults.spell = '_unspecified_spell'
         assert self.conjurefile['registry'] == (
             'https://github.com/battlemidget/spells.git')
-        self.conjurefile.merge_argv(args)
+        self.conjurefile.merge_argv(args, defaults)
         assert self.conjurefile['registry'] == (
             'https://github.com/conjure-up/spells.git')
+        assert self.conjurefile['cache-dir'] == '/tmp/testyyyy'
+        assert self.conjurefile['no-sync'] is True
+        assert self.conjurefile['color'] == 'always'
+        assert self.conjurefile['spell'] == '_unspecified_spell'
 
-    def test_conjurefile_debug_enabled(self):
-        "conjurefile.test_debug_enabled"
-        assert self.conjurefile['debug']
+    def test_conjurefile_debug_disabled(self):
+        "conjurefile.test_debug_disabled"
+        assert not self.conjurefile['debug']
 
     def test_conjurefile_melddict_level_1(self):
         "conjurefile.test_melddict_level_1"
@@ -51,6 +65,9 @@ class ConjurefileTestCase(unittest.TestCase):
         args = argparse.Namespace()
         args.spell = 'canonical-kubernetes'
         args.cloud = 'aws/us-east-1'
-        self.conjurefile.merge_argv(args)
+        defaults = argparse.Namespace()
+        defaults.spell = None
+        defaults.cloud = None
+        self.conjurefile.merge_argv(args, defaults)
         assert self.conjurefile['spell'] == 'canonical-kubernetes'
         assert self.conjurefile['cloud'] == 'aws/us-east-1'

--- a/test/test_controllers_clouds_tui.py
+++ b/test/test_controllers_clouds_tui.py
@@ -75,6 +75,7 @@ class CloudsTUIFinishTestCase(unittest.TestCase):
             'conjureup.controllers.clouds.tui.app')
         self.mock_app = self.app_patcher.start()
         self.mock_app.ui = MagicMock(name="app.ui")
+        self.mock_app.conjurefile = {}
         self.ev_app_patcher = patch(
             'conjureup.events.app', self.mock_app)
         self.ev_app_patcher.start()
@@ -98,7 +99,7 @@ class CloudsTUIFinishTestCase(unittest.TestCase):
     def test_finish_w_model(self):
         "clouds.finish with an existing controller"
         self.mock_gcc.return_value = 'testcontroller'
-        self.mock_app.argv.model = 'testmodel'
+        self.mock_app.conjurefile['model'] = 'testmodel'
         self.mock_app.provider.cloud = 'cloud'
         self.controller.finish()
         self.mock_controllers.use.assert_has_calls([
@@ -107,8 +108,9 @@ class CloudsTUIFinishTestCase(unittest.TestCase):
     def test_finish_no_model(self):
         "clouds.finish without existing controller"
         self.mock_gcc.return_value = None
-        self.mock_app.argv.cloud = 'testcloud'
-        self.mock_app.argv.controller = None
+        self.mock_app.conjurefile['cloud'] = 'testcloud'
+        self.mock_app.conjurefile['controller'] = None
+        self.mock_app.conjurefile['model'] = None
         self.controller.finish()
         self.mock_controllers.use.assert_has_calls([
             call('credentials'), call().render()])

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -62,11 +62,11 @@ class UtilsTestCase(unittest.TestCase):
         app.headless = False
         juju_version.return_value = '2.j'
 
-        app.noreport = True
+        app.no_report = True
         utils._sentry_report('message', tags={'foo': 'bar'})
         assert not app.sentry.capture.called
 
-        app.noreport = False
+        app.no_report = False
         utils._sentry_report('message', tags={'foo': 'bar'})
         app.sentry.capture.assert_called_once_with(
             'raven.events.Message',

--- a/tools/mockups/base.py
+++ b/tools/mockups/base.py
@@ -13,8 +13,8 @@ class MockupView(BaseView):
             if key in ['q', 'Q']:
                 raise ExitMainLoop()
 
-        app.notrack = True
-        app.noreport = True
+        app.no_track = True
+        app.no_report = True
         app.ui = ConjureUI()
         EventLoop.build_loop(app.ui, STYLES, unhandled_input=_stop)
         super().show()


### PR DESCRIPTION
Also, fix CLI overrides not being honored unless already present in Conjurefile.

Also, standardize CLI opts to consistently use hyphens, with aliases for backwards compatibility, as well as hyphenated CLI opts never being honored in Conjurefile.