### PR TITLE
Put color as an option

### DIFF
--- a/conjureup/destroy.py
+++ b/conjureup/destroy.py
@@ -47,6 +47,10 @@ def parse_options(argv):
     parser.add_argument('-c', '--conf-file', dest='conf_file',
                         help='Path to configuration file', action='append',
                         type=pathlib.Path)
+    parser.add_argument('--color', type=str, default='auto',
+                        choices=['auto', 'never', 'always'],
+                        help='Whether to use colorized output '
+                             'in headless mode.')
 
     return parser.parse_args(argv)
 


### PR DESCRIPTION
Conjure-down uses colorised output. If there is no option defined in the `configure-up.conf` file, conjure-down fails silently with 

```
Error in cleanup code: 'color'
Traceback (most recent call last):
    File "/snap/conjure-up/1004/lib/python3.6/site-packages/conjureup/events.py", line 182, in shutdown_watcher
    utils.warning('Shutting down')
    File "/snap/conjure-up/1004/lib/python3.6/site-packages/conjureup/utils.py", line 317, in warning
    send_msg(msg, 'warning', 'yellow')
    File "/snap/conjure-up/1004/lib/python3.6/site-packages/conjureup/utils.py", line 290, in send_msg
    if app.conjurefile['color'] == 'auto':
KeyError: 'color'
```

This change loads color with a default.