### PR TITLE
Add network and storage check for LXD to cloud screen

### DIFF
--- a/conjureup/app.py
+++ b/conjureup/app.py
@@ -24,7 +24,7 @@ from ubuntui.ev import EventLoop
 from ubuntui.palette import STYLES
 
 from conjureup import __version__ as VERSION
-from conjureup import charm, consts, controllers, events, juju, utils
+from conjureup import charm, consts, controllers, errors, events, juju, utils
 from conjureup.app_config import app
 from conjureup.download import (
     EndpointType,
@@ -37,7 +37,7 @@ from conjureup.download import (
 from conjureup.log import setup_logging
 from conjureup.models.addon import AddonModel
 from conjureup.models.conjurefile import Conjurefile
-from conjureup.models.provider import SchemaErrorUnknownCloud, load_schema
+from conjureup.models.provider import load_schema
 from conjureup.models.step import StepModel
 from conjureup.telemetry import SENTRY_DSN, track_event, track_screen
 from conjureup.ui import ConjureUI
@@ -466,7 +466,7 @@ def main():
 
             try:
                 app.provider.load(cloud)
-            except SchemaErrorUnknownCloud as e:
+            except errors.SchemaCloudError as e:
                 utils.error(e)
                 sys.exit(1)
 

--- a/conjureup/errors.py
+++ b/conjureup/errors.py
@@ -1,3 +1,11 @@
+class MessageException(Exception):
+    message = "General error"
+
+    def __init__(self, *args, **kwargs):
+        self.message = self.message.format(*args, **kwargs)
+        super().__init__(self.message)
+
+
 class BootstrapError(Exception):
     "An error when bootstrapping a new controller"
 
@@ -26,9 +34,51 @@ class MAASConfigError(Exception):
     "An error representing a MAAS configuration issue."
 
 
-class LocalhostLXDBinaryNotFound(Exception):
-    "Unable to find a LXD binary for localhost deployment"
+class SchemaError(MessageException):
+    message = "General Schema error"
 
 
-class LXDSetupControllerError(Exception):
-    "Unable to determine LXD network/storage"
+class SchemaCloudError(SchemaError):
+    message = ("Unable to find cloud for {}, you can double check that "
+               "cloud exists by running `juju clouds`. Please see "
+               "`juju help clouds` for more information.")
+
+
+class SchemaCredentialError(SchemaError):
+    message = ("Unable to find credentials for {}, you can double check "
+               "what credentials you do have available by running "
+               "`juju credentials`. Please see `juju help add-credential` "
+               "for more information.")
+
+
+class LXDError(MessageException):
+    message = "General LXD error"
+
+
+class LXDBinaryNotFoundError(LXDError):
+    message = ("LXD not found.  To install, see "
+               "https://docs.conjure-up.io/devel/en/#users-of-lxd")
+
+
+class LXDCompatibilityError(LXDError):
+    message = ("LXD version 3.0.0 or greater is required. "
+               "To install or upgrade, see "
+               "https://docs.conjure-up.io/devel/en/#users-of-lxd")
+
+
+class LXDParseError(LXDCompatibilityError):
+    message = ("Unable to parse JSON output from LXD, does "
+               "`{} query --wait -X GET /1.0` "
+               "return info about the LXD server?")
+
+
+class LXDNetworkError(LXDError):
+    message = ("Unable to find IPv4-only network bridge for LXD. "
+               "For information on configuring networking for LXD, see "
+               "https://docs.conjure-up.io/devel/en/#users-of-lxd")
+
+
+class LXDStorageError(LXDError):
+    message = ("Unable to find a storage pool for LXD. "
+               "For information on configuring storage for LXD, see "
+               "https://docs.conjure-up.io/devel/en/#users-of-lxd")

--- a/conjureup/events.py
+++ b/conjureup/events.py
@@ -10,7 +10,6 @@ from urwid import ExitMainLoop
 from conjureup import errors, utils
 from conjureup.app_config import app
 from conjureup.telemetry import track_exception
-from conjureup.ui.views.lxdsetup import LXDSetupViewError
 
 
 class Event(asyncio.Event):
@@ -124,11 +123,10 @@ LXDAvailable = Event('LXDAvailable')
 NOTRACK_EXCEPTIONS = [
     lambda exc: isinstance(exc, OSError) and exc.errno == errno.ENOSPC,
     lambda exc: isinstance(exc, utils.SudoError),
-    lambda exc: isinstance(exc, LXDSetupViewError),
-    lambda exc: isinstance(exc, errors.LocalhostLXDBinaryNotFound),
     lambda exc: isinstance(exc, errors.BootstrapInterrupt),
     lambda exc: isinstance(exc, errors.MAASConfigError),
-    lambda exc: isinstance(exc, errors.LXDSetupControllerError),
+    lambda exc: isinstance(exc, errors.SchemaError),
+    lambda exc: isinstance(exc, errors.LXDError),
 ]
 
 

--- a/conjureup/ui/views/cloud.py
+++ b/conjureup/ui/views/cloud.py
@@ -17,9 +17,7 @@ class CloudView(BaseView):
     default_disabled_msg = 'This cloud is disabled due to your selection of ' \
                            'spell or add-on. Please use the arrow keys to ' \
                            'select another cloud.'
-    lxd_unavailable_msg = ("LXD version 3.0.0 or greater is required. "
-                           "To install or upgrade, see "
-                           "https://docs.conjure-up.io/devel/en/#users-of-lxd")
+    lxd_unavailable_msg = "Checking for LXD..."
 
     def __init__(self, app, public_clouds, custom_clouds,
                  compatible_cloud_types, cb=None, back=None):
@@ -52,12 +50,15 @@ class CloudView(BaseView):
                                          self.default_disabled_msg)
         self.set_footer(msg)
 
-    def _enable_localhost_widget(self):
+    def _update_localhost_widget(self, enabled, message=None):
         """ Sets the proper widget for localhost availability
         """
         if self._items_localhost_idx is None:
             return
-        self.widget.contents[self._items_localhost_idx][0].enabled = True
+        widget = self.widget.contents[self._items_localhost_idx][0]
+        widget.enabled = enabled
+        if message:
+            widget.user_data['disabled_msg'] = message
         if self.widget.selected_widgets is None:
             self.widget.select_first()
         self.update_message()

--- a/conjureup/ui/views/lxdsetup.py
+++ b/conjureup/ui/views/lxdsetup.py
@@ -2,12 +2,9 @@ from ubuntui.utils import Color
 from ubuntui.widgets.hr import HR
 from urwid import Columns, Text
 
+from conjureup import errors
 from conjureup.ui.views.base import BaseView
 from conjureup.ui.widgets.selectors import RadioList
-
-
-class LXDSetupViewError(Exception):
-    pass
 
 
 class LXDSetupView(BaseView):
@@ -23,16 +20,10 @@ class LXDSetupView(BaseView):
             'storage-pool': RadioList(self.devices['storage-pools'].keys()),
         }
 
-        if not self.devices['networks'] or not self.devices['storage-pools']:
-            raise LXDSetupViewError(
-                "Could not locate any network or storage "
-                "devices to continue. Please make sure you "
-                "have at least 1 network bridge and 1 storage "
-                "pool: see `lxc network list` and "
-                "`lxc storage list`.  \n\n"
-                "Also note that the network bridge must not have "
-                "ipv6 enabled, to disable run `lxc network set "
-                "lxdbr0 ipv6.address none ipv6.nat false`")
+        if not self.devices['networks']:
+            raise errors.LXDNetworkError()
+        if not self.devices['storage-pools']:
+            raise errors.LXDStorageError()
 
         super().__init__()
 


### PR DESCRIPTION
To provide earlier and more detailed feedback on the reason for LXD not working, this adds the checks for networking and storage to the monitor task on the Cloud Selection screen.  If the networks or storage aren't available, localhost will be disabled and hilighting it will provide a specific message about why it is disabled.

With this, all of the LXD and schema error classes were refactored into the errors module.

Fixes #1431