### PR TITLE
Update libjuju 0.9.1

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 aiofiles==0.3.1
 Jinja2==2.9.6
-juju==0.9.0
+juju==0.9.1
 juju-wait==2.6.3
 prettytable==0.7.2
 progressbar2==3.20.0
@@ -18,5 +18,3 @@ awscli==1.11.123
 pyvmomi==6.5.0.2017.5-1
 kv==0.3.0
 melddict==1.0.1
-# NB: Remove once websockets 5.0.2 is out
-git+https://github.com/aaugustin/websockets


### PR DESCRIPTION
This removes the hard requirement on upstream websockets module as 6.0 is
officially released.

Signed-off-by: Adam Stokes <battlemidget@users.noreply.github.com>