### PR TITLE
Fix missed usages of argv/opts values to Conjurefile

### DIFF
--- a/conjureup/app.py
+++ b/conjureup/app.py
@@ -236,7 +236,11 @@ def main():
                 str(conf)))
             sys.exit(1)
 
-    app.conjurefile = Conjurefile.load(opts.conf_file)
+    try:
+        app.conjurefile = Conjurefile.load(opts.conf_file)
+    except ValueError as e:
+        print(str(e))
+        sys.exit(1)
     app.conjurefile.merge_argv(opts, opt_defaults)
 
     if app.conjurefile['gen-config']:

--- a/conjureup/models/conjurefile.py
+++ b/conjureup/models/conjurefile.py
@@ -90,7 +90,13 @@ class Conjurefile(MeldDict):
         """
         cf = Conjurefile()
         for p in paths:
-            cf += yaml.safe_load(p.read_text())
+            try:
+                new_data = yaml.safe_load(p.read_text())
+                if not isinstance(new_data, dict):
+                    raise ValueError('contents are not a mapping')
+            except Exception as e:
+                raise ValueError('Unable to load {}: {}'.format(p, e))
+            cf += new_data
         return cf
 
     def merge_argv(self, argv, defaults):


### PR DESCRIPTION
Ensure that all CLI opts go through, and can be set by, the Conjurefile.  Also improve error handling when Conjurefile fails to load.