### PR TITLE
Allow to define juju and juju-wait paths with env variables

### DIFF
--- a/conjureup/juju.py
+++ b/conjureup/juju.py
@@ -44,10 +44,12 @@ def set_bin_path():
     """ Sets the juju binary path
     """
     candidates = [
+        os.environ['JUJU'],
         '/snap/bin/juju',
         '/snap/bin/conjure-up.juju',
         '/usr/bin/juju',
         '/usr/local/bin/juju',
+
     ]
     _check_bin_candidates(candidates, 'bin_path')
     # Update $PATH so that we make sure this candidate is used
@@ -60,6 +62,7 @@ def set_wait_path():
     """ Sets juju-wait path
     """
     candidates = [
+        os.environ['JUJU_WAIT'],
         '/snap/bin/juju-wait',
         '/snap/bin/conjure-up.juju-wait',
         '/usr/bin/juju-wait',

--- a/conjureup/juju.py
+++ b/conjureup/juju.py
@@ -49,7 +49,6 @@ def set_bin_path():
         '/snap/bin/conjure-up.juju',
         '/usr/bin/juju',
         '/usr/local/bin/juju',
-
     ]
     _check_bin_candidates(candidates, 'bin_path')
     # Update $PATH so that we make sure this candidate is used


### PR DESCRIPTION
This change allows to use juju and juju-wait when they are installed
somewhere else than in the standard paths.

For example on Linux, using the Homebrew package manager:
/home/linuxbrew/.linuxbrew/Cellar/juju

And on ARM macs:
/opt/Homebrew/Cellar

This allows to build and ship conjure-up with non-standard paths.