### PR TITLE
Replace app data after configure rather than merge

### DIFF
--- a/conjureup/ui/views/applicationconfigure.py
+++ b/conjureup/ui/views/applicationconfigure.py
@@ -157,9 +157,8 @@ class ApplicationConfigureView(BaseView):
         self.application.options = self.options_copy
         self.application.num_units = self.num_units_copy
         self.application.constraints = self.constraints_copy
-        # Apply fragment updates to bundle
-        app.current_bundle.apply({"applications": {
-            self.application.name: self.application.to_dict()
-        }})
+        # Replace application data with updated info
+        new_data = self.application.to_dict()
+        app.current_bundle['applications'][self.application.name] = new_data
 
         self.prev_screen()


### PR DESCRIPTION
Mostly it's equivalent, but the list of placement directives was getting merged and thus duplicated every time the app was configured.  Replacing the data rather than merging seems to be the more correct approach.

Fixes #1435