### PR TITLE
Dont track LXD network errors

### DIFF
--- a/conjureup/controllers/lxdsetup/gui.py
+++ b/conjureup/controllers/lxdsetup/gui.py
@@ -1,15 +1,11 @@
 import ipaddress
 from subprocess import CalledProcessError
 
-from conjureup import controllers, utils
+from conjureup import controllers, errors, utils
 from conjureup.app_config import app
 from conjureup.ui.views.lxdsetup import LXDSetupView
 
 from . import common
-
-
-class LXDSetupControllerError(Exception):
-    pass
 
 
 class LXDSetupController(common.BaseLXDSetupController):
@@ -46,7 +42,7 @@ class LXDSetupController(common.BaseLXDSetupController):
         try:
             iface = ipaddress.IPv4Interface("{}/24".format(phys_iface_addr))
         except ipaddress.AddressValueError:
-            raise LXDSetupControllerError(
+            raise errors.LXDSetupControllerError(
                 "Unable to determine ip address of {network}, please double "
                 "check `lxc network edit {network}` and make "
                 "sure an address is associated with that bridge.".format(

--- a/conjureup/errors.py
+++ b/conjureup/errors.py
@@ -24,3 +24,7 @@ class AppConfigAttributeError(Exception):
 
 class MAASConfigError(Exception):
     "An error representing a MAAS configuration issue."
+
+
+class LXDSetupControllerError(Exception):
+    "Unable to determine LXD network/storage"

--- a/conjureup/events.py
+++ b/conjureup/events.py
@@ -127,6 +127,7 @@ NOTRACK_EXCEPTIONS = [
     lambda exc: isinstance(exc, LXDSetupViewError),
     lambda exc: isinstance(exc, errors.BootstrapInterrupt),
     lambda exc: isinstance(exc, errors.MAASConfigError),
+    lambda exc: isinstance(exc, errors.LXDSetupControllerError),
 ]
 
 


### PR DESCRIPTION
We provide informative errors to the user on what they need to do, skip sending
this to sentry.

Fixes #1454

Signed-off-by: Adam Stokes <battlemidget@users.noreply.github.com>