### PR TITLE
Fix KeyError if bootstrap-series not set

### DIFF
--- a/conjureup/app.py
+++ b/conjureup/app.py
@@ -96,6 +96,8 @@ def parse_options(argv):
                         help='The MAAS node hostname to deploy to. Useful '
                         'for using lower end hardware as the Juju admin '
                         'controller.', metavar='<host>.maas')
+    parser.add_argument('--bootstrap-series', dest='bootstrap_series',
+                        help="Override Juju's default controller series.")
     parser.add_argument(
         '--version', action='version', version='%(prog)s {}'.format(VERSION))
     parser.add_argument('--no-track', '--notrack', action='store_true',

--- a/conjureup/juju.py
+++ b/conjureup/juju.py
@@ -241,7 +241,7 @@ async def bootstrap(controller, cloud, model='conjure-up', credential=None):
         add_config("bootstrap-timeout", app.conjurefile['bootstrap-timeout'])
     if app.conjurefile['bootstrap-to']:
         cmd.extend(["--to", app.conjurefile['bootstrap-to']])
-    if app.conjurefile.get('bootstrap-series'):
+    if app.conjurefile['bootstrap-series']:
         cmd.extend(["--bootstrap-series", app.conjurefile['bootstrap-series']])
 
     if credential is not None:

--- a/conjureup/juju.py
+++ b/conjureup/juju.py
@@ -241,7 +241,7 @@ async def bootstrap(controller, cloud, model='conjure-up', credential=None):
         add_config("bootstrap-timeout", app.conjurefile['bootstrap-timeout'])
     if app.conjurefile['bootstrap-to']:
         cmd.extend(["--to", app.conjurefile['bootstrap-to']])
-    if app.conjurefile['bootstrap-series']:
+    if app.conjurefile.get('bootstrap-series'):
         cmd.extend(["--bootstrap-series", app.conjurefile['bootstrap-series']])
 
     if credential is not None:


### PR DESCRIPTION
Addresses issue reported in #1556, but it seems like there are multiple issues reported there.

```
2018-12-13 13:40:13,172 [DEBUG] conjure-up/openstack-novalxd - juju.py:213 - Bootstrapping to set region: {}
2018-12-13 13:40:13,175 [DEBUG] conjure-up/openstack-novalxd - events.py:52 - Setting Error at conjureup/events.py:149
2018-12-13 13:40:13,176 [ERROR] conjure-up/openstack-novalxd - events.py:161 - Unhandled exception in <Task finished coro=<BaseBootstrapController.run() done, defined at /snap/conjure-up/1036/lib/python3.6/site-packages/conjureup/controllers/juju/bootstrap/common.py:15> exception=KeyError('bootstrap-series',)>
Traceback (most recent call last):
  File "/snap/conjure-up/1036/lib/python3.6/site-packages/conjureup/controllers/juju/bootstrap/common.py", line 21, in run
    await self.do_bootstrap()
  File "/snap/conjure-up/1036/lib/python3.6/site-packages/conjureup/controllers/juju/bootstrap/common.py", line 54, in do_bootstrap
    credential=app.provider.credential)
  File "/snap/conjure-up/1036/lib/python3.6/site-packages/conjureup/juju.py", line 244, in bootstrap
    if app.conjurefile['bootstrap-series']:
KeyError: 'bootstrap-series'
```