### PR TITLE
Pass model-config options from conjurefile to juju

### DIFF
--- a/conjureup/juju.py
+++ b/conjureup/juju.py
@@ -12,6 +12,7 @@ import yaml
 from juju.client.jujudata import FileJujuData
 from juju.controller import Controller
 from juju.model import Model
+from melddict import MeldDict
 
 from conjureup import consts, errors, events, utils
 from conjureup.app_config import app
@@ -220,6 +221,8 @@ async def bootstrap(controller, cloud, model='conjure-up', series="xenial",
     def add_config(k, v):
         cmd.extend(["--config", "{}={}".format(k, v)])
 
+    app.provider.model_defaults = MeldDict(app.provider.model_defaults or {})
+    app.provider.model_defaults.add(app.conjurefile.get('model-config', {}))
     if app.provider.model_defaults:
         for k, v in app.provider.model_defaults.items():
             if v is not None:
@@ -240,10 +243,6 @@ async def bootstrap(controller, cloud, model='conjure-up', series="xenial",
         add_config("bootstrap-timeout", app.conjurefile['bootstrap-timeout'])
     if app.conjurefile['bootstrap-to']:
         cmd.extend(["--to", app.conjurefile['bootstrap-to']])
-    if app.conjurefile.get('model-config', None):
-        for k, v in app.conjurefile['model-config'].items():
-            if v is not None:
-                add_config(k, v)
 
     cmd.extend(["--bootstrap-series", series])
     if credential is not None:

--- a/conjureup/juju.py
+++ b/conjureup/juju.py
@@ -190,7 +190,8 @@ async def create_model():
             model_name=app.provider.model,
             cloud_name=app.provider.cloud,
             region=app.provider.region,
-            credential_name=app.provider.credential)
+            credential_name=app.provider.credential,
+            config=app.conjurefile.get('model-config', None))
         events.ModelConnected.set()
     finally:
         await controller.disconnect()
@@ -239,6 +240,10 @@ async def bootstrap(controller, cloud, model='conjure-up', series="xenial",
         add_config("bootstrap-timeout", app.conjurefile['bootstrap-timeout'])
     if app.conjurefile['bootstrap-to']:
         cmd.extend(["--to", app.conjurefile['bootstrap-to']])
+    if app.conjurefile.get('model-config', None):
+        for k, v in app.conjurefile['model-config'].items():
+            if v is not None:
+                add_config(k, v)
 
     cmd.extend(["--bootstrap-series", series])
     if credential is not None:

--- a/conjureup/models/conjurefile.py
+++ b/conjureup/models/conjurefile.py
@@ -42,6 +42,15 @@ class Conjurefile(MeldDict):
     # (Optional) Model name. This can be any arbitrary name of your Juju Model
     # model: k8s-1
 
+    # (Optional) Model config. Options to set on a controller model
+    # https://docs.jujucharms.com/devel/en/models-config#list-of-model-keys
+    #
+    # Note: See section Proxy below for setting apt(s)/http(s) proxy settings
+    #
+    # model-config:
+    #   vpc-id: VPC1234
+    #   apt-mirror: http://archive.ubuntu.com/ubuntu/
+
     # For the Kubernetes spell you may want Helm installed so you can deploy
     # charts to the cluster.
     # addons:

--- a/test/Conjurefile
+++ b/test/Conjurefile
@@ -5,3 +5,6 @@ registry: 'https://github.com/battlemidget/spells.git'
 
 cloud: 'aws'
 color: 'always'
+
+model-config:
+  extra-info: "This is a model level config setting"


### PR DESCRIPTION
Allows you to set things like `vpc-id` in conjurefile and be applied to your models.

Test with:

conjure-up -c test/Conjurefile
juju model-config and check extra-info item

Signed-off-by: Adam Stokes <battlemidget@users.noreply.github.com>