### PR TITLE
Fix case where no whitelisted clouds are enabled

### DIFF
--- a/conjureup/ui/widgets/selectors.py
+++ b/conjureup/ui/widgets/selectors.py
@@ -207,14 +207,18 @@ class SelectList(Pile):
     def select_first_of_values(self, values):
         opts = self.option_widgets
         for i, opt in enumerate(opts):
-            if opt.value not in values:
-                continue
-            if getattr(opt, 'enabled', True):
+            if opt.value in values and getattr(opt, 'enabled', True):
                 self.select_item(i)
                 break
         else:
             if opts:
-                self.select_item_by_value(values[0])
+                for i, opt in enumerate(opts):
+                    if opt.value in values:
+                        self.select_item(i)
+                        break
+                else:
+                    if opts:
+                        self.select_item(0)
 
 
 class CheckList(SelectList):


### PR DESCRIPTION
If there are whitelisted clouds, the first enabled one should be selected.  If none of the whitelisted clouds are enabled, the first one in the list that's in the whitelist should be selected.  If none of the whitelisted clouds are in the list, the first one in the list should be selected.

Fixes #1487
Fixes #1491