### PR TITLE
Add bootstrap series override to Conjurefile

### DIFF
--- a/conjureup/juju.py
+++ b/conjureup/juju.py
@@ -198,8 +198,7 @@ async def create_model():
         await controller.disconnect()
 
 
-async def bootstrap(controller, cloud, model='conjure-up', series="xenial",
-                    credential=None):
+async def bootstrap(controller, cloud, model='conjure-up', credential=None):
     """ Performs juju bootstrap
 
     If not LXD pass along the newly defined credentials
@@ -208,7 +207,6 @@ async def bootstrap(controller, cloud, model='conjure-up', series="xenial",
     controller: name of your controller
     cloud: name of local or public cloud to deploy to
     model: name of default model to create
-    series: define the bootstrap series defaults to xenial
     credential: credentials key
     """
     if app.provider.region is not None:
@@ -243,8 +241,9 @@ async def bootstrap(controller, cloud, model='conjure-up', series="xenial",
         add_config("bootstrap-timeout", app.conjurefile['bootstrap-timeout'])
     if app.conjurefile['bootstrap-to']:
         cmd.extend(["--to", app.conjurefile['bootstrap-to']])
+    if app.conjurefile['bootstrap-series']:
+        cmd.extend(["--bootstrap-series", app.conjurefile['bootstrap-series']])
 
-    cmd.extend(["--bootstrap-series", series])
     if credential is not None:
         cmd.extend(["--credential", credential])
 

--- a/conjureup/models/conjurefile.py
+++ b/conjureup/models/conjurefile.py
@@ -98,6 +98,9 @@ class Conjurefile(MeldDict):
     # Comma separate list of ips to not filter through proxy
     # no-proxy: 8.8.8.8,172.16.0.1
 
+    # Override Juju default controller series
+    # bootstrap-series: bionic
+
     # (Optional) Bundle Add
     # Add a Juju bundle fragment overlay
     # bundle-add: /home/user/my-bundle-fragment.yaml


### PR DESCRIPTION
The bootstrap series override is currently hard-coded to xenial, rather than just letting Juju choose its default. This removes the hard-coded value and replaces it with an optional override in the Conjurefile.

Fixes #1516