### PR TITLE
Disable controllers which have no endpoints

### DIFF
--- a/conjureup/utils.py
+++ b/conjureup/utils.py
@@ -612,7 +612,7 @@ def is_valid_hostname(hostname):
     if hostname[-1] == ".":
         # strip exactly one dot from the right, if present
         hostname = hostname[:-1]
-    allowed = re.compile("(?!-)[A-Z\d\-\_]{1,63}(?<!-)$", re.IGNORECASE)
+    allowed = re.compile(r"(?!-)[A-Z\d\-\_]{1,63}(?<!-)$", re.IGNORECASE)
     return all(allowed.match(x) for x in hostname.split("."))
 
 

--- a/tools/graph-controllers.py
+++ b/tools/graph-controllers.py
@@ -5,8 +5,9 @@ import os
 import re
 from subprocess import PIPE, run
 
-controllers_use_re = re.compile("(\s*)\S*\s*controllers\.use\('(.*)'\).render")
-scope_re = re.compile("^(\s*)def (\w*)\(")
+controllers_use_re = re.compile(
+    r"(\s*)\S*\s*controllers\.use\('(.*)'\).render")
+scope_re = re.compile(r"^(\s*)def (\w*)\(")
 
 default_name_map = dict(spellpicker="Spell Selection",
                         bundlereadme="Spell Readme",

--- a/tox.ini
+++ b/tox.ini
@@ -21,7 +21,7 @@ commands =
     pylint conjureup test tools
 
 [testenv:flake]
-commands = flake8 --ignore E501,E722,E741 {posargs} conjureup test tools
+commands = flake8 --ignore E501,E722,E741,W504 {posargs} conjureup test tools
 deps = flake8
 
 [testenv:docs]


### PR DESCRIPTION
Controllers without endpoints happen if the bootstrap fails before the controller instance is created.  These cannot be used in future deploys, obviously, and will cause an error if selected.  This disables them and provides information on how to clean them up.

Fixes #1515

![screenshot from 2019-01-24 10-14-28](https://user-images.githubusercontent.com/406082/51687668-097f5600-1fc1-11e9-9285-cb34d853e80a.png)
