### PR TITLE
Fix incorrect exception name for LXDBinaryNotFoundError

### DIFF
--- a/conjureup/models/provider.py
+++ b/conjureup/models/provider.py
@@ -350,7 +350,7 @@ class Localhost(BaseProvider):
             app.env['LXD_DIR'] = str(self.lxd_socket_dir)
             self.lxc_bin = '/usr/bin/lxc'
         else:
-            raise errors.LXDBinaryNotFound()
+            raise errors.LXDBinaryNotFoundError()
         app.log.debug("LXD environment set: binary {} lxd_dir {}".format(
             self.lxc_bin, self.lxd_socket_dir))
 


### PR DESCRIPTION
This was missed in the refactor in #1455

Fixes #1477