### PR TITLE
bump libjuju (needed for 2.5)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 aiofiles==0.3.1
 Jinja2==2.9.6
-juju==0.11.1
+juju==0.11.2
 juju-wait==2.6.3
 prettytable==0.7.2
 progressbar2==3.20.0


### PR DESCRIPTION
Running conjure-up 2.6.5 with libjuju 0.11.1 fails like this: 
```
2019-01-31 15:28:06,761 [DEBUG] conjure-up/kubernetes-core - telemetry.py:32 - Juju Add Model: Started aws/us-west-1
2019-01-31 15:28:07,255 [DEBUG] conjure-up/kubernetes-core - events.py:52 - Setting Error at conjureup/events.py:149
2019-01-31 15:28:07,255 [ERROR] conjure-up/kubernetes-core - events.py:161 - Unhandled exception in <Task finished coro=<BaseBootstrapController.run() done, defined at /Users/kwmonroe/test/venv/lib/python3.7/site-packages/conjure_up-2.6.4-py3.7.egg/conjureup/controllers/juju/bootstrap/common.py:15> exception=AttributeError("'CloudFacade' object has no attribute 'UpdateCredentials'")>
Traceback (most recent call last):
  File "/Users/kwmonroe/test/venv/lib/python3.7/site-packages/conjure_up-2.6.4-py3.7.egg/conjureup/controllers/juju/bootstrap/common.py", line 19, in run
    await self.do_add_model()
  File "/Users/kwmonroe/test/venv/lib/python3.7/site-packages/conjure_up-2.6.4-py3.7.egg/conjureup/controllers/juju/bootstrap/common.py", line 38, in do_add_model
    await juju.create_model()
  File "/Users/kwmonroe/test/venv/lib/python3.7/site-packages/conjure_up-2.6.4-py3.7.egg/conjureup/juju.py", line 195, in create_model
    config=app.conjurefile.get('model-config', None))
  File "/Users/kwmonroe/test/venv/lib/python3.7/site-packages/juju/controller.py", line 256, in add_model
    owner=owner)
  File "/Users/kwmonroe/test/venv/lib/python3.7/site-packages/juju/controller.py", line 220, in add_credential
    await cloud_facade.UpdateCredentials([
AttributeError: 'CloudFacade' object has no attribute 'UpdateCredentials'
```

This is fixed by the following (released in 0.11.2):

https://github.com/juju/python-libjuju/pull/281

Bump requirements.txt to get libjuju updated in conjure-up.